### PR TITLE
ci: add Windows benchmark baseline and smoke workflow

### DIFF
--- a/.github/scripts/check_package_contents.py
+++ b/.github/scripts/check_package_contents.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import tarfile
+import zipfile
+from pathlib import Path
+
+FORBIDDEN = (
+    ".free-code-logs",
+    ".env",
+    ".venv",
+    ".github",
+    "uv.lock",
+    "__pycache__",
+)
+
+
+def main() -> None:
+    dist = Path("dist")
+    sdists = list(dist.glob("*.tar.gz"))
+    wheels = list(dist.glob("*.whl"))
+    if len(sdists) != 1 or len(wheels) != 1:
+        raise SystemExit(f"Expected one sdist and one wheel, got {sdists!r} and {wheels!r}")
+
+    with tarfile.open(sdists[0]) as package:
+        names = package.getnames()
+    with zipfile.ZipFile(wheels[0]) as package:
+        names.extend(package.namelist())
+
+    matches = [name for name in names if any(part in name for part in FORBIDDEN)]
+    if matches:
+        raise SystemExit("Forbidden files in package:\n" + "\n".join(matches))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/verify_gold_with_annotations.py
+++ b/.github/scripts/verify_gold_with_annotations.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import sys
+import time
+import traceback
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from harness_bench.core import VerifyResult
+from harness_bench.runner import TaskRun
+from harness_bench.tasks import ALL_TASKS, get_task
+
+
+def _task_sort_key(task_id: str) -> tuple[int, str]:
+    rest = task_id.removeprefix("task_")
+    head, _, _ = rest.partition("_")
+    try:
+        return (int(head), task_id)
+    except ValueError:
+        return (10**9, task_id)
+
+
+def _annotation_escape(value: str) -> str:
+    return value.replace("%", "%25").replace("\r", "%0D").replace("\n", "%0A")
+
+
+def _emit_error(title: str, message: str) -> None:
+    print(f"::error title={_annotation_escape(title)}::{_annotation_escape(message)}")
+
+
+def _one_line(message: str) -> str:
+    lines = [line for line in message.splitlines() if line.strip()]
+    return lines[0] if lines else "(no detail)"
+
+
+def verify_gold_with_annotations(task_ids: list[str] | None = None) -> int:
+    targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
+    results: list[TaskRun] = []
+
+    for task in targets:
+        started = time.monotonic()
+        try:
+            with TemporaryDirectory(prefix=f"hb_gold_{task.id}_") as tmp:
+                ws = Path(tmp)
+                task.setup(ws)
+                task.apply_gold(ws)
+                outcome: VerifyResult = task.verify(ws)
+            elapsed = time.monotonic() - started
+            result = TaskRun(
+                task_id=task.id,
+                passed=outcome.passed,
+                message=outcome.message,
+                elapsed_seconds=elapsed,
+            )
+        except Exception:  # noqa: BLE001 - CI diagnostic wrapper must keep going
+            elapsed = time.monotonic() - started
+            result = TaskRun(
+                task_id=task.id,
+                passed=False,
+                message=traceback.format_exc(),
+                elapsed_seconds=elapsed,
+            )
+
+        results.append(result)
+        status = "OK  " if result.passed else "BAD "
+        print(f"[{status}] {task.id} ({result.elapsed_seconds * 1000:.1f}ms) — {_one_line(result.message)}")
+        if not result.passed:
+            _emit_error(f"verify-gold failed: {task.id}", result.message)
+
+    results.sort(key=lambda run: _task_sort_key(run.task_id))
+    failed = [run for run in results if not run.passed]
+    print()
+    print("=" * 64)
+    print(f"Gold-verification: {len(results) - len(failed)}/{len(results)} OK")
+    if failed:
+        print()
+        print("Verifier failures (likely bugs in the verifier or gold solution):")
+        for run in failed:
+            print(f"  - {run.task_id}: {_one_line(run.message)}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(verify_gold_with_annotations(sys.argv[1:] or None))

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  quality:
+    name: Quality (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+
+    env:
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: utf-8
+
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Run Ruff
+        run: uv run ruff check .
+
+      - name: Run tests
+        run: uv run pytest
+
+      - name: Verify harness gold solutions
+        run: uv run python .github/scripts/verify_gold_with_annotations.py
+
+      - name: Build package
+        run: uv build
+
+      - name: Check package contents
+        run: uv run python .github/scripts/check_package_contents.py

--- a/.github/workflows/windows-benchmark-smoke.yml
+++ b/.github/workflows/windows-benchmark-smoke.yml
@@ -1,0 +1,186 @@
+name: Windows benchmark smoke
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Benchmark runner to execute"
+        required: true
+        default: "run-cli"
+        type: choice
+        options:
+          - run
+          - run-pure
+          - run-openrouter
+          - run-cli
+      tasks:
+        description: "Task ids separated by comma, space, or newline"
+        required: true
+        type: string
+        default: "task_111_xlsx_extract_b2, task_112_xlsx_sum_column, task_113_xlsx_update_cell, task_123_sqlite_count, task_124_sqlite_sum, task_148_csv_to_xlsx, task_149_sqlite_to_json, task_152_sqlite_join_to_json, task_153_xlsx_to_markdown_report, task_154_jsonl_into_sqlite, task_158_xlsx_split_sheets, task_191_sqlite_revenue_report, task_196_xlsx_to_csv_and_json, task_199_sqlite_filtered_export, task_203_sqlite_team_markdown_report, task_207_inventory_anomaly_report, task_219_sql_paid_leaderboard"
+      recursion_limit:
+        description: "Agent recursion limit for in-process deepagents runners"
+        required: true
+        default: "80"
+        type: string
+      openrouter_model:
+        description: "Model id for run-openrouter"
+        required: true
+        default: "qwen/qwen3.6-plus"
+        type: string
+      cli_command:
+        description: "Command prefix for run-cli; the task prompt is appended by the benchmark"
+        required: false
+        default: "cmd /c npx -y opencode-ai@latest run --model openrouter/qwen/qwen3.6-plus"
+        type: string
+      cli_timeout:
+        description: "Per-task timeout in seconds for run-cli"
+        required: true
+        default: "900"
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  windows-benchmark-smoke:
+    name: Windows real benchmark smoke (${{ inputs.runner }})
+    runs-on: windows-latest
+    timeout-minutes: 180
+
+    env:
+      PYTHONUTF8: "1"
+      PYTHONIOENCODING: "utf-8"
+      UV_SYSTEM_PYTHON: "0"
+      # Keep --keep workspaces inside the checkout so they can be uploaded.
+      TEMP: ${{ github.workspace }}\\.bench-tmp
+      TMP: ${{ github.workspace }}\\.bench-tmp
+      # GigaChat path: `run` and `run-pure`.
+      GIGACHAT_CREDENTIALS: ${{ secrets.GIGACHAT_CREDENTIALS }}
+      GIGACHAT_USER: ${{ secrets.GIGACHAT_USER }}
+      GIGACHAT_PASSWORD: ${{ secrets.GIGACHAT_PASSWORD }}
+      GIGACHAT_BASE_URL: ${{ secrets.GIGACHAT_BASE_URL }}
+      GIGACHAT_MODEL: ${{ vars.GIGACHAT_MODEL || 'GigaChat-3-Ultra' }}
+      GIGACHAT_SCOPE: ${{ vars.GIGACHAT_SCOPE }}
+      GIGACHAT_VERIFY_SSL_CERTS: ${{ vars.GIGACHAT_VERIFY_SSL_CERTS }}
+      # OpenRouter path: `run-openrouter` and the default `run-cli` command.
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      OPENROUTER_BASE_URL: ${{ vars.OPENROUTER_BASE_URL }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: uv sync --dev
+
+      - name: Preflight selected runner
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          New-Item -ItemType Directory -Force -Path $env:TEMP | Out-Null
+
+          foreach ($name in @("GIGACHAT_BASE_URL", "GIGACHAT_MODEL", "GIGACHAT_SCOPE", "GIGACHAT_VERIFY_SSL_CERTS", "OPENROUTER_BASE_URL")) {
+            if ((Test-Path "Env:\\$name") -and -not (Get-Item "Env:\\$name").Value) {
+              Remove-Item "Env:\\$name"
+            }
+          }
+
+          $runner = "${{ inputs.runner }}"
+          Write-Host "Runner: $runner"
+          uv run python -m harness_bench list | Select-Object -First 20
+
+          if ($runner -in @("run", "run-pure")) {
+            if (-not $env:GIGACHAT_CREDENTIALS -and -not (($env:GIGACHAT_USER) -and ($env:GIGACHAT_PASSWORD))) {
+              throw "Runner '$runner' requires GIGACHAT_CREDENTIALS or GIGACHAT_USER + GIGACHAT_PASSWORD repository secrets."
+            }
+          }
+
+          if ($runner -eq "run-openrouter") {
+            if (-not $env:OPENROUTER_API_KEY) {
+              throw "Runner 'run-openrouter' requires OPENROUTER_API_KEY repository secret."
+            }
+          }
+
+          if ($runner -eq "run-cli") {
+            $cliCommand = "${{ inputs.cli_command }}"
+            Write-Host "CLI command: $cliCommand"
+            node --version
+            npm --version
+            if ($cliCommand -match "(?i)openrouter" -and -not $env:OPENROUTER_API_KEY) {
+              throw "Runner 'run-cli' with an OpenRouter-backed CLI command requires OPENROUTER_API_KEY repository secret."
+            }
+          }
+
+      - name: Run benchmark smoke
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Continue"
+          foreach ($name in @("GIGACHAT_BASE_URL", "GIGACHAT_MODEL", "GIGACHAT_SCOPE", "GIGACHAT_VERIFY_SSL_CERTS", "OPENROUTER_BASE_URL")) {
+            if ((Test-Path "Env:\\$name") -and -not (Get-Item "Env:\\$name").Value) {
+              Remove-Item "Env:\\$name"
+            }
+          }
+
+          $runner = "${{ inputs.runner }}"
+          $tasksText = @'
+          ${{ inputs.tasks }}
+          '@
+          $tasks = $tasksText -split "[,\s]+" |
+            ForEach-Object { $_.Trim() } |
+            Where-Object { $_ -and -not $_.StartsWith("#") }
+
+          if (-not $tasks) {
+            throw "No benchmark tasks selected."
+          }
+
+          $benchArgs = @("-m", "harness_bench", $runner)
+          foreach ($task in $tasks) {
+            $benchArgs += @("--task", $task)
+          }
+          $benchArgs += @("--keep", "--allow-task-failures")
+
+          if ($runner -in @("run", "run-pure", "run-openrouter")) {
+            $benchArgs += @("--recursion-limit", "${{ inputs.recursion_limit }}")
+          }
+          if ($runner -eq "run-openrouter") {
+            $benchArgs += @("--model", "${{ inputs.openrouter_model }}")
+          }
+          if ($runner -eq "run-cli") {
+            $benchArgs += @("--cli-command", "${{ inputs.cli_command }}", "--timeout", "${{ inputs.cli_timeout }}")
+          }
+
+          Write-Host "uv run python $($benchArgs -join ' ')"
+          uv run python @benchArgs
+          $exitCode = $LASTEXITCODE
+          Write-Host "Benchmark exit code: $exitCode"
+
+          Write-Host "Workspace directories kept under $env:TEMP:"
+          if (Test-Path $env:TEMP) {
+            Get-ChildItem -Path $env:TEMP -Directory -ErrorAction SilentlyContinue |
+              Select-Object -ExpandProperty FullName
+          }
+
+          exit $exitCode
+
+      - name: Upload kept benchmark workspaces
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-benchmark-workspaces-${{ inputs.runner }}
+          path: .bench-tmp/**
+          if-no-files-found: ignore
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -51,6 +51,12 @@ coverage.xml
 .pytest_cache/
 cover/
 
+# Generated benchmark exports / local Harbor runs
+harbor_dataset*/
+harbor_jobs*/
+jobs/
+pi_mono_gigachat_full_*.log
+
 # Translations
 *.mo
 *.pot

--- a/LEGACY_RESULTS.md
+++ b/LEGACY_RESULTS.md
@@ -8,6 +8,19 @@ comparable across set sizes** — the bench grew to 231 tasks on
 `v0.3.0`. Current results live in `README.md`; this file is kept for
 traceability only.
 
+The older `pi-mono` / GigaChat row on the 200-task set has been
+superseded by the 2026-05-24 `pi-mono` / GigaChat-3-Ultra row in
+`README.md`; it remains below only as legacy /200 evidence.
+
+## Superseded runs on the current 231-task set
+
+These rows used the current task-set size but were replaced by newer
+same-runner or same-model measurements in `README.md`.
+
+| Date | Runner | Model | Harness adapt | Result | % | Replaced by |
+| --- | --- | --- | --- | --- | --- | --- |
+| 2026-05-22 | `deepagents` | GigaChat-3-Ultra (PROM) | no (baseline, no profile) | 154 / 231 | 66.7 % | 2026-05-24 `deepagents` / GigaChat-3-Ultra (PROM), no profile: 164 / 231 |
+
 ## Runs on the 221-task set (set existed 2026-05-19 → 2026-05-21)
 
 | Date | Runner | Model | Harness adapt | Result | % |

--- a/README.md
+++ b/README.md
@@ -190,12 +190,13 @@ tracked in this repository.
 | 10 | 2026-05-23 | `deepagents` | **GigaChat-3-Ultra** (PROM, deepagents 0.6.3) | **yes (v10 = v9 + `AgentsMdInjectMiddleware`)** | **194 / 231** | **84.0 %** |
 | 11 | 2026-05-24 | `pi-mono` 0.75.3 | GigaChat-3-Ultra (PROM, `@gigachain/pi-gigachat`) | yes (pi tools + AGENTS.md discovery) | 188 / 231 | 81.4 % |
 | 12 | 2026-05-22 | `deepagents` | DeepSeek V4 Flash (284B-A13B MoE) | no | 186 / 231 | 80.5 % |
-| 13 | 2026-05-22 | `deepagents` | OpenAI gpt-oss-120b (120B dense) | no | 165 / 231 | 71.4 % |
-| 14 | 2026-05-24 | `deepagents` | GigaChat-3-Ultra (PROM) | no (baseline, no profile, `run-pure`) | 164 / 231 | 71.0 % |
-| 15 | 2026-05-22 | `deepagents` | Qwen3-235B-A22B-Instruct-2507 | no | 162 / 231 | 70.1 % |
-| 16 | 2026-05-25 | `gigacode cli` | unknown | unknown | 151 / 231 | 65.4 % |
-| 17 | 2026-05-23 | `ouroboros` | GigaChat-3-Ultra (PROM, native function-calling mode) | no | 136 / 231 | 58.9 % |
-| 18 | 2026-05-22 | `deepagents` | GLM-4-32B (32B dense) | no | 76 / 231 | 32.9 % |
+| 13 | 2026-05-25 | `OpenHands SDK` 1.22.1 | GigaChat-3-Ultra (PROM via `gpt2giga`) | yes (SDK CLI wrapper + AGENTS.md/MEMORY.md prompt wiring) | 183 / 231 | 79.2 % |
+| 14 | 2026-05-22 | `deepagents` | OpenAI gpt-oss-120b (120B dense) | no | 165 / 231 | 71.4 % |
+| 15 | 2026-05-24 | `deepagents` | GigaChat-3-Ultra (PROM) | no (baseline, no profile, `run-pure`) | 164 / 231 | 71.0 % |
+| 16 | 2026-05-22 | `deepagents` | Qwen3-235B-A22B-Instruct-2507 | no | 162 / 231 | 70.1 % |
+| 17 | 2026-05-25 | `gigacode cli` | unknown | unknown | 151 / 231 | 65.4 % |
+| 18 | 2026-05-23 | `ouroboros` | GigaChat-3-Ultra (PROM, native function-calling mode) | no | 136 / 231 | 58.9 % |
+| 19 | 2026-05-22 | `deepagents` | GLM-4-32B (32B dense) | no | 76 / 231 | 32.9 % |
 
 The full /200 and /221 task-set history (older runs done before the
 bench was extended), plus superseded /231 rows, lives in

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ files, transform CSV / JSON / JSONL / XLSX, run pytest, search across a
 project tree, write and use `MEMORY.md` per repo conventions, and chain
 all of that into multi-step pipelines.
 
+This benchmark is part of the
+[`GigaChain`](https://github.com/ai-forever/gigachain) project.
+
 Every task is **mechanically verified** — no LLM-as-judge. Verifiers use
 exact content checks where byte-for-byte output matters, plus regex
 matches, line lists, JSON parsing, importing a Python module and calling

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # harness-bench
 
-A self-contained **231-task agent benchmark** (`task-set v0.3.0`) for evaluating LLM-backed
+A self-contained **298-task agent benchmark** (`task-set v0.7.0`) for evaluating LLM-backed
 coding agents on file-operation work: create / edit / refactor source
 files, transform CSV / JSON / JSONL / XLSX, run pytest, search across a
 project tree, write and use `MEMORY.md` per repo conventions, and chain
@@ -37,7 +37,7 @@ uv venv && uv pip install -e ".[gigachat,openrouter]"
 # to the public profile.
 uv pip install -e ".[gigachat-profile]"
 
-# List all 231 tasks
+# List all 298 tasks
 uv run python -m harness_bench list
 
 # Show the benchmark task-set version and revision history
@@ -91,7 +91,7 @@ uv run python -m harness_bench apply-gold \
 
 ## What's inside
 
-### Tasks (231 total, task-set v0.3.0)
+### Tasks (298 total, task-set v0.7.0)
 
 | Module | Range | Wave |
 | --- | --- | --- |
@@ -101,7 +101,8 @@ uv run python -m harness_bench apply-gold \
 | `tasks_hard.py` | 101–150 | CSV / XLSX / SQLite aggregates, JSONL, Python impl + pytest, multi-file `grep`, Apache log parsing |
 | `tasks_extreme.py` | 151–205 | composite pipelines, archives, project-wide refactors, algorithms with pytest, statistics, XML / markdown, three-way joins |
 | `tasks_diagnostic.py` | 206–221 | paid-revenue reconciliation, inventory anomalies, pricing-API migration, latency reconstruction, tar+hash manifests, interval merge, config precedence, markdown link audit, data-quality reports, TODO/FIXME triage, category rollups, email extraction, runtime config, SQL leaderboards, import migrations, log-level summaries |
-| `tasks_memory.py` | 222–231 | memory discipline: read / write / forget / refuse facts in `MEMORY.md` along with the auxiliary deliverable (LICENSE, `requirements-dev.txt`, `bio.txt`, `profile.json`, …). Exercises agent memory rather than file I/O. |
+| `tasks_memory.py` | 222–253 | memory discipline: read / write / forget / refuse facts in `MEMORY.md` along with the auxiliary deliverable (LICENSE, `requirements-dev.txt`, `bio.txt`, `profile.json`, …). Exercises agent memory rather than file I/O. |
+| `tasks_agentic.py` | 254–298 | benchmark-inspired agentic wave adapted from Terminal-Bench (logs, process tables, Makefile plans, checksums, permission audits), tau2-bench (policy-bound action decisions across airline / retail / banking / clinic / etc.), and SWE-bench (pytest bug-fix tasks). |
 
 Task prompts are in **Russian** — the bench is deliberately bilingual
 to keep models honest. The verifiers and gold answers are English / data
@@ -119,6 +120,10 @@ changes do not need a task-set bump.
 | `0.1.0` | 2026-05-13 | 1–200 | 200 | Initial extracted file/code/data benchmark |
 | `0.2.0` | 2026-05-19 | 201–221 | 221 | Advanced composites and diagnostic hard tasks |
 | `0.3.0` | 2026-05-21 | 222–231 | 231 | Memory-discipline tasks using `AGENTS.md` and `MEMORY.md` |
+| `0.4.0` | 2026-06-02 | 232–253 | 253 | Extended memory suite: knowledge update, contradiction resolution, temporal reasoning, abstention, preferences, multi-hop/multi-session |
+| `0.5.0` | 2026-06-02 | 254–262 | 262 | Agentic wave adapted from Terminal-Bench, tau2-bench, and SWE-bench patterns |
+| `0.6.0` | 2026-06-02 | 263–283 | 283 | Agentic wave expanded to 10 Terminal-Bench / 10 tau2 / 10 SWE-bench tasks |
+| `0.7.0` | 2026-06-02 | 284–298 | 298 | Agentic wave expanded to 15 Terminal-Bench / 15 tau2 / 15 SWE-bench tasks |
 
 ### Infrastructure
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,17 @@ uv run python -m harness_bench run-cli \
     --cli-command 'free-code -p --model haiku --dangerously-skip-permissions' \
     --concurrency 5
 
+# Windows/Git Bash + cmd.exe CLIs with non-ASCII prompts/artifacts: force UTF-8
+# in both the outer shell and the Windows console before launching the runner.
+# `cmd.exe //c` is intentional for Git Bash/MSYS; keep `cmd /c` inside
+# `--cli-command` because that string is parsed by Python's subprocess, not MSYS.
+cmd.exe //c "chcp 65001 >nul" && \
+PYTHONUTF8=1 PYTHONIOENCODING=utf-8 LANG=C.UTF-8 LC_ALL=C.UTF-8 \
+uv run python -m harness_bench run-cli \
+    --timeout 600 \
+    --cli-command 'cmd /c gigacode --approval-mode=auto-edit' \
+    --task task_05_greet --task task_35_remove_blank_lines
+
 # Verify the gold solutions without calling any model. Useful when
 # adding a new task — confirms the verifier accepts a hand-written
 # "perfect" solution.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ uv run python -m harness_bench run-cli \
     --cli-command 'free-code -p --model haiku --dangerously-skip-permissions' \
     --concurrency 5
 
+# Drive `opencode` against any OpenAI-compatible deployment (example:
+# Qwen3.6-27B-FP8 served by vLLM). Point OPENCODE_CONFIG at a config
+# that registers a custom openai-compatible provider, sets the thinking
+# sampling (temp=0.6 top_p=0.95 top_k=20) and DISABLES formatter/LSP so
+# edits stay byte-exact for the verifiers (otherwise opencode auto-runs
+# a formatter and rewrites quotes/whitespace, failing exact checks):
+OPENCODE_CONFIG=/path/to/opencode-vllm.json \
+uv run python -m harness_bench run-cli \
+    --cli-command 'opencode run -m vllm/qwen3.6-27b' \
+    --timeout 900 --concurrency 5
+
 # Verify the gold solutions without calling any model. Useful when
 # adding a new task — confirms the verifier accepts a hand-written
 # "perfect" solution.
@@ -179,24 +190,26 @@ tracked in this repository.
 | # | Date | Runner | Model | Harness adapt | Result | % |
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | 2026-05-21 | `free-code` 2.1.119 | **Claude Opus 4.7** | yes (built-in + AGENTS.md inject) | **231 / 231** | **100 %** |
-| 2 | 2026-05-22 | `free-code` 2.1.119 | **Claude Haiku 4.5** | yes (built-in + AGENTS.md inject) | **222 / 231** | **96.1 %** |
-| 3 | 2026-05-24 | `ouroboros` | **Claude Sonnet 4.6** (via OpenRouter, native tool calls) | yes (Ouroboros CLI adapter) | **222 / 231** | **96.1 %** |
-| 4 | 2026-05-24 | `ouroboros` | **Claude Haiku 4.5** (via OpenRouter, native tool calls) | yes (Ouroboros CLI adapter) | **215 / 231** | **93.1 %** |
-| 5 | 2026-05-24 | `deepagents` | **Claude Haiku 4.5** (via OpenRouter, `max_tokens=4096`) | no | **209 / 231** | **90.5 %** |
-| 6 | 2026-05-22 | `deepagents` | MiniMax-M2 (via OpenRouter) | no | 209 / 231 | 90.5 % |
-| 7 | 2026-05-22 | `deepagents` | DeepSeek V3.2-exp (via OpenRouter) | no | 208 / 231 | 90.0 % |
-| 8 | 2026-05-22 | `deepagents` | GLM-4.6 (via OpenRouter) | no | 206 / 231 | 89.2 % |
-| 9 | 2026-05-22 | `deepagents` | **GigaChat-3-Ultra** (PROM, deepagents 0.6.3 + langgraph 1.2.1) | **yes (v9 + memory wiring)** | **195 / 231** | **84.4 %** |
-| 10 | 2026-05-23 | `deepagents` | **GigaChat-3-Ultra** (PROM, deepagents 0.6.3) | **yes (v10 = v9 + `AgentsMdInjectMiddleware`)** | **194 / 231** | **84.0 %** |
-| 11 | 2026-05-24 | `pi-mono` 0.75.3 | GigaChat-3-Ultra (PROM, `@gigachain/pi-gigachat`) | yes (pi tools + AGENTS.md discovery) | 188 / 231 | 81.4 % |
-| 12 | 2026-05-22 | `deepagents` | DeepSeek V4 Flash (284B-A13B MoE) | no | 186 / 231 | 80.5 % |
-| 13 | 2026-05-25 | `OpenHands SDK` 1.22.1 | GigaChat-3-Ultra (PROM via `gpt2giga`) | yes (SDK CLI wrapper + AGENTS.md/MEMORY.md prompt wiring) | 183 / 231 | 79.2 % |
-| 14 | 2026-05-22 | `deepagents` | OpenAI gpt-oss-120b (120B dense) | no | 165 / 231 | 71.4 % |
-| 15 | 2026-05-24 | `deepagents` | GigaChat-3-Ultra (PROM) | no (baseline, no profile, `run-pure`) | 164 / 231 | 71.0 % |
-| 16 | 2026-05-22 | `deepagents` | Qwen3-235B-A22B-Instruct-2507 | no | 162 / 231 | 70.1 % |
-| 17 | 2026-05-25 | `gigacode cli` | unknown | unknown | 151 / 231 | 65.4 % |
-| 18 | 2026-05-23 | `ouroboros` | GigaChat-3-Ultra (PROM, native function-calling mode) | no | 136 / 231 | 58.9 % |
-| 19 | 2026-05-22 | `deepagents` | GLM-4-32B (32B dense) | no | 76 / 231 | 32.9 % |
+| 2 | 2026-06-02 | `opencode` 1.3.7 | **Qwen3.6-27B-FP8** (vLLM, native tool calls) | yes (custom openai-compatible provider, thinking sampling, formatter/LSP off) | **224 / 231** | **97.0 %** |
+| 3 | 2026-05-22 | `free-code` 2.1.119 | **Claude Haiku 4.5** | yes (built-in + AGENTS.md inject) | **222 / 231** | **96.1 %** |
+| 4 | 2026-05-24 | `ouroboros` | **Claude Sonnet 4.6** (via OpenRouter, native tool calls) | yes (Ouroboros CLI adapter) | **222 / 231** | **96.1 %** |
+| 5 | 2026-05-24 | `ouroboros` | **Claude Haiku 4.5** (via OpenRouter, native tool calls) | yes (Ouroboros CLI adapter) | **215 / 231** | **93.1 %** |
+| 6 | 2026-05-24 | `deepagents` | **Claude Haiku 4.5** (via OpenRouter, `max_tokens=4096`) | no | **209 / 231** | **90.5 %** |
+| 7 | 2026-05-22 | `deepagents` | MiniMax-M2 (via OpenRouter) | no | 209 / 231 | 90.5 % |
+| 8 | 2026-05-22 | `deepagents` | DeepSeek V3.2-exp (via OpenRouter) | no | 208 / 231 | 90.0 % |
+| 9 | 2026-05-22 | `deepagents` | GLM-4.6 (via OpenRouter) | no | 206 / 231 | 89.2 % |
+| 10 | 2026-05-22 | `deepagents` | **GigaChat-3-Ultra** (PROM, deepagents 0.6.3 + langgraph 1.2.1) | **yes (v9 + memory wiring)** | **195 / 231** | **84.4 %** |
+| 11 | 2026-05-23 | `deepagents` | **GigaChat-3-Ultra** (PROM, deepagents 0.6.3) | **yes (v10 = v9 + `AgentsMdInjectMiddleware`)** | **194 / 231** | **84.0 %** |
+| 12 | 2026-05-24 | `pi-mono` 0.75.3 | GigaChat-3-Ultra (PROM, `@gigachain/pi-gigachat`) | yes (pi tools + AGENTS.md discovery) | 188 / 231 | 81.4 % |
+| 13 | 2026-06-02 | `deepagents` | Qwen3.6-27B-FP8 (vLLM, deepagents defaults) | no | 187 / 231 | 81.0 % |
+| 14 | 2026-05-22 | `deepagents` | DeepSeek V4 Flash (284B-A13B MoE) | no | 186 / 231 | 80.5 % |
+| 15 | 2026-05-25 | `OpenHands SDK` 1.22.1 | GigaChat-3-Ultra (PROM via `gpt2giga`) | yes (SDK CLI wrapper + AGENTS.md/MEMORY.md prompt wiring) | 183 / 231 | 79.2 % |
+| 16 | 2026-05-22 | `deepagents` | OpenAI gpt-oss-120b (120B dense) | no | 165 / 231 | 71.4 % |
+| 17 | 2026-05-24 | `deepagents` | GigaChat-3-Ultra (PROM) | no (baseline, no profile, `run-pure`) | 164 / 231 | 71.0 % |
+| 18 | 2026-05-22 | `deepagents` | Qwen3-235B-A22B-Instruct-2507 | no | 162 / 231 | 70.1 % |
+| 19 | 2026-05-25 | `gigacode cli` | unknown | unknown | 151 / 231 | 65.4 % |
+| 20 | 2026-05-23 | `ouroboros` | GigaChat-3-Ultra (PROM, native function-calling mode) | no | 136 / 231 | 58.9 % |
+| 21 | 2026-05-22 | `deepagents` | GLM-4-32B (32B dense) | no | 76 / 231 | 32.9 % |
 
 The full /200 and /221 task-set history (older runs done before the
 bench was extended), plus superseded /231 rows, lives in
@@ -210,6 +223,21 @@ single model across time; superseded /231 rows are kept for traceability.
 - **Closed-source ceiling**: Claude Opus 4.7 and Haiku 4.5 saturate the
   bench (100 % and 96 %). Any number above ~95 % is now bench-limited
   rather than model-limited.
+- **opencode + Qwen3.6-27B-FP8**: run through the generic `run-cli`
+  driver with a custom OpenAI-compatible vLLM provider (thinking
+  sampling `temp=0.6 top_p=0.95 top_k=20`, formatter/LSP disabled so
+  edits stay byte-exact) reaches **224 / 231 (97.0 %)** — second only to
+  the Opus 4.7 ceiling and ahead of every recorded Claude Haiku/Sonnet
+  row. The 7 misses are content-format / missing-output-file tasks plus
+  one memory-note refusal (`task_231_memory_refuse_secrets`).
+- **Harness contribution on Qwen3.6-27B-FP8**: the same model on stock
+  `deepagents` defaults (`run-openrouter`, no profile, no model-specific
+  sampling) scores **187 / 231 (81.0 %)**, so the opencode harness
+  adaptation is worth **+37 tasks** (187 → 224). The baseline misses
+  skew heavily toward tasks the agent ends without writing the output
+  file (many sub-2s "missing file" failures) — i.e. on bare defaults the
+  model under-uses the file tools, which the opencode setup (and its
+  recommended sampling) largely fixes.
 - **Ouroboros + Claude via OpenRouter**: the 2026-05-24 Sonnet run ties
   the recorded Claude-Code-style Haiku row at 222/231 and lands only
   9 tasks behind the Opus ceiling. The Haiku run through the same

--- a/README.md
+++ b/README.md
@@ -64,6 +64,13 @@ uv run python -m harness_bench run-cli \
 # adding a new task — confirms the verifier accepts a hand-written
 # "perfect" solution.
 uv run python -m harness_bench verify-gold
+
+# Direct no-Docker workspace checks for one task. This is the same
+# verifier/oracle surface used by the Harbor export.
+uv run python -m harness_bench verify-task \
+    --task task_06_toggle_debug --workspace /path/to/workspace
+uv run python -m harness_bench apply-gold \
+    --task task_06_toggle_debug --workspace /path/to/workspace
 ```
 
 `.env` at the repo root is auto-loaded by every runner.
@@ -109,7 +116,8 @@ changes do not need a task-set bump.
 | `runner_cli.py` | Alternative driver that shells out to an external CLI agent (`free-code`, `claude`, etc.). Default: `free-code -p --model haiku --dangerously-skip-permissions`. Detects Claude-Code-style CLIs and auto-injects workspace `AGENTS.md` via `--append-system-prompt`. |
 | `runner_openrouter.py` | Runner for any OpenAI-compatible OpenRouter model via `langchain-openai`. Does **not** apply any harness profile — measures raw `deepagents` defaults against the chosen model. |
 | `runner_pure.py` | Stock `deepagents` + GigaChat runner that bypasses `deepagents-gigachat` profile lookup even when that package is installed. Useful as a no-profile baseline, not a direct raw-API baseline. |
-| `__main__.py` | CLI: `list`, `version`, `run`, `run-pure`, `run-cli`, `run-openrouter`, `verify-gold`. |
+| `harbor_export.py` | Additive Harbor export layer. Generates local Harbor task directories from the same Python task registry; does not replace the no-Docker local runners. |
+| `__main__.py` | CLI: `list`, `version`, `run`, `run-pure`, `run-cli`, `run-openrouter`, `verify-gold`, `verify-task`, `apply-gold`, `export-harbor`. |
 
 Each task is independent: the runner creates a fresh
 `tempfile.TemporaryDirectory`, writes `setup_files` (and optionally
@@ -121,47 +129,109 @@ the runners inherit environment variables. The benchmark is meant for a
 trusted local environment. After the agent stops, the per-task verifier
 inspects the workspace.
 
+## Harbor export
+
+The repo can generate a local Harbor dataset without changing the native
+benchmark flow:
+
+```bash
+# One-task smoke export
+uv run python -m harness_bench export-harbor \
+    --output harbor_dataset --task task_06_toggle_debug --clean
+
+# Full dataset export
+uv run python -m harness_bench export-harbor --output harbor_dataset --clean
+```
+
+Each exported Harbor task contains:
+
+- `instruction.md` from the task prompt.
+- `environment/Dockerfile` plus a `setup.tar` with the initial workspace.
+- `solution/solve.sh` that calls `python -m harness_bench apply-gold`.
+- `tests/test.sh` that calls `python -m harness_bench verify-task` and writes
+  `/logs/verifier/reward.txt`.
+
+The Docker image contains only task setup and runtime dependencies. The
+benchmark registry / gold data is copied into Harbor `solution/` and `tests/`
+payloads, so normal agents do not get the gold answers baked into the image.
+
+Local no-Docker execution remains the canonical development loop:
+`run`, `run-cli`, `run-pure`, `run-openrouter`, `verify-gold`,
+`verify-task`, and `apply-gold` all run directly on the host. Docker is only
+needed when invoking Harbor's own local runner.
+
 ## Results
 
-All runs use `--concurrency 5` on the 231-task set (`task-set v0.3.0`).
+Unless noted, runs use `--concurrency 5` on the 231-task set
+(`task-set v0.3.0`). The `pi-mono` row used `--concurrency 4`; the
+run completed 230/231 tasks and was stopped after
+`task_230_memory_forget_telegram` hung, so that task is counted as a
+failure in the table.
 Raw run directories are local artifacts and are ignored by git; the table
 below is a traceability summary, not a bundled replay log.
+GigaChat rows labeled PROM use the active password-auth `.env` setup
+(`GIGACHAT_BASE_URL=https://gigachat.sberdevices.ru/v1`); secrets are not
+tracked in this repository.
 
 | # | Date | Runner | Model | Harness adapt | Result | % |
 | --- | --- | --- | --- | --- | --- | --- |
 | 1 | 2026-05-21 | `free-code` 2.1.119 | **Claude Opus 4.7** | yes (built-in + AGENTS.md inject) | **231 / 231** | **100 %** |
 | 2 | 2026-05-22 | `free-code` 2.1.119 | **Claude Haiku 4.5** | yes (built-in + AGENTS.md inject) | **222 / 231** | **96.1 %** |
-| 3 | 2026-05-22 | `deepagents` | MiniMax-M2 (via OpenRouter) | no | 209 / 231 | 90.5 % |
-| 4 | 2026-05-22 | `deepagents` | DeepSeek V3.2-exp (via OpenRouter) | no | 208 / 231 | 90.0 % |
-| 5 | 2026-05-22 | `deepagents` | GLM-4.6 (via OpenRouter) | no | 206 / 231 | 89.2 % |
-| 6 | 2026-05-22 | `deepagents` | **GigaChat-3-Ultra** (PROM, deepagents 0.6.3 + langgraph 1.2.1) | **yes (v9 + memory wiring)** | **195 / 231** | **84.4 %** |
-| 7 | 2026-05-23 | `deepagents` | **GigaChat-3-Ultra** (PROM, deepagents 0.6.3) | **yes (v10 = v9 + `AgentsMdInjectMiddleware`)** | **194 / 231** | **84.0 %** |
-| 8 | 2026-05-22 | `deepagents` | DeepSeek V4 Flash (284B-A13B MoE) | no | 186 / 231 | 80.5 % |
-| 9 | 2026-05-22 | `deepagents` | OpenAI gpt-oss-120b (120B dense) | no | 165 / 231 | 71.4 % |
-| 10 | 2026-05-22 | `deepagents` | Qwen3-235B-A22B-Instruct-2507 | no | 162 / 231 | 70.1 % |
-| 11 | 2026-05-22 | `deepagents` | GigaChat-3-Ultra (PROM) | no (baseline, no profile) | 154 / 231 | 66.7 % |
-| 12 | 2026-05-23 | `ouroboros` | GigaChat-3-Ultra (PROM, native function-calling mode) | no | 136 / 231 | 58.9 % |
-| 13 | 2026-05-22 | `deepagents` | GLM-4-32B (32B dense) | no | 76 / 231 | 32.9 % |
+| 3 | 2026-05-24 | `ouroboros` | **Claude Sonnet 4.6** (via OpenRouter, native tool calls) | yes (Ouroboros CLI adapter) | **222 / 231** | **96.1 %** |
+| 4 | 2026-05-24 | `ouroboros` | **Claude Haiku 4.5** (via OpenRouter, native tool calls) | yes (Ouroboros CLI adapter) | **215 / 231** | **93.1 %** |
+| 5 | 2026-05-24 | `deepagents` | **Claude Haiku 4.5** (via OpenRouter, `max_tokens=4096`) | no | **209 / 231** | **90.5 %** |
+| 6 | 2026-05-22 | `deepagents` | MiniMax-M2 (via OpenRouter) | no | 209 / 231 | 90.5 % |
+| 7 | 2026-05-22 | `deepagents` | DeepSeek V3.2-exp (via OpenRouter) | no | 208 / 231 | 90.0 % |
+| 8 | 2026-05-22 | `deepagents` | GLM-4.6 (via OpenRouter) | no | 206 / 231 | 89.2 % |
+| 9 | 2026-05-22 | `deepagents` | **GigaChat-3-Ultra** (PROM, deepagents 0.6.3 + langgraph 1.2.1) | **yes (v9 + memory wiring)** | **195 / 231** | **84.4 %** |
+| 10 | 2026-05-23 | `deepagents` | **GigaChat-3-Ultra** (PROM, deepagents 0.6.3) | **yes (v10 = v9 + `AgentsMdInjectMiddleware`)** | **194 / 231** | **84.0 %** |
+| 11 | 2026-05-24 | `pi-mono` 0.75.3 | GigaChat-3-Ultra (PROM, `@gigachain/pi-gigachat`) | yes (pi tools + AGENTS.md discovery) | 188 / 231 | 81.4 % |
+| 12 | 2026-05-22 | `deepagents` | DeepSeek V4 Flash (284B-A13B MoE) | no | 186 / 231 | 80.5 % |
+| 13 | 2026-05-22 | `deepagents` | OpenAI gpt-oss-120b (120B dense) | no | 165 / 231 | 71.4 % |
+| 14 | 2026-05-24 | `deepagents` | GigaChat-3-Ultra (PROM) | no (baseline, no profile, `run-pure`) | 164 / 231 | 71.0 % |
+| 15 | 2026-05-22 | `deepagents` | Qwen3-235B-A22B-Instruct-2507 | no | 162 / 231 | 70.1 % |
+| 16 | 2026-05-25 | `gigacode cli` | unknown | unknown | 151 / 231 | 65.4 % |
+| 17 | 2026-05-23 | `ouroboros` | GigaChat-3-Ultra (PROM, native function-calling mode) | no | 136 / 231 | 58.9 % |
+| 18 | 2026-05-22 | `deepagents` | GLM-4-32B (32B dense) | no | 76 / 231 | 32.9 % |
 
 The full /200 and /221 task-set history (older runs done before the
-bench was extended) lives in
+bench was extended), plus superseded /231 rows, lives in
 [`LEGACY_RESULTS.md`](LEGACY_RESULTS.md), along with a profile-evolution
 write-up for the GigaChat harness. Those numbers are **not directly
-comparable** to the /231 rows above and should only be used to track a
-single model across time.
+comparable** across task-set sizes and should only be used to track a
+single model across time; superseded /231 rows are kept for traceability.
 
 ### What the table shows
 
 - **Closed-source ceiling**: Claude Opus 4.7 and Haiku 4.5 saturate the
   bench (100 % and 96 %). Any number above ~95 % is now bench-limited
   rather than model-limited.
+- **Ouroboros + Claude via OpenRouter**: the 2026-05-24 Sonnet run ties
+  the recorded Claude-Code-style Haiku row at 222/231 and lands only
+  9 tasks behind the Opus ceiling. The Haiku run through the same
+  Ouroboros adapter scores 215/231, 7 tasks below both Sonnet/OpenRouter
+  and the Claude-Code-style Haiku row. There is no directly comparable
+  Claude Code Sonnet /231 row recorded in this table; older /200 Sonnet
+  rows in `LEGACY_RESULTS.md` are not directly comparable to the current
+  task set.
+- **Deepagents + Haiku via OpenRouter**: stock deepagents reaches
+  209/231 with `max_tokens=4096`, tying MiniMax-M2 and landing 6 tasks
+  behind the Ouroboros Haiku adapter run. Its misses skew toward file
+  side effects (rename/delete/missing output files), exact report format,
+  and a few composite data tasks.
 - **OSS top tier (no adapt)**: MiniMax-M2, DeepSeek V3.2-exp, GLM-4.6
   group at 89-91 % with no model-specific harness profile.
 - **GigaChat profile contribution**: the
   [`deepagents-gigachat`](https://github.com/ai-forever/deepagents-gigachat)
-  v9/v10 profile adds **+41 tasks** over stock deepagents on the same
-  model (154 → 195/194). On harness-bench it places GigaChat-3-Ultra
+  v9/v10 profile adds **+31/+30 tasks** over the latest stock
+  deepagents GigaChat baseline (164 → 195/194). On harness-bench it
+  places GigaChat-3-Ultra
   above DeepSeek V4 Flash and the open-source mid tier.
+- **Pi-mono + GigaChat**: `pi-mono` 0.75.3 via
+  `@gigachain/pi-gigachat` reaches 188/231 on PROM. That puts it below
+  the GigaChat-specific deepagents profile, but above the stock
+  deepagents GigaChat baseline and the Ouroboros/GigaChat native
+  function-calling row.
 - **Old generations underperform**: GLM-4-32B (a pre-4.6 dense build)
   scores only 33 %, two generations behind GLM-4.6. Agent capability
   scaled much faster than raw quality in the open-source space during

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -23,7 +23,7 @@ import sys
 from pathlib import Path
 
 from harness_bench.harbor_export import export_harbor_dataset
-from harness_bench.runner import run_all, summarize, verify_gold
+from harness_bench.runner import run_all, summarize, verify_gold, write_results_json
 from harness_bench.runner_cli import DEFAULT_CLI_COMMAND, DEFAULT_TIMEOUT_SECONDS, run_all_cli
 from harness_bench.runner_openrouter import DEFAULT_OPENROUTER_MODEL
 from harness_bench.runner_openrouter import run_all as run_all_openrouter
@@ -86,6 +86,13 @@ def _cmd_version(args: argparse.Namespace) -> int:
     return 1 if args.check and errors else 0
 
 
+def _maybe_write_json(args: argparse.Namespace, results: list) -> None:
+    json_output = getattr(args, "json_output", None)
+    if json_output:
+        write_results_json(results, json_output)
+        print(f"\nWrote results JSON to {json_output}")
+
+
 def _cmd_run(args: argparse.Namespace) -> int:
     results = run_all(
         task_ids=args.task,
@@ -94,6 +101,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
+    _maybe_write_json(args, results)
     return 0 if all(r.passed for r in results) else 1
 
 
@@ -107,6 +115,7 @@ def _cmd_run_openrouter(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
+    _maybe_write_json(args, results)
     return 0 if all(r.passed for r in results) else 1
 
 
@@ -118,6 +127,7 @@ def _cmd_run_pure(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
+    _maybe_write_json(args, results)
     return 0 if all(r.passed for r in results) else 1
 
 
@@ -130,6 +140,7 @@ def _cmd_run_cli(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
+    _maybe_write_json(args, results)
     return 0 if all(r.passed for r in results) else 1
 
 
@@ -193,6 +204,18 @@ def _cmd_export_harbor(args: argparse.Namespace) -> int:
     return 0
 
 
+def _add_json_output(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--json-output",
+        dest="json_output",
+        default=None,
+        help=(
+            "Write a machine-readable JSON report (aggregate pass_rate plus a "
+            "per-task breakdown with tags) to this path."
+        ),
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m harness_bench")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -233,6 +256,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run up to N tasks in parallel (default: 1; uses a thread pool, "
         "each task still has its own isolated TemporaryDirectory).",
     )
+    _add_json_output(p_run)
     p_run.set_defaults(func=_cmd_run)
 
     p_or = sub.add_parser(
@@ -260,6 +284,7 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_or.add_argument("--concurrency", type=int, default=1)
+    _add_json_output(p_or)
     p_or.set_defaults(func=_cmd_run_openrouter)
 
     p_pure = sub.add_parser(
@@ -273,6 +298,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_pure.add_argument("--keep", action="store_true", help="Keep temp workspaces")
     p_pure.add_argument("--recursion-limit", type=int, default=80)
     p_pure.add_argument("--concurrency", type=int, default=1)
+    _add_json_output(p_pure)
     p_pure.set_defaults(func=_cmd_run_pure)
 
     p_gold = sub.add_parser(
@@ -372,6 +398,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=1,
         help="Run up to N tasks in parallel (default: 1).",
     )
+    _add_json_output(p_cli)
     p_cli.set_defaults(func=_cmd_run_cli)
 
     return parser

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from collections.abc import Sequence
 
 from harness_bench.runner import run_all, summarize, verify_gold
 from harness_bench.runner_cli import DEFAULT_CLI_COMMAND, DEFAULT_TIMEOUT_SECONDS, run_all_cli
@@ -33,6 +34,13 @@ from harness_bench.versioning import (
     TASK_SET_VERSION,
     validate_task_set_metadata,
 )
+
+
+def _exit_code(results: Sequence[object], *, allow_task_failures: bool) -> int:
+    """Return the process exit code for a completed benchmark run."""
+    if allow_task_failures:
+        return 0
+    return 0 if all(getattr(r, "passed", False) for r in results) else 1
 
 
 def _cmd_list(_args: argparse.Namespace) -> int:
@@ -92,7 +100,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
-    return 0 if all(r.passed for r in results) else 1
+    return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
 def _cmd_run_openrouter(args: argparse.Namespace) -> int:
@@ -104,7 +112,7 @@ def _cmd_run_openrouter(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
-    return 0 if all(r.passed for r in results) else 1
+    return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
 def _cmd_run_pure(args: argparse.Namespace) -> int:
@@ -115,7 +123,7 @@ def _cmd_run_pure(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
-    return 0 if all(r.passed for r in results) else 1
+    return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
 def _cmd_run_cli(args: argparse.Namespace) -> int:
@@ -127,7 +135,7 @@ def _cmd_run_cli(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
-    return 0 if all(r.passed for r in results) else 1
+    return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
 def _cmd_verify_gold(args: argparse.Namespace) -> int:
@@ -186,6 +194,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run up to N tasks in parallel (default: 1; uses a thread pool, "
         "each task still has its own isolated TemporaryDirectory).",
     )
+    p_run.add_argument(
+        "--allow-task-failures",
+        action="store_true",
+        help=(
+            "Exit 0 when the harness completes even if some benchmark tasks fail. "
+            "Useful for smoke tests that validate runner mechanics rather than model quality."
+        ),
+    )
     p_run.set_defaults(func=_cmd_run)
 
     p_or = sub.add_parser(
@@ -204,6 +220,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_or.add_argument("--keep", action="store_true", help="Keep temp workspaces")
     p_or.add_argument("--recursion-limit", type=int, default=80)
     p_or.add_argument("--concurrency", type=int, default=1)
+    p_or.add_argument(
+        "--allow-task-failures",
+        action="store_true",
+        help="Exit 0 when the harness completes even if some benchmark tasks fail.",
+    )
     p_or.set_defaults(func=_cmd_run_openrouter)
 
     p_pure = sub.add_parser(
@@ -217,6 +238,11 @@ def build_parser() -> argparse.ArgumentParser:
     p_pure.add_argument("--keep", action="store_true", help="Keep temp workspaces")
     p_pure.add_argument("--recursion-limit", type=int, default=80)
     p_pure.add_argument("--concurrency", type=int, default=1)
+    p_pure.add_argument(
+        "--allow-task-failures",
+        action="store_true",
+        help="Exit 0 when the harness completes even if some benchmark tasks fail.",
+    )
     p_pure.set_defaults(func=_cmd_run_pure)
 
     p_gold = sub.add_parser(
@@ -263,6 +289,11 @@ def build_parser() -> argparse.ArgumentParser:
         type=int,
         default=1,
         help="Run up to N tasks in parallel (default: 1).",
+    )
+    p_cli.add_argument(
+        "--allow-task-failures",
+        action="store_true",
+        help="Exit 0 when the harness completes even if some benchmark tasks fail.",
     )
     p_cli.set_defaults(func=_cmd_run_cli)
 

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -20,13 +20,15 @@ from __future__ import annotations
 import argparse
 import json
 import sys
+from pathlib import Path
 
+from harness_bench.harbor_export import export_harbor_dataset
 from harness_bench.runner import run_all, summarize, verify_gold
 from harness_bench.runner_cli import DEFAULT_CLI_COMMAND, DEFAULT_TIMEOUT_SECONDS, run_all_cli
 from harness_bench.runner_openrouter import DEFAULT_OPENROUTER_MODEL
 from harness_bench.runner_openrouter import run_all as run_all_openrouter
 from harness_bench.runner_pure import run_all as run_all_pure
-from harness_bench.tasks import ALL_TASKS
+from harness_bench.tasks import ALL_TASKS, get_task
 from harness_bench.versioning import (
     CURRENT_TASK_SET_REVISION,
     TASK_SET_REVISIONS,
@@ -101,6 +103,7 @@ def _cmd_run_openrouter(args: argparse.Namespace) -> int:
         model_name=args.model,
         keep_workspace=args.keep,
         recursion_limit=args.recursion_limit,
+        max_tokens=args.max_tokens,
         concurrency=args.concurrency,
     )
     summarize(results)
@@ -143,6 +146,50 @@ def _cmd_verify_gold(args: argparse.Namespace) -> int:
             head = (r.message or "").splitlines()
             print(f"  - {r.task_id}: {head[0] if head else ''}")
         return 1
+    return 0
+
+
+def _cmd_apply_gold(args: argparse.Namespace) -> int:
+    task = get_task(args.task)
+    workspace = Path(args.workspace)
+    workspace.mkdir(parents=True, exist_ok=True)
+    task.apply_gold(workspace)
+    print(f"Applied gold solution for {task.id} in {workspace}")
+    return 0
+
+
+def _cmd_verify_task(args: argparse.Namespace) -> int:
+    task = get_task(args.task)
+    workspace = Path(args.workspace)
+    result = task.verify(workspace)
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "task_id": task.id,
+                    "workspace": str(workspace),
+                    "passed": result.passed,
+                    "message": result.message,
+                },
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
+    else:
+        status = "OK" if result.passed else "BAD"
+        print(f"[{status}] {task.id}: {result.message}")
+    return 0 if result.passed else 1
+
+
+def _cmd_export_harbor(args: argparse.Namespace) -> int:
+    result = export_harbor_dataset(
+        args.output,
+        task_ids=args.task,
+        org=args.org,
+        dataset=args.dataset,
+        clean=args.clean,
+    )
+    print(f"Exported {result.task_count} Harbor task(s) to {result.output_dir}")
     return 0
 
 
@@ -203,6 +250,15 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_or.add_argument("--keep", action="store_true", help="Keep temp workspaces")
     p_or.add_argument("--recursion-limit", type=int, default=80)
+    p_or.add_argument(
+        "--max-tokens",
+        type=int,
+        default=None,
+        help=(
+            "Optional ChatOpenAI max_tokens override. Leave unset to preserve "
+            "the provider/model default."
+        ),
+    )
     p_or.add_argument("--concurrency", type=int, default=1)
     p_or.set_defaults(func=_cmd_run_openrouter)
 
@@ -225,6 +281,58 @@ def build_parser() -> argparse.ArgumentParser:
     )
     p_gold.add_argument("--task", action="append", help="Task id (repeatable)")
     p_gold.set_defaults(func=_cmd_verify_gold)
+
+    p_apply_gold = sub.add_parser(
+        "apply-gold",
+        help="Apply one task's gold solution to a workspace (no Docker required)",
+    )
+    p_apply_gold.add_argument("--task", required=True, help="Task id")
+    p_apply_gold.add_argument(
+        "--workspace",
+        default=".",
+        help="Workspace path to modify (default: current directory)",
+    )
+    p_apply_gold.set_defaults(func=_cmd_apply_gold)
+
+    p_verify_task = sub.add_parser(
+        "verify-task",
+        help="Run one task verifier against a workspace (no Docker required)",
+    )
+    p_verify_task.add_argument("--task", required=True, help="Task id")
+    p_verify_task.add_argument(
+        "--workspace",
+        default=".",
+        help="Workspace path to inspect (default: current directory)",
+    )
+    p_verify_task.add_argument("--json", action="store_true", help="Print result as JSON")
+    p_verify_task.set_defaults(func=_cmd_verify_task)
+
+    p_harbor = sub.add_parser(
+        "export-harbor",
+        help="Generate a local Harbor dataset from the benchmark task registry",
+    )
+    p_harbor.add_argument(
+        "--output",
+        default="harbor_dataset",
+        help="Output directory (default: harbor_dataset)",
+    )
+    p_harbor.add_argument(
+        "--task",
+        action="append",
+        help="Task id (repeatable). Export all tasks if omitted.",
+    )
+    p_harbor.add_argument("--org", default="ai-forever", help="Harbor org namespace")
+    p_harbor.add_argument(
+        "--dataset",
+        default="harness-bench-fast",
+        help="Harbor dataset name",
+    )
+    p_harbor.add_argument(
+        "--clean",
+        action="store_true",
+        help="Delete the output directory before exporting",
+    )
+    p_harbor.set_defaults(func=_cmd_export_harbor)
 
     p_cli = sub.add_parser(
         "run-cli",

--- a/harness_bench/core.py
+++ b/harness_bench/core.py
@@ -87,5 +87,7 @@ class Task:
         """Run the verifier, converting unexpected exceptions to failures."""
         try:
             return self.verifier(workspace)
+        except UnicodeDecodeError as exc:
+            return VerifyResult(False, f"verifier failed to decode text as UTF-8: {exc}")
         except Exception as exc:  # noqa: BLE001 — verifier robustness
             return VerifyResult(False, f"verifier raised: {type(exc).__name__}: {exc}")

--- a/harness_bench/harbor_export.py
+++ b/harness_bench/harbor_export.py
@@ -1,0 +1,369 @@
+"""Export benchmark tasks into Harbor's local task format.
+
+The exporter is intentionally additive: it materializes Harbor task directories
+from the existing in-process Task registry, but the registry and local runners
+remain the source of truth.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import shutil
+import tarfile
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from harness_bench.core import Task
+from harness_bench.tasks import ALL_TASKS, get_task
+from harness_bench.versioning import TASK_SET_VERSION
+
+DEFAULT_HARBOR_ORG = "ai-forever"
+DEFAULT_HARBOR_DATASET = "harness-bench-fast"
+
+_PACKAGE_FILES = ("pyproject.toml", "README.md", "LICENSE", "LEGACY_RESULTS.md")
+_DEFAULT_IGNORES = ("__pycache__/", ".DS_Store", "*.pyc", "*.swp", "*.swo", "*~")
+
+
+@dataclass(frozen=True)
+class HarborExportResult:
+    """Summary of a Harbor dataset export."""
+
+    output_dir: Path
+    task_count: int
+    task_ids: tuple[str, ...]
+
+
+def export_harbor_dataset(
+    output_dir: Path | str,
+    *,
+    task_ids: Iterable[str] | None = None,
+    org: str = DEFAULT_HARBOR_ORG,
+    dataset: str = DEFAULT_HARBOR_DATASET,
+    clean: bool = False,
+) -> HarborExportResult:
+    """Write a local Harbor dataset directory for the selected benchmark tasks."""
+    output_path = Path(output_dir)
+    if clean and output_path.exists():
+        shutil.rmtree(output_path)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    tasks = _select_tasks(task_ids)
+    task_refs: list[tuple[str, str]] = []
+    for task in tasks:
+        task_name = f"{org}/{dataset}__{task.id}"
+        task_dir = output_path / task.id
+        _write_task(task_dir, task, harbor_name=task_name, dataset=dataset)
+        task_refs.append((task_name, f"sha256:{_compute_task_content_hash(task_dir)}"))
+    _write_dataset_files(output_path, org=org, dataset=dataset, tasks=tasks, task_refs=task_refs)
+
+    return HarborExportResult(
+        output_dir=output_path,
+        task_count=len(tasks),
+        task_ids=tuple(task.id for task in tasks),
+    )
+
+
+def _select_tasks(task_ids: Iterable[str] | None) -> list[Task]:
+    if task_ids is None:
+        return list(ALL_TASKS)
+    return [get_task(task_id) for task_id in task_ids]
+
+
+def _write_dataset_files(
+    output_dir: Path,
+    *,
+    org: str,
+    dataset: str,
+    tasks: list[Task],
+    task_refs: list[tuple[str, str]],
+) -> None:
+    dataset_name = f"{org}/{dataset}"
+    lines = [
+        'schema_version = "1.0"',
+        "",
+        "[dataset]",
+        f"name = {_toml_string(dataset_name)}",
+        f"description = {_toml_string('Self-contained file-operation agent benchmark')}",
+        'keywords = ["benchmark", "agent", "evaluation", "harness"]',
+        "",
+        "[[dataset.authors]]",
+        'name = "AI Forever"',
+        "",
+    ]
+    for task_name, digest in task_refs:
+        lines.extend(
+            [
+                "[[tasks]]",
+                f"name = {_toml_string(task_name)}",
+                f"digest = {_toml_string(digest)}",
+                "",
+            ]
+        )
+    output_dir.joinpath("dataset.toml").write_text("\n".join(lines))
+    output_dir.joinpath("README.md").write_text(
+        "\n".join(
+            [
+                "# harness-bench-fast Harbor export",
+                "",
+                f"Task-set version: `{TASK_SET_VERSION}`",
+                f"Tasks exported: `{len(tasks)}`",
+                "",
+                "This directory is generated from the Python task registry. "
+                "Regenerate it with `python -m harness_bench export-harbor`.",
+                "",
+            ]
+        )
+    )
+
+
+def _write_task(task_dir: Path, task: Task, *, harbor_name: str, dataset: str) -> None:
+    if task_dir.exists():
+        shutil.rmtree(task_dir)
+
+    environment_dir = task_dir / "environment"
+    solution_dir = task_dir / "solution"
+    tests_dir = task_dir / "tests"
+    environment_dir.mkdir(parents=True)
+    solution_dir.mkdir()
+    tests_dir.mkdir()
+
+    task_dir.joinpath("instruction.md").write_text(task.prompt.rstrip() + "\n")
+    task_dir.joinpath("README.md").write_text(_task_readme(task))
+    task_dir.joinpath("task.toml").write_text(
+        _task_toml(task, harbor_name=harbor_name, dataset=dataset)
+    )
+    solution_dir.joinpath("solve.sh").write_text(_solution_script(task))
+    tests_dir.joinpath("test.sh").write_text(_test_script(task))
+    tests_dir.joinpath("test_outputs.py").write_text(_test_outputs_stub())
+    environment_dir.joinpath("Dockerfile").write_text(_dockerfile())
+
+    _write_setup_tar(environment_dir / "setup.tar", task)
+    _copy_benchmark_runtime(solution_dir / "benchmark")
+    _copy_benchmark_runtime(tests_dir / "benchmark")
+
+
+def _task_readme(task: Task) -> str:
+    tags = ", ".join(task.tags) if task.tags else "none"
+    return "\n".join(
+        [
+            f"# {task.id}",
+            "",
+            task.name,
+            "",
+            f"Task-set version: `{TASK_SET_VERSION}`",
+            f"Tags: `{tags}`",
+            "",
+        ]
+    )
+
+
+def _task_toml(task: Task, *, harbor_name: str, dataset: str) -> str:
+    tags = list(task.tags)
+    keywords = sorted({"harness-bench-fast", "agent", "benchmark", *tags})
+    metadata = {
+        "benchmark": dataset,
+        "task_id": task.id,
+        "task_set_version": TASK_SET_VERSION,
+        "tags": tags,
+    }
+    lines = [
+        'schema_version = "1.2"',
+        "artifacts = []",
+        "",
+        "[task]",
+        f"name = {_toml_string(harbor_name)}",
+        f"description = {_toml_string(task.name)}",
+        f"keywords = {_toml_array(keywords)}",
+        "",
+        "[[task.authors]]",
+        'name = "AI Forever"',
+        "",
+        "[metadata]",
+    ]
+    lines.extend(f"{key} = {_toml_value(value)}" for key, value in metadata.items())
+    lines.extend(
+        [
+            "",
+            "[verifier]",
+            "timeout_sec = 600.0",
+            "",
+            "[verifier.env]",
+            "",
+            "[agent]",
+            "timeout_sec = 600.0",
+            "",
+            "[environment]",
+            "build_timeout_sec = 600.0",
+            'os = "linux"',
+            "cpus = 1",
+            "memory_mb = 2048",
+            "storage_mb = 10240",
+            "gpus = 0",
+            "allow_internet = true",
+            'workdir = "/app"',
+            "mcp_servers = []",
+            "",
+            "[environment.env]",
+            "",
+            "[solution.env]",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _solution_script(task: Task) -> str:
+    return "\n".join(
+        [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            'WORKSPACE="${HARBOR_WORKSPACE:-/app}"',
+            'PYTHON_BIN="${PYTHON_BIN:-python}"',
+            'BENCHMARK_PYTHONPATH="${HARBOR_BENCHMARK_PYTHONPATH:-/solution/benchmark}"',
+            (
+                "PYTHONPATH=\"$BENCHMARK_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}\" "
+                f"\"$PYTHON_BIN\" -m harness_bench apply-gold --task {json.dumps(task.id)} --workspace \"$WORKSPACE\""
+            ),
+            "",
+        ]
+    )
+
+
+def _test_script(task: Task) -> str:
+    return "\n".join(
+        [
+            "#!/usr/bin/env bash",
+            "set -euo pipefail",
+            'WORKSPACE="${HARBOR_WORKSPACE:-/app}"',
+            'PYTHON_BIN="${PYTHON_BIN:-python}"',
+            'VERIFIER_LOG_DIR="${HARBOR_VERIFIER_LOG_DIR:-/logs/verifier}"',
+            'mkdir -p "$VERIFIER_LOG_DIR"',
+            'BENCHMARK_PYTHONPATH="${HARBOR_BENCHMARK_PYTHONPATH:-/tests/benchmark}"',
+            (
+                "if PYTHONPATH=\"$BENCHMARK_PYTHONPATH${PYTHONPATH:+:$PYTHONPATH}\" "
+                f"\"$PYTHON_BIN\" -m harness_bench verify-task --task {json.dumps(task.id)} --workspace \"$WORKSPACE\"; then"
+            ),
+            '  echo 1 > "$VERIFIER_LOG_DIR/reward.txt"',
+            "else",
+            '  echo 0 > "$VERIFIER_LOG_DIR/reward.txt"',
+            "fi",
+            "",
+        ]
+    )
+
+
+def _test_outputs_stub() -> str:
+    return "\n".join(
+        [
+            '"""Harbor verifier compatibility stub.',
+            "",
+            "The actual check is implemented by tests/test.sh, which delegates to",
+            "the benchmark's Python verifier and writes /logs/verifier/reward.txt.",
+            '"""',
+            "",
+        ]
+    )
+
+
+def _dockerfile() -> str:
+    return "\n".join(
+        [
+            "FROM python:3.12-slim",
+            "",
+            "ENV PYTHONDONTWRITEBYTECODE=1",
+            "",
+            "RUN pip install --no-cache-dir pytest openpyxl PyYAML python-dotenv",
+            "",
+            "WORKDIR /app",
+            "COPY setup.tar /tmp/harness_setup.tar",
+            "RUN tar -xf /tmp/harness_setup.tar -C /app && rm /tmp/harness_setup.tar",
+            "",
+        ]
+    )
+
+
+def _write_setup_tar(tar_path: Path, task: Task) -> None:
+    with TemporaryDirectory(prefix=f"hb_harbor_setup_{task.id}_") as tmp:
+        workspace = Path(tmp)
+        task.setup(workspace)
+        with tarfile.open(tar_path, "w") as archive:
+            for path in sorted(workspace.rglob("*")):
+                archive.add(path, arcname=path.relative_to(workspace))
+
+
+def _copy_benchmark_runtime(target_dir: Path) -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    if target_dir.exists():
+        shutil.rmtree(target_dir)
+    target_dir.mkdir(parents=True)
+
+    package_dst = target_dir / "harness_bench"
+    shutil.copytree(
+        repo_root / "harness_bench",
+        package_dst,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc", "runs", ".free-code-logs"),
+    )
+    for rel in _PACKAGE_FILES:
+        source = repo_root / rel
+        if source.exists():
+            shutil.copy2(source, target_dir / rel)
+
+
+def _compute_task_content_hash(task_dir: Path) -> str:
+    files = _collect_hashable_files(task_dir)
+    outer = hashlib.sha256()
+    for file_path in files:
+        rel = file_path.relative_to(task_dir).as_posix()
+        file_hash = _compute_file_hash(file_path)
+        outer.update(f"{rel}\0{file_hash}\n".encode())
+    return outer.hexdigest()
+
+
+def _collect_hashable_files(task_dir: Path) -> list[Path]:
+    files = [path for path in task_dir.rglob("*") if path.is_file()]
+    files = [
+        path
+        for path in files
+        if not _matches_default_ignore(path.relative_to(task_dir).as_posix())
+    ]
+    return sorted(files, key=lambda path: path.relative_to(task_dir).as_posix())
+
+
+def _matches_default_ignore(rel_path: str) -> bool:
+    from fnmatch import fnmatch
+
+    for pattern in _DEFAULT_IGNORES:
+        if pattern.endswith("/") and (
+            rel_path == pattern.rstrip("/") or rel_path.startswith(pattern)
+        ):
+            return True
+        if fnmatch(rel_path, pattern):
+            return True
+    return False
+
+
+def _compute_file_hash(file_path: Path) -> str:
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _toml_string(value: str) -> str:
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _toml_array(values: Iterable[str]) -> str:
+    return "[" + ", ".join(_toml_string(value) for value in values) + "]"
+
+
+def _toml_value(value: object) -> str:
+    if isinstance(value, str):
+        return _toml_string(value)
+    if isinstance(value, list | tuple):
+        return _toml_array(str(item) for item in value)
+    return json.dumps(value, ensure_ascii=False)

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -198,7 +198,7 @@ def run_all(
     """Run a subset (or all) of the benchmark tasks.
 
     When `concurrency == 1` (default) tasks run sequentially and progress is
-    printed in two lines per task (`→ task_id: name` then `[PASS] ...`).
+    printed in two lines per task (`[START] task_id: name` then `[PASS] ...`).
     When `concurrency > 1` tasks run in a `ThreadPoolExecutor` (each task is
     fully isolated in its own `TemporaryDirectory`, so no synchronization is
     required around the workspace); progress is printed as a single line per
@@ -213,7 +213,7 @@ def run_all(
     if concurrency <= 1:
         results: list[TaskRun] = []
         for task in targets:
-            print(f"→ {task.id}: {task.name}")
+            print(f"[START] {task.id}: {task.name}")
             run = run_task(task, keep_workspace=keep_workspace, recursion_limit=recursion_limit)
             results.append(run)
             status = "PASS" if run.passed else "FAIL"

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -16,6 +16,42 @@ from harness_bench.core import Task, VerifyResult
 from harness_bench.tasks import ALL_TASKS, get_task
 
 
+def _is_graph_recursion_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` is LangGraph's recursion-limit failure."""
+    try:
+        from langgraph.errors import GraphRecursionError
+    except ImportError:  # pragma: no cover - langgraph is an indirect runtime dep.
+        return exc.__class__.__name__ == "GraphRecursionError"
+    return isinstance(exc, GraphRecursionError)
+
+
+def _agent_exception_task_run(
+    exc: BaseException,
+    *,
+    task_id: str,
+    elapsed_seconds: float,
+    recursion_limit: int,
+    workspace: Path | None,
+) -> TaskRun:
+    """Convert an agent/runtime exception into a normal task failure."""
+    if _is_graph_recursion_error(exc):
+        return TaskRun(
+            task_id=task_id,
+            passed=False,
+            message=f"graph recursion limit reached after {recursion_limit} steps",
+            elapsed_seconds=elapsed_seconds,
+            workspace=workspace,
+        )
+    return TaskRun(
+        task_id=task_id,
+        passed=False,
+        message="",
+        elapsed_seconds=elapsed_seconds,
+        error=traceback.format_exc(),
+        workspace=workspace,
+    )
+
+
 @dataclass
 class TaskRun:
     """The outcome of running a single task."""
@@ -69,8 +105,12 @@ def build_agent(workspace: Path, *, recursion_limit: int = 80) -> Any:
     )
     model = GigaChat(
         model=os.getenv("GIGACHAT_MODEL", "GigaChat-3-Ultra"),
-        base_url=os.getenv("GIGACHAT_BASE_URL", "https://gigachat.sberdevices.ru/v1"),
-        verify_ssl_certs=False,
+        # Let gigachat-sdk use its current default base URL unless the caller
+        # explicitly overrides it. Hard-coding the old IFT URL here breaks
+        # CORP/PERS credentials that expect the SDK default endpoint.
+        base_url=os.getenv("GIGACHAT_BASE_URL") or None,
+        verify_ssl_certs=os.getenv("GIGACHAT_VERIFY_SSL_CERTS", "false").lower()
+        not in ("false", "0", "no"),
         profanity_check=False,
         timeout=600,
         # Transient backend errors (403/429/5xx from IFT endpoint under
@@ -127,13 +167,12 @@ def run_task(
         try:
             agent = build_agent(workspace_path, recursion_limit=recursion_limit)
             agent.invoke({"messages": [{"role": "user", "content": task.prompt}]})
-        except Exception:  # noqa: BLE001 — log and surface as failure
-            return TaskRun(
+        except Exception as exc:  # noqa: BLE001 — log and surface as task failure
+            return _agent_exception_task_run(
+                exc,
                 task_id=task.id,
-                passed=False,
-                message="",
                 elapsed_seconds=time.monotonic() - started,
-                error=traceback.format_exc(),
+                recursion_limit=recursion_limit,
                 workspace=workspace_path if keep_workspace else None,
             )
         result = task.verify(workspace_path)
@@ -253,10 +292,19 @@ def summarize(results: list[TaskRun]) -> None:
     if passed < total:
         print()
         print("Failures:")
+        show_tracebacks = os.getenv("HARNESS_BENCH_SHOW_TRACEBACK", "").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
         for r in results:
             if r.passed:
                 continue
             print(f"  - {r.task_id}: {_one_line_detail(r)}")
+            if show_tracebacks and r.error:
+                print("    Traceback:")
+                for line in r.error.rstrip().splitlines():
+                    print(f"      {line}")
 
 
 # ---------------------------------------------------------------------------

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -259,6 +259,56 @@ def summarize(results: list[TaskRun]) -> None:
             print(f"  - {r.task_id}: {_one_line_detail(r)}")
 
 
+def results_to_payload(results: list[TaskRun]) -> dict[str, Any]:
+    """Build a JSON-serializable payload describing a benchmark run.
+
+    The payload carries an aggregate (``passed``/``total``/``pass_rate``) plus a
+    per-task breakdown including each task's free-form ``tags`` and numeric id,
+    so downstream tooling can compute per-category metrics without re-importing
+    the task registry.
+    """
+    from harness_bench.versioning import TASK_SET_VERSION, task_number
+
+    total = len(results)
+    passed = sum(1 for r in results if r.passed)
+    tasks_payload: list[dict[str, Any]] = []
+    for r in results:
+        try:
+            tags = list(get_task(r.task_id).tags)
+        except Exception:  # noqa: BLE001 — tags are best-effort metadata
+            tags = []
+        tasks_payload.append(
+            {
+                "task_id": r.task_id,
+                "number": task_number(r.task_id),
+                "passed": r.passed,
+                "message": r.message,
+                "elapsed_seconds": r.elapsed_seconds,
+                "error": r.error,
+                "tags": tags,
+            }
+        )
+    return {
+        "task_set_version": TASK_SET_VERSION,
+        "total": total,
+        "passed": passed,
+        "pass_rate": (passed / total) if total else 0.0,
+        "tasks": tasks_payload,
+    }
+
+
+def write_results_json(results: list[TaskRun], path: str | Path) -> None:
+    """Serialize a run's results to ``path`` as JSON (parents are created)."""
+    import json
+
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        json.dumps(results_to_payload(results), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Gold sanity check (no LLM): exercises the verifiers themselves.
 # ---------------------------------------------------------------------------

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -18,10 +18,12 @@ defaults to operating on its own cwd.
 
 from __future__ import annotations
 
+import gc
 import os
 import re
 import shlex
 import subprocess
+import sys
 import threading
 import time
 import traceback
@@ -88,6 +90,45 @@ schedule waits for the IP to be unblocked before the next attempt.
 _TOKEN_LOCK = threading.Lock()
 _TOKEN_CACHE: dict[str, tuple[str, float]] = {}
 """Per-token-URL cache of (access_token, expires_at_unix_seconds)."""
+
+_CLEANUP_RETRY_DELAYS = (0.1, 0.25, 0.5, 1.0, 2.0)
+"""Short retry window for Windows temp-dir cleanup races / stale handles."""
+
+
+def _cleanup_workspace_keepalive(
+    workspace_keepalive: TemporaryDirectory[str],
+    *,
+    task_id: str,
+) -> Path | None:
+    """Best-effort cleanup of a per-task temp workspace.
+
+    On Windows, a CLI agent or shell child can keep a file handle/cwd inside the
+    workspace for a moment after ``subprocess.run`` returns. ``TemporaryDirectory``
+    then raises ``OSError: [WinError 145] The directory is not empty`` and used
+    to abort the whole benchmark run after an otherwise completed task. Retry a
+    few times, then leave the workspace behind with a warning instead of turning
+    cleanup into a harness crash.
+    """
+    workspace = Path(workspace_keepalive.name)
+    last_exc: OSError | None = None
+    for attempt, delay in enumerate((0.0, *_CLEANUP_RETRY_DELAYS), start=1):
+        if delay:
+            gc.collect()
+            time.sleep(delay)
+        try:
+            workspace_keepalive.cleanup()
+            return None
+        except OSError as exc:
+            last_exc = exc
+            if attempt <= len(_CLEANUP_RETRY_DELAYS):
+                continue
+
+    print(
+        f"[WARN] cleanup failed for {task_id} workspace {workspace}: {last_exc}; "
+        "leaving it for inspection",
+        file=sys.stderr,
+    )
+    return workspace
 
 
 def _get_gigachat_access_token() -> str | None:
@@ -356,7 +397,7 @@ def run_task_cli(
                 # — long enough to outlive multi-minute IP throttles on the
                 # IFT endpoint.
                 if workspace_keepalive is not None:
-                    workspace_keepalive.cleanup()
+                    _cleanup_workspace_keepalive(workspace_keepalive, task_id=task.id)
                     workspace_keepalive = None
                 delay = _BACKOFF_SCHEDULE[min(attempt, len(_BACKOFF_SCHEDULE) - 1)]
                 time.sleep(delay)
@@ -391,7 +432,7 @@ def run_task_cli(
                     ) + [task.prompt]
                     # Clean prior workspace and re-set up for PROM attempt.
                     if workspace_keepalive is not None:
-                        workspace_keepalive.cleanup()
+                        _cleanup_workspace_keepalive(workspace_keepalive, task_id=task.id)
                         workspace_keepalive = None
                     if keep_workspace:
                         workspace_path = Path(mkdtemp(prefix=f"hb_cli_prom_{task.id}_"))
@@ -444,7 +485,7 @@ def run_task_cli(
         raise RuntimeError("run_task_cli retry loop fell through")
     finally:
         if workspace_keepalive is not None:
-            workspace_keepalive.cleanup()
+            _cleanup_workspace_keepalive(workspace_keepalive, task_id=task.id)
 
 
 def run_all_cli(

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -94,6 +94,77 @@ _TOKEN_CACHE: dict[str, tuple[str, float]] = {}
 _CLEANUP_RETRY_DELAYS = (0.1, 0.25, 0.5, 1.0, 2.0)
 """Short retry window for Windows temp-dir cleanup races / stale handles."""
 
+_PROCESS_TREE_SHUTDOWN_TIMEOUT = 10
+"""Seconds to wait for pipes to close after killing a timed-out CLI tree."""
+
+
+def _terminate_process_tree(proc: subprocess.Popen[str]) -> None:
+    """Terminate a CLI process and its children without changing the CLI command.
+
+    ``run-cli`` often launches Windows agents through ``cmd /c`` because the
+    real executable can be a ``.cmd`` wrapper. Killing only that immediate
+    ``cmd.exe`` leaves the actual agent process alive with inherited stdout /
+    stderr handles, so ``communicate()`` can block long after the configured
+    per-task timeout. On Windows, ``taskkill /T`` kills the whole tree rooted at
+    the wrapper process. On POSIX, start a new process group and terminate that
+    group.
+    """
+    if os.name == "nt":
+        subprocess.run(  # noqa: S603,S607 — Windows process-tree cleanup helper
+            ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        return
+
+    try:
+        os.killpg(proc.pid, 15)
+    except ProcessLookupError:
+        return
+    except OSError:
+        proc.kill()
+
+
+def _run_cli_subprocess(
+    argv: list[str],
+    *,
+    cwd: Path,
+    timeout: int,
+    env: dict[str, str] | None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the CLI command with a hard per-task process-tree timeout."""
+    creationflags = 0
+    start_new_session = False
+    if os.name == "nt":
+        creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+    else:
+        start_new_session = True
+
+    proc = subprocess.Popen(  # noqa: S603 — trusted local benchmark command
+        argv,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        encoding="utf-8",
+        env=env,
+        creationflags=creationflags,
+        start_new_session=start_new_session,
+    )
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _terminate_process_tree(proc)
+        try:
+            proc.communicate(timeout=_PROCESS_TREE_SHUTDOWN_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.communicate()
+        raise
+    return subprocess.CompletedProcess(argv, proc.returncode, stdout, stderr)
+
 
 def _cleanup_workspace_keepalive(
     workspace_keepalive: TemporaryDirectory[str],
@@ -335,15 +406,10 @@ def run_task_cli(
             argv += [task.prompt]
 
             try:
-                last_result = subprocess.run(  # noqa: S603 — trusted local benchmark
+                last_result = _run_cli_subprocess(
                     argv,
                     cwd=workspace_path,
-                    capture_output=True,
-                    text=True,
-                    encoding="utf-8",
                     timeout=timeout,
-                    check=False,
-                    stdin=subprocess.DEVNULL,
                     env=_subprocess_env_with_token(),
                 )
             except subprocess.TimeoutExpired:
@@ -443,15 +509,10 @@ def run_task_cli(
                         workspace_path = Path(workspace_keepalive.name)
                     task.setup(workspace_path)
                     try:
-                        prom_result = subprocess.run(  # noqa: S603
+                        prom_result = _run_cli_subprocess(
                             prom_argv,
                             cwd=workspace_path,
-                            capture_output=True,
-                            text=True,
-                            encoding="utf-8",
                             timeout=timeout,
-                            check=False,
-                            stdin=subprocess.DEVNULL,
                             env=prom_env,
                         )
                     except subprocess.TimeoutExpired:

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -149,6 +149,7 @@ def _run_cli_subprocess(
         stdin=subprocess.DEVNULL,
         text=True,
         encoding="utf-8",
+        errors="replace",
         env=env,
         creationflags=creationflags,
         start_new_session=start_new_session,

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -462,7 +462,7 @@ def run_all_cli(
     if concurrency <= 1:
         results: list[TaskRun] = []
         for task in targets:
-            print(f"→ {task.id}: {task.name}")
+            print(f"[START] {task.id}: {task.name}")
             run = run_task_cli(
                 task,
                 cli_command=cli_command,

--- a/harness_bench/runner_openrouter.py
+++ b/harness_bench/runner_openrouter.py
@@ -133,7 +133,7 @@ def run_all(
     if concurrency <= 1:
         results: list[TaskRun] = []
         for task in targets:
-            print(f"→ {task.id}: {task.name}")
+            print(f"[START] {task.id}: {task.name}")
             run = run_task(
                 task,
                 model_name=model_name,

--- a/harness_bench/runner_openrouter.py
+++ b/harness_bench/runner_openrouter.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import os
 import threading
 import time
-import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -20,6 +19,7 @@ from typing import Any
 from harness_bench.core import Task
 from harness_bench.runner import (
     TaskRun,
+    _agent_exception_task_run,
     _load_env_from_dotenv,
     _one_line_detail,
     _task_sort_key,
@@ -96,13 +96,12 @@ def run_task(
                 recursion_limit=recursion_limit,
             )
             agent.invoke({"messages": [{"role": "user", "content": task.prompt}]})
-        except Exception:  # noqa: BLE001 — surface as failure
-            return TaskRun(
+        except Exception as exc:  # noqa: BLE001 — surface as task failure
+            return _agent_exception_task_run(
+                exc,
                 task_id=task.id,
-                passed=False,
-                message="",
                 elapsed_seconds=time.monotonic() - started,
-                error=traceback.format_exc(),
+                recursion_limit=recursion_limit,
                 workspace=workspace_path if keep_workspace else None,
             )
         result = task.verify(workspace_path)

--- a/harness_bench/runner_openrouter.py
+++ b/harness_bench/runner_openrouter.py
@@ -42,6 +42,7 @@ def build_agent(
     *,
     model_name: str = DEFAULT_OPENROUTER_MODEL,
     recursion_limit: int = 80,
+    max_tokens: int | None = None,
 ) -> Any:
     """Build a stock `deepagents` agent backed by an OpenRouter model.
 
@@ -58,11 +59,15 @@ def build_agent(
         virtual_mode=True,
         inherit_env=True,
     )
+    model_kwargs: dict[str, Any] = {}
+    if max_tokens is not None:
+        model_kwargs["max_tokens"] = max_tokens
     model = ChatOpenAI(
         model=model_name,
         base_url=os.getenv("OPENROUTER_BASE_URL", DEFAULT_BASE_URL),
         api_key=os.getenv("OPENROUTER_API_KEY"),
         timeout=600,
+        **model_kwargs,
     )
     # Memory tasks (222–231) ship an AGENTS.md fixture; pre-existing 221
     # tasks do not. `LocalShellBackend(virtual_mode=True)` maps
@@ -78,6 +83,7 @@ def run_task(
     model_name: str = DEFAULT_OPENROUTER_MODEL,
     keep_workspace: bool = False,
     recursion_limit: int = 80,
+    max_tokens: int | None = None,
 ) -> TaskRun:
     workspace_keepalive: TemporaryDirectory | None = None
     try:
@@ -94,6 +100,7 @@ def run_task(
                 workspace_path,
                 model_name=model_name,
                 recursion_limit=recursion_limit,
+                max_tokens=max_tokens,
             )
             agent.invoke({"messages": [{"role": "user", "content": task.prompt}]})
         except Exception:  # noqa: BLE001 — surface as failure
@@ -124,6 +131,7 @@ def run_all(
     model_name: str = DEFAULT_OPENROUTER_MODEL,
     keep_workspace: bool = False,
     recursion_limit: int = 80,
+    max_tokens: int | None = None,
     concurrency: int = 1,
 ) -> list[TaskRun]:
     _load_env_from_dotenv()
@@ -140,6 +148,7 @@ def run_all(
                 model_name=model_name,
                 keep_workspace=keep_workspace,
                 recursion_limit=recursion_limit,
+                max_tokens=max_tokens,
             )
             results.append(run)
             status = "PASS" if run.passed else "FAIL"
@@ -160,6 +169,7 @@ def run_all(
                 model_name=model_name,
                 keep_workspace=keep_workspace,
                 recursion_limit=recursion_limit,
+                max_tokens=max_tokens,
             ): task
             for task in targets
         }

--- a/harness_bench/runner_pure.py
+++ b/harness_bench/runner_pure.py
@@ -128,7 +128,7 @@ def run_all(
     if concurrency <= 1:
         results: list[TaskRun] = []
         for task in targets:
-            print(f"→ {task.id}: {task.name}")
+            print(f"[START] {task.id}: {task.name}")
             run = run_task(task, keep_workspace=keep_workspace, recursion_limit=recursion_limit)
             results.append(run)
             status = "PASS" if run.passed else "FAIL"

--- a/harness_bench/runner_pure.py
+++ b/harness_bench/runner_pure.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import os
 import threading
 import time
-import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from tempfile import TemporaryDirectory
@@ -14,6 +13,7 @@ from typing import Any
 from harness_bench.core import Task
 from harness_bench.runner import (
     TaskRun,
+    _agent_exception_task_run,
     _load_env_from_dotenv,
     _one_line_detail,
     _task_sort_key,
@@ -55,8 +55,12 @@ def build_agent(workspace: Path, *, recursion_limit: int = 80) -> Any:
     )
     model = ProfilelessGigaChat(
         model=os.getenv("GIGACHAT_MODEL", "GigaChat-3-Ultra"),
-        base_url=os.getenv("GIGACHAT_BASE_URL", "https://gigachat.sberdevices.ru/v1"),
-        verify_ssl_certs=False,
+        # Let gigachat-sdk use its current default base URL unless the caller
+        # explicitly overrides it. Hard-coding the old IFT URL here breaks
+        # CORP/PERS credentials that expect the SDK default endpoint.
+        base_url=os.getenv("GIGACHAT_BASE_URL") or None,
+        verify_ssl_certs=os.getenv("GIGACHAT_VERIFY_SSL_CERTS", "false").lower()
+        not in ("false", "0", "no"),
         profanity_check=False,
         timeout=600,
         max_retries=20,
@@ -88,13 +92,12 @@ def run_task(
         try:
             agent = build_agent(workspace_path, recursion_limit=recursion_limit)
             agent.invoke({"messages": [{"role": "user", "content": task.prompt}]})
-        except Exception:
-            return TaskRun(
+        except Exception as exc:  # noqa: BLE001 — log and surface as task failure
+            return _agent_exception_task_run(
+                exc,
                 task_id=task.id,
-                passed=False,
-                message="",
                 elapsed_seconds=time.monotonic() - started,
-                error=traceback.format_exc(),
+                recursion_limit=recursion_limit,
                 workspace=workspace_path if keep_workspace else None,
             )
         result = task.verify(workspace_path)

--- a/harness_bench/tasks.py
+++ b/harness_bench/tasks.py
@@ -20,6 +20,7 @@ import json
 from pathlib import Path
 
 from harness_bench.core import Task, VerifyResult
+from harness_bench.tasks_agentic import AGENTIC_TASKS
 from harness_bench.tasks_diagnostic import DIAGNOSTIC_TASKS
 from harness_bench.tasks_extra import EXTRA_TASKS
 from harness_bench.tasks_extreme import EXTREME_TASKS
@@ -817,6 +818,7 @@ ALL_TASKS: list[Task] = [
     *EXTREME_TASKS,
     *DIAGNOSTIC_TASKS,
     *MEMORY_TASKS,
+    *AGENTIC_TASKS,
 ]
 
 _TASK_INDEX: dict[str, Task] = {t.id: t for t in ALL_TASKS}

--- a/harness_bench/tasks_agentic.py
+++ b/harness_bench/tasks_agentic.py
@@ -1,0 +1,2074 @@
+"""Agentic benchmark-inspired tasks (254..298).
+
+This wave adapts patterns from Terminal-Bench, tau2-bench, and SWE-bench
+into the compact harness-bench format: terminal/data workflows, policy-bound
+tool decisions, and repository bug fixes with pytest.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from harness_bench.core import Task, VerifyResult
+from harness_bench.verifiers import file_lines_equal, pytest_passes
+
+
+def _read_json(ws: Path, rel: str) -> object:
+    return json.loads((ws / rel).read_text())
+
+
+def _json_equals(rel: str, expected: object):
+    def _check(ws: Path) -> VerifyResult:
+        try:
+            data = _read_json(ws, rel)
+        except FileNotFoundError:
+            return VerifyResult(False, f"{rel} missing")
+        except json.JSONDecodeError as exc:
+            return VerifyResult(False, f"{rel} invalid JSON: {exc}")
+        if data != expected:
+            return VerifyResult(False, f"{rel} mismatch: {data!r}")
+        return VerifyResult(True, f"{rel} matches expected JSON")
+
+    return _check
+
+
+def _json_equals_fuzzy(rel: str, expected: dict, *, free_text_fields: tuple[str, ...]):
+    """Exact JSON match, except `free_text_fields` only need to be present
+    and a non-empty string.
+
+    Use for human-readable explanation fields (`reason`, `reason_code`) whose
+    exact wording the prompt never dictates: the policy-load-bearing fields
+    (amounts, ids, dates, booleans, enum action) are still matched exactly, so
+    the task stays non-trivial, but a correctly-decided answer is not rejected
+    just because it phrased its justification differently.
+    """
+
+    def _check(ws: Path) -> VerifyResult:
+        try:
+            data = _read_json(ws, rel)
+        except FileNotFoundError:
+            return VerifyResult(False, f"{rel} missing")
+        except json.JSONDecodeError as exc:
+            return VerifyResult(False, f"{rel} invalid JSON: {exc}")
+        if not isinstance(data, dict):
+            return VerifyResult(False, f"{rel} is not a JSON object: {data!r}")
+        if set(data.keys()) != set(expected.keys()):
+            return VerifyResult(False, f"{rel} key mismatch: {sorted(data.keys())!r}")
+        for key, want in expected.items():
+            if key in free_text_fields:
+                got = data.get(key)
+                if not isinstance(got, str) or not got.strip():
+                    return VerifyResult(
+                        False, f"{rel}.{key} must be a non-empty string, got {got!r}"
+                    )
+                continue
+            if data.get(key) != want:
+                return VerifyResult(
+                    False, f"{rel}.{key} = {data.get(key)!r}, expected {want!r}"
+                )
+        return VerifyResult(True, f"{rel} matches expected JSON (free text: {free_text_fields})")
+
+    return _check
+
+
+# ---------------------------------------------------------------------------
+# 254. terminal-style log forensics
+# ---------------------------------------------------------------------------
+_ACCESS_LOG_254 = """\
+2026-05-24T10:00:01Z api01 GET /v1/orders 200 41
+2026-05-24T10:00:02Z api02 POST /v1/payments 502 89
+2026-05-24T10:00:03Z api01 GET /v1/orders 200 38
+2026-05-24T10:00:04Z api03 GET /v1/search 504 120
+2026-05-24T10:00:05Z api02 POST /v1/payments 502 91
+2026-05-24T10:00:06Z api03 GET /v1/search 200 77
+2026-05-24T10:00:07Z api02 POST /v1/payments 200 83
+2026-05-24T10:00:08Z api01 GET /v1/orders 500 44
+"""
+
+_SUMMARY_254 = """\
+endpoint,status,count
+/v1/orders,200,2
+/v1/orders,500,1
+/v1/payments,200,1
+/v1/payments,502,2
+/v1/search,200,1
+/v1/search,504,1
+"""
+
+
+TASK_254 = Task(
+    id="task_254_terminal_log_status_matrix",
+    name="Build an endpoint/status matrix from access.log",
+    tags=("terminal-bench", "logs", "csv", "execute", "hard"),
+    prompt=(
+        "В файле access.log лежат строки формата: timestamp host method endpoint"
+        " status latency_ms. Создай report/status_matrix.csv с заголовком"
+        " endpoint,status,count. Посчитай количество строк для каждой пары"
+        " endpoint/status. Отсортируй сначала по endpoint, затем по числовому"
+        " status. Не добавляй лишних строк."
+    ),
+    setup_files={"access.log": _ACCESS_LOG_254},
+    gold_files={"report/status_matrix.csv": _SUMMARY_254},
+    verifier=file_lines_equal(
+        "report/status_matrix.csv",
+        [line for line in _SUMMARY_254.strip().splitlines()],
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# 255. terminal-style process table triage
+# ---------------------------------------------------------------------------
+_PS_255 = """\
+USER       PID %CPU %MEM COMMAND
+root         1  0.0  0.1 /sbin/init
+app       1042 87.5 12.0 python worker.py --queue emails
+app       1043 12.1 42.5 python worker.py --queue images
+db        1200 33.0 51.2 postgres: writer
+app       1300  2.0  1.1 nginx: worker
+"""
+
+_PROCESS_REPORT_255 = {
+    "cpu_hot": [{"pid": 1042, "command": "python worker.py --queue emails", "cpu": 87.5}],
+    "memory_hot": [
+        {"pid": 1043, "command": "python worker.py --queue images", "mem": 42.5},
+        {"pid": 1200, "command": "postgres: writer", "mem": 51.2},
+    ],
+}
+
+
+TASK_255 = Task(
+    id="task_255_terminal_process_hotspots",
+    name="Summarize CPU and memory hotspots from ps output",
+    tags=("terminal-bench", "process", "json", "hard"),
+    prompt=(
+        "В ps.txt лежит таблица с колонками USER PID %CPU %MEM COMMAND."
+        " Создай process_hotspots.json с двумя списками: cpu_hot для процессов"
+        " с %CPU >= 50 и memory_hot для процессов с %MEM >= 40. В каждом"
+        " объекте должны быть pid, command и соответственно cpu или mem."
+        " Порядок сохраняй как в ps.txt."
+    ),
+    setup_files={"ps.txt": _PS_255},
+    gold_files={"process_hotspots.json": json.dumps(_PROCESS_REPORT_255, indent=2) + "\n"},
+    verifier=_json_equals("process_hotspots.json", _PROCESS_REPORT_255),
+)
+
+
+# ---------------------------------------------------------------------------
+# 256. terminal-style process output normalization
+# ---------------------------------------------------------------------------
+_RAW_EVENTS_256 = """\
+INFO job=ingest attempt=1 duration_ms=120
+WARN job=ingest attempt=2 duration_ms=240
+INFO job=export attempt=1 duration_ms=80
+ERROR job=ingest attempt=3 duration_ms=510
+INFO job=export attempt=2 duration_ms=90
+ERROR job=sync attempt=1 duration_ms=310
+INFO job=sync attempt=2 duration_ms=150
+"""
+
+_EVENTS_JSON_256 = [
+    {"job": "export", "attempts": 2, "max_duration_ms": 90, "errors": 0},
+    {"job": "ingest", "attempts": 3, "max_duration_ms": 510, "errors": 1},
+    {"job": "sync", "attempts": 2, "max_duration_ms": 310, "errors": 1},
+]
+
+
+def _verify_task_256(ws: Path) -> VerifyResult:
+    p = ws / "job_summary.json"
+    if not p.exists():
+        return VerifyResult(False, "job_summary.json missing")
+    try:
+        data = json.loads(p.read_text())
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"invalid JSON: {exc}")
+    if data != _EVENTS_JSON_256:
+        return VerifyResult(False, f"job_summary.json mismatch: {data!r}")
+    return VerifyResult(True, "job_summary.json matches expected aggregate")
+
+
+TASK_256 = Task(
+    id="task_256_terminal_event_summary",
+    name="Normalize shell-style event lines into JSON",
+    tags=("terminal-bench", "parse", "json", "execute", "hard"),
+    prompt=(
+        "Прочитай raw_events.txt. Каждая строка начинается с уровня INFO/WARN/"
+        "ERROR, дальше key=value поля job, attempt, duration_ms. Создай"
+        " job_summary.json: JSON-массив объектов, отсортированный по job."
+        " Для каждого job укажи attempts (количество строк), max_duration_ms"
+        " (максимум duration_ms) и errors (количество строк уровня ERROR)."
+    ),
+    setup_files={"raw_events.txt": _RAW_EVENTS_256},
+    gold_files={"job_summary.json": json.dumps(_EVENTS_JSON_256, indent=2) + "\n"},
+    verifier=_verify_task_256,
+)
+
+
+# ---------------------------------------------------------------------------
+# 257. tau2-style airline policy refusal
+# ---------------------------------------------------------------------------
+_AIRLINE_STATE_257 = {
+    "reservation_id": "EHGLP3",
+    "user_id": "emma_kim_9957",
+    "traveler": "Emma Kim",
+    "booked_at": "2026-05-20T09:30:00Z",
+    "request_at": "2026-05-24T12:00:00Z",
+    "fare": "basic",
+    "insurance": False,
+    "status": "confirmed",
+}
+
+_AIRLINE_ACTION_257 = {
+    "action": "refuse_cancellation",
+    "reservation_id": "EHGLP3",
+    "refund_amount": 0,
+    "reason": "basic fare without insurance is outside the 24 hour cancellation window",
+}
+
+
+def _verify_task_257(ws: Path) -> VerifyResult:
+    # `reason` is free-form prose the prompt never dictates verbatim, so match
+    # the decision fields (action / reservation_id / refund_amount) exactly and
+    # only require `reason` to be a present, non-empty string.
+    result = _json_equals_fuzzy(
+        "agent_action.json", _AIRLINE_ACTION_257, free_text_fields=("reason",)
+    )(ws)
+    if not result.passed:
+        return result
+    state = json.loads((ws / "reservation.json").read_text())
+    if state != _AIRLINE_STATE_257:
+        return VerifyResult(False, "reservation.json must not be modified")
+    return VerifyResult(True, "policy refusal action is correct")
+
+
+TASK_257 = Task(
+    id="task_257_tau2_airline_refusal",
+    name="Choose a policy-compliant airline cancellation action",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Смоделируй финальный tool-call для airline-сценария. Клиент Emma Kim"
+        " хочет отменить бронь EHGLP3 и утверждает, что ей говорили про"
+        " страховку на прошлой поездке. Используй reservation.json и"
+        " airline_policy.md. Нельзя менять reservation.json. Создай"
+        " agent_action.json ровно с полями action, reservation_id,"
+        " refund_amount, reason. Если отмена запрещена политикой, action"
+        " должен быть refuse_cancellation."
+    ),
+    setup_files={
+        "reservation.json": json.dumps(_AIRLINE_STATE_257, indent=2) + "\n",
+        "airline_policy.md": (
+            "# Cancellation policy\n"
+            "- Basic fare can be cancelled for a full refund only within 24 hours of booking.\n"
+            "- After 24 hours, basic fare cancellation requires travel insurance on the reservation.\n"
+            "- Previous trips and verbal claims do not override the reservation record.\n"
+            "- When cancellation is not allowed, do not change the reservation state.\n"
+        ),
+    },
+    gold_files={"agent_action.json": json.dumps(_AIRLINE_ACTION_257, indent=2) + "\n"},
+    verifier=_verify_task_257,
+)
+
+
+# ---------------------------------------------------------------------------
+# 258. tau2-style retail order action
+# ---------------------------------------------------------------------------
+_ORDER_258 = {
+    "order_id": "R-1042",
+    "customer_id": "c_778",
+    "delivered_days_ago": 17,
+    "items": [
+        {"sku": "hoodie-navy-m", "category": "apparel", "price": 64.0, "opened": False},
+        {"sku": "mug-ceramic", "category": "home", "price": 18.0, "opened": True},
+    ],
+}
+
+_RETAIL_ACTION_258 = {
+    "action": "create_return_label",
+    "order_id": "R-1042",
+    "accepted_skus": ["hoodie-navy-m"],
+    "rejected_skus": ["mug-ceramic"],
+    "refund_total": 64.0,
+}
+
+
+def _verify_task_258(ws: Path) -> VerifyResult:
+    try:
+        action = _read_json(ws, "retail_action.json")
+    except FileNotFoundError:
+        return VerifyResult(False, "retail_action.json missing")
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"invalid JSON: {exc}")
+    if action != _RETAIL_ACTION_258:
+        return VerifyResult(False, f"retail_action.json mismatch: {action!r}")
+    return VerifyResult(True, "retail action matches policy")
+
+
+TASK_258 = Task(
+    id="task_258_tau2_retail_partial_return",
+    name="Produce a partial retail return action",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Покупатель просит вернуть оба товара из заказа R-1042. По policy.md"
+        " реши, какие позиции можно принять. Создай retail_action.json с"
+        " полями action, order_id, accepted_skus, rejected_skus, refund_total."
+        " Если хотя бы один товар можно вернуть, action должен быть"
+        " create_return_label. Списки sku отсортируй как в заказе."
+    ),
+    setup_files={
+        "order.json": json.dumps(_ORDER_258, indent=2) + "\n",
+        "policy.md": (
+            "# Retail returns\n"
+            "- Returns are allowed within 30 days after delivery.\n"
+            "- Apparel may be returned if it is unopened.\n"
+            "- Home goods may be returned only when unopened and within 14 days.\n"
+            "- Refund total is the sum of accepted item prices.\n"
+        ),
+    },
+    gold_files={"retail_action.json": json.dumps(_RETAIL_ACTION_258, indent=2) + "\n"},
+    verifier=_verify_task_258,
+)
+
+
+# ---------------------------------------------------------------------------
+# 259. tau2-style telecom plan migration
+# ---------------------------------------------------------------------------
+_TELECOM_STATE_259 = {
+    "account_id": "acct-91",
+    "current_plan": "starter_5gb",
+    "contract_months_remaining": 0,
+    "autopay": True,
+    "lines": [
+        {"line_id": "L1", "usage_gb": 8.4},
+        {"line_id": "L2", "usage_gb": 1.2},
+        {"line_id": "L3", "usage_gb": 14.9},
+    ],
+}
+
+_TELECOM_ACTION_259 = {
+    "action": "switch_plan",
+    "account_id": "acct-91",
+    "new_plan": "family_25gb",
+    "monthly_delta_usd": 18,
+    "requires_consent": True,
+}
+
+
+def _verify_task_259(ws: Path) -> VerifyResult:
+    try:
+        action = _read_json(ws, "telecom_action.json")
+    except FileNotFoundError:
+        return VerifyResult(False, "telecom_action.json missing")
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"invalid JSON: {exc}")
+    if action != _TELECOM_ACTION_259:
+        return VerifyResult(False, f"telecom_action.json mismatch: {action!r}")
+    return VerifyResult(True, "telecom action matches upgrade rules")
+
+
+TASK_259 = Task(
+    id="task_259_tau2_telecom_plan_switch",
+    name="Select a telecom plan switch action",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Клиент хочет самый дешевый тариф, который покроет текущее суммарное"
+        " потребление всех линий без овердрафта. Используй account.json и"
+        " plans.csv. Создай telecom_action.json с полями action, account_id,"
+        " new_plan, monthly_delta_usd, requires_consent. Значение action —"
+        " switch_plan. Если смена повышает цену, requires_consent=true."
+        " Не меняй исходные файлы."
+    ),
+    setup_files={
+        "account.json": json.dumps(_TELECOM_STATE_259, indent=2) + "\n",
+        "plans.csv": (
+            "plan_id,included_gb,monthly_usd\n"
+            "starter_5gb,5,30\n"
+            "family_15gb,15,42\n"
+            "family_25gb,25,48\n"
+            "unlimited,999,80\n"
+        ),
+    },
+    gold_files={"telecom_action.json": json.dumps(_TELECOM_ACTION_259, indent=2) + "\n"},
+    verifier=_verify_task_259,
+)
+
+
+# ---------------------------------------------------------------------------
+# 260. SWE-bench-style version parsing bug
+# ---------------------------------------------------------------------------
+_VERSIONS_PY_260 = """\
+def normalize_version(raw: str) -> tuple[int, ...]:
+    parts = raw.strip().split(".")
+    return tuple(int(part) for part in parts)
+
+
+def is_compatible(installed: str, required: str) -> bool:
+    return normalize_version(installed) >= normalize_version(required)
+"""
+
+_TEST_VERSION_260 = """\
+from versions import is_compatible, normalize_version
+
+
+def test_plain_versions_still_work():
+    assert normalize_version("1.2.3") == (1, 2, 3)
+    assert is_compatible("1.10.0", "1.2.9")
+
+
+def test_prefix_and_suffix_are_ignored():
+    assert normalize_version("v2.4.0") == (2, 4, 0)
+    assert normalize_version("3.1.0-rc1") == (3, 1, 0)
+    assert is_compatible("v3.1.0-rc1", "3.0.9")
+
+
+def test_missing_patch_is_padded():
+    assert normalize_version("2.4") == (2, 4, 0)
+    assert is_compatible("2.4", "2.4.0")
+"""
+
+_VERSIONS_GOLD_260 = """\
+import re
+
+
+def normalize_version(raw: str) -> tuple[int, ...]:
+    numbers = [int(part) for part in re.findall(r"\\d+", raw)]
+    while len(numbers) < 3:
+        numbers.append(0)
+    return tuple(numbers[:3])
+
+
+def is_compatible(installed: str, required: str) -> bool:
+    return normalize_version(installed) >= normalize_version(required)
+"""
+
+TASK_260 = Task(
+    id="task_260_swe_version_parser",
+    name="Fix normalize_version for prefixed and prerelease versions",
+    tags=("swe-bench", "python", "pytest", "bugfix", "hard"),
+    prompt=(
+        "В мини-репозитории падают тесты для парсинга версий. Почини"
+        " versions.py так, чтобы normalize_version принимала обычные версии,"
+        " префикс v, суффиксы вроде -rc1, а также версии без patch-компонента."
+        " Запусти тесты и не меняй tests/test_versions.py."
+    ),
+    setup_files={"versions.py": _VERSIONS_PY_260, "tests/test_versions.py": _TEST_VERSION_260},
+    gold_files={"versions.py": _VERSIONS_GOLD_260},
+    verifier=pytest_passes("tests"),
+)
+
+
+# ---------------------------------------------------------------------------
+# 261. SWE-bench-style config precedence bug
+# ---------------------------------------------------------------------------
+_SETTINGS_PY_261 = """\
+import os
+
+
+def load_settings(defaults: dict, file_settings: dict, cli_settings: dict) -> dict:
+    settings = {}
+    settings.update(cli_settings)
+    settings.update(file_settings)
+    settings.update(defaults)
+    if "APP_PORT" in os.environ:
+        settings["port"] = int(os.environ["APP_PORT"])
+    return settings
+"""
+
+_TEST_SETTINGS_261 = """\
+from settings import load_settings
+
+
+def test_precedence_defaults_file_cli_env(monkeypatch):
+    monkeypatch.setenv("APP_PORT", "9000")
+    got = load_settings(
+        {"host": "127.0.0.1", "port": 8000, "debug": False},
+        {"port": 8100, "debug": True},
+        {"debug": False},
+    )
+    assert got == {"host": "127.0.0.1", "port": 9000, "debug": False}
+
+
+def test_none_cli_value_does_not_delete_file_value(monkeypatch):
+    monkeypatch.delenv("APP_PORT", raising=False)
+    got = load_settings({"timeout": 10}, {"timeout": 30}, {"timeout": None})
+    assert got["timeout"] == 30
+"""
+
+_SETTINGS_GOLD_261 = """\
+import os
+
+
+def load_settings(defaults: dict, file_settings: dict, cli_settings: dict) -> dict:
+    settings = {}
+    settings.update(defaults)
+    settings.update(file_settings)
+    settings.update({key: value for key, value in cli_settings.items() if value is not None})
+    if "APP_PORT" in os.environ:
+        settings["port"] = int(os.environ["APP_PORT"])
+    return settings
+"""
+
+TASK_261 = Task(
+    id="task_261_swe_config_precedence",
+    name="Fix configuration precedence and None handling",
+    tags=("swe-bench", "python", "pytest", "bugfix", "hard"),
+    prompt=(
+        "Почини баг в settings.py. Ожидаемый приоритет настроек:"
+        " defaults < file_settings < cli_settings < переменная окружения"
+        " APP_PORT. Значения None в cli_settings означают 'не задано' и не"
+        " должны перетирать значение из файла. Тесты менять нельзя."
+    ),
+    setup_files={"settings.py": _SETTINGS_PY_261, "tests/test_settings.py": _TEST_SETTINGS_261},
+    gold_files={"settings.py": _SETTINGS_GOLD_261},
+    verifier=pytest_passes("tests"),
+)
+
+
+# ---------------------------------------------------------------------------
+# 262. SWE-bench-style CSV edge case
+# ---------------------------------------------------------------------------
+_REPORTS_PY_262 = """\
+import csv
+
+
+def top_customers(path: str, limit: int = 3) -> list[str]:
+    totals = {}
+    with open(path) as f:
+        for row in csv.DictReader(f):
+            totals[row["customer"]] = int(row["amount"])
+    return [name for name, total in sorted(totals.items(), key=lambda item: item[1], reverse=True)[:limit]]
+"""
+
+_TEST_REPORTS_262 = """\
+from pathlib import Path
+
+from reports import top_customers
+
+
+def test_sums_repeated_customers_and_ignores_refunds(tmp_path: Path):
+    csv_path = tmp_path / "orders.csv"
+    csv_path.write_text(
+        "customer,amount,status\\n"
+        "Ada,40,paid\\n"
+        "Bob,100,refunded\\n"
+        "Ada,35,paid\\n"
+        "Cara,60,paid\\n"
+        "Bob,25,paid\\n"
+    )
+    assert top_customers(str(csv_path), limit=3) == ["Ada", "Cara", "Bob"]
+
+
+def test_tie_breaks_by_name(tmp_path: Path):
+    csv_path = tmp_path / "orders.csv"
+    csv_path.write_text(
+        "customer,amount,status\\n"
+        "Zoe,50,paid\\n"
+        "Ann,50,paid\\n"
+        "Mike,10,paid\\n"
+    )
+    assert top_customers(str(csv_path), limit=2) == ["Ann", "Zoe"]
+"""
+
+_REPORTS_GOLD_262 = """\
+import csv
+
+
+def top_customers(path: str, limit: int = 3) -> list[str]:
+    totals: dict[str, int] = {}
+    with open(path, newline="") as f:
+        for row in csv.DictReader(f):
+            if row["status"] != "paid":
+                continue
+            customer = row["customer"]
+            totals[customer] = totals.get(customer, 0) + int(row["amount"])
+    ranked = sorted(totals.items(), key=lambda item: (-item[1], item[0]))
+    return [name for name, _total in ranked[:limit]]
+"""
+
+TASK_262 = Task(
+    id="task_262_swe_csv_top_customers",
+    name="Fix top_customers aggregation and sorting",
+    tags=("swe-bench", "python", "pytest", "bugfix", "hard"),
+    prompt=(
+        "В reports.py есть баг в функции top_customers. Нужно суммировать"
+        " несколько paid-заказов одного клиента, игнорировать refunded-заказы,"
+        " сортировать по сумме по убыванию, а при равной сумме по имени"
+        " клиента по возрастанию. Тесты менять нельзя."
+    ),
+    setup_files={"reports.py": _REPORTS_PY_262, "tests/test_reports.py": _TEST_REPORTS_262},
+    gold_files={"reports.py": _REPORTS_GOLD_262},
+    verifier=pytest_passes("tests"),
+)
+
+
+# ---------------------------------------------------------------------------
+# 263. terminal-style disk usage ranking
+# ---------------------------------------------------------------------------
+_DU_263 = """\
+16K ./src/api
+44K ./src/web
+8K ./docs
+120K ./data/raw
+64K ./data/processed
+12K ./tests
+"""
+
+_TOP_DIRS_263 = """\
+data/raw	120
+data/processed	64
+src/web	44
+"""
+
+TASK_263 = Task(
+    id="task_263_terminal_du_top_dirs",
+    name="Extract top directories from du-style output",
+    tags=("terminal-bench", "parse", "text", "execute", "hard"),
+    prompt=(
+        "В файле du.txt лежит вывод, похожий на `du -h`, но все размеры уже"
+        " в KiB и записаны как '<N>K <path>'. Создай reports/top_dirs.tsv:"
+        " три самые большие директории, формат '<path без ./>\\t<size_kib>',"
+        " сортировка по размеру по убыванию. Заголовок не нужен."
+    ),
+    setup_files={"du.txt": _DU_263},
+    gold_files={"reports/top_dirs.tsv": _TOP_DIRS_263},
+    verifier=file_lines_equal("reports/top_dirs.tsv", _TOP_DIRS_263.strip().splitlines()),
+)
+
+
+# ---------------------------------------------------------------------------
+# 264. terminal-style env precedence
+# ---------------------------------------------------------------------------
+_EFFECTIVE_ENV_264 = """\
+API_URL=https://api.prod.example
+DEBUG=false
+LOG_LEVEL=debug
+TIMEOUT=45
+"""
+
+TASK_264 = Task(
+    id="task_264_terminal_env_precedence",
+    name="Merge env files with CLI precedence",
+    tags=("terminal-bench", "config", "text", "hard"),
+    prompt=(
+        "Собери effective.env из трех файлов: env/defaults.env,"
+        " env/local.env, env/cli.env. Приоритет значений:"
+        " defaults < local < cli. Игнорируй пустые строки и комментарии,"
+        " итоговые KEY=VALUE строки отсортируй по имени ключа."
+    ),
+    setup_files={
+        "env/defaults.env": "API_URL=https://api.dev.example\nDEBUG=true\nTIMEOUT=30\n",
+        "env/local.env": "# local overrides\nAPI_URL=https://api.prod.example\nTIMEOUT=45\n",
+        "env/cli.env": "DEBUG=false\nLOG_LEVEL=debug\n",
+    },
+    gold_files={"effective.env": _EFFECTIVE_ENV_264},
+    verifier=file_lines_equal("effective.env", _EFFECTIVE_ENV_264.strip().splitlines()),
+)
+
+
+# ---------------------------------------------------------------------------
+# 265. terminal-style Makefile dependency plan
+# ---------------------------------------------------------------------------
+_BUILD_ORDER_265 = """\
+clean
+assets
+compile
+package
+deploy
+"""
+
+TASK_265 = Task(
+    id="task_265_terminal_makefile_plan",
+    name="Resolve a Makefile target dependency order",
+    tags=("terminal-bench", "makefile", "dependency", "hard"),
+    prompt=(
+        "В Makefile.simple есть targets в формате 'target: dep1 dep2'."
+        " Построй build_order.txt для цели deploy: каждый target должен"
+        " появиться после своих зависимостей, по одному target в строке."
+        " Команды под target отсутствуют; строки комментариев игнорируй."
+        " Если на каком-то шаге к сборке готовы сразу несколько targets"
+        " (все их зависимости уже идут выше), бери из них лексикографически"
+        " наименьший — чтобы порядок был однозначным."
+    ),
+    setup_files={
+        "Makefile.simple": (
+            "# simplified make dependencies\n"
+            "deploy: package\n"
+            "package: compile assets\n"
+            "compile: clean\n"
+            "assets: clean\n"
+            "clean:\n"
+        )
+    },
+    gold_files={"build_order.txt": _BUILD_ORDER_265},
+    verifier=file_lines_equal("build_order.txt", _BUILD_ORDER_265.strip().splitlines()),
+)
+
+
+# ---------------------------------------------------------------------------
+# 266. terminal-style checksum manifest
+# ---------------------------------------------------------------------------
+_FILES_266 = {
+    "payload/a.txt": "alpha\n",
+    "payload/b.txt": "bravo\n",
+    "payload/nested/c.txt": "charlie\n",
+}
+
+
+def _manifest_266() -> str:
+    import hashlib
+
+    rows = []
+    for rel, content in sorted(_FILES_266.items()):
+        rows.append(f"{hashlib.sha256(content.encode()).hexdigest()}  {rel}")
+    return "\n".join(rows) + "\n"
+
+
+def _verify_task_266(ws: Path) -> VerifyResult:
+    expected = _manifest_266().strip().splitlines()
+    p = ws / "SHA256SUMS"
+    if not p.exists():
+        return VerifyResult(False, "SHA256SUMS missing")
+    actual = [line for line in p.read_text().splitlines() if line.strip()]
+    if actual != expected:
+        return VerifyResult(False, f"SHA256SUMS mismatch: {actual!r}")
+    return VerifyResult(True, "SHA256SUMS matches payload files")
+
+
+TASK_266 = Task(
+    id="task_266_terminal_sha256_manifest",
+    name="Create a deterministic SHA256 manifest",
+    tags=("terminal-bench", "hash", "manifest", "execute", "hard"),
+    prompt=(
+        "Для всех обычных файлов внутри каталога payload создай SHA256SUMS."
+        " Формат каждой строки как у sha256sum: '<hex>  <relative-path>'."
+        " Пути должны быть относительно корня рабочей директории и"
+        " отсортированы лексикографически."
+    ),
+    setup_files=_FILES_266,
+    gold_files={"SHA256SUMS": _manifest_266()},
+    verifier=_verify_task_266,
+)
+
+
+# ---------------------------------------------------------------------------
+# 267. terminal-style failed job report
+# ---------------------------------------------------------------------------
+_JOB_REPORT_267 = {
+    "failed_jobs": ["backup-users", "sync-ledger"],
+    "slowest_job": "backup-users",
+    "slowest_duration_s": 540,
+}
+
+
+TASK_267 = Task(
+    id="task_267_terminal_job_log_report",
+    name="Summarize job failures and slowest duration",
+    tags=("terminal-bench", "logs", "json", "hard"),
+    prompt=(
+        "Прочитай jobs.log. Каждая строка: '<timestamp> job=<name>"
+        " status=<ok|failed> duration_s=<N>'. Создай job_report.json с"
+        " failed_jobs (список имен failed в порядке появления), slowest_job"
+        " и slowest_duration_s по всем строкам."
+    ),
+    setup_files={
+        "jobs.log": (
+            "2026-05-24T01:00:00Z job=backup-users status=failed duration_s=540\n"
+            "2026-05-24T01:05:00Z job=sync-ledger status=failed duration_s=180\n"
+            "2026-05-24T01:10:00Z job=refresh-cache status=ok duration_s=45\n"
+            "2026-05-24T01:12:00Z job=send-digest status=ok duration_s=12\n"
+        )
+    },
+    gold_files={"job_report.json": json.dumps(_JOB_REPORT_267, indent=2) + "\n"},
+    verifier=_json_equals("job_report.json", _JOB_REPORT_267),
+)
+
+
+# ---------------------------------------------------------------------------
+# 268. terminal-style permission audit
+# ---------------------------------------------------------------------------
+_PERMISSION_REPORT_268 = """\
+scripts/deploy.sh	world-writable
+secrets/token.txt	world-readable
+"""
+
+TASK_268 = Task(
+    id="task_268_terminal_permission_audit",
+    name="Audit risky file permissions from ls output",
+    tags=("terminal-bench", "permissions", "security", "hard"),
+    prompt=(
+        "В ls_permissions.txt лежит вывод `ls -l` с путями в последней колонке."
+        " Создай permission_findings.tsv без заголовка. Добавь строку"
+        " '<path>\\tworld-writable' для файлов, у которых установлен бит записи"
+        " для others, и '<path>\\tworld-readable' для файлов внутри secrets/,"
+        " у которых установлен бит чтения для others. Порядок как в исходном"
+        " файле."
+    ),
+    setup_files={
+        "ls_permissions.txt": (
+            "-rw-r--r-- 1 app app 120 May 25 10:00 README.md\n"
+            "-rwxrwxrwx 1 app app 400 May 25 10:01 scripts/deploy.sh\n"
+            "-rw-r----- 1 app app  99 May 25 10:02 secrets/db.txt\n"
+            "-rw-r--r-- 1 app app  40 May 25 10:03 secrets/token.txt\n"
+        )
+    },
+    gold_files={"permission_findings.tsv": _PERMISSION_REPORT_268},
+    verifier=file_lines_equal(
+        "permission_findings.tsv", _PERMISSION_REPORT_268.strip().splitlines()
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# 269. terminal-style markdown index
+# ---------------------------------------------------------------------------
+_INDEX_269 = """\
+docs/api/auth.md	Auth API
+docs/api/orders.md	Orders API
+docs/guide/install.md	Install Guide
+"""
+
+TASK_269 = Task(
+    id="task_269_terminal_markdown_index",
+    name="Build an index from markdown H1 headings",
+    tags=("terminal-bench", "markdown", "search", "hard"),
+    prompt=(
+        "Найди все .md-файлы внутри docs. Для каждого возьми первый заголовок"
+        " первого уровня (# Title) и создай docs_index.tsv в корне. Формат"
+        " '<path>\\t<title>', пути сортируй лексикографически."
+    ),
+    setup_files={
+        "docs/api/auth.md": "# Auth API\n\nDetails\n",
+        "docs/api/orders.md": "# Orders API\n\nDetails\n",
+        "docs/guide/install.md": "# Install Guide\n\nDetails\n",
+        "docs/README.txt": "# Not markdown\n",
+    },
+    gold_files={"docs_index.tsv": _INDEX_269},
+    verifier=file_lines_equal("docs_index.tsv", _INDEX_269.strip().splitlines()),
+)
+
+
+# ---------------------------------------------------------------------------
+# 270..254. tau2-style policy tasks
+# ---------------------------------------------------------------------------
+_BANK_ACTION_270 = {
+    "action": "open_dispute",
+    "transaction_id": "txn-774",
+    "provisional_credit": 48.75,
+    "reason_code": "duplicate_card_present",
+}
+
+TASK_270 = Task(
+    id="task_270_tau2_bank_duplicate_charge",
+    name="Choose a bank dispute action for duplicate charge",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Клиент оспаривает повторное списание. Используй transaction.json и"
+        " policy.md. Создай bank_action.json с action, transaction_id,"
+        " provisional_credit, reason_code. Если policy разрешает dispute,"
+        " action=open_dispute."
+    ),
+    setup_files={
+        "transaction.json": json.dumps(
+            {
+                "transaction_id": "txn-774",
+                "merchant": "Metro Cafe",
+                "amount": 48.75,
+                "card_present": True,
+                "duplicate_of": "txn-773",
+                "days_since_posted": 3,
+            },
+            indent=2,
+        )
+        + "\n",
+        "policy.md": (
+            "- Duplicate card-present charges may be disputed within 10 days.\n"
+            "- Provisional credit equals the duplicate transaction amount.\n"
+        ),
+    },
+    gold_files={"bank_action.json": json.dumps(_BANK_ACTION_270, indent=2) + "\n"},
+    verifier=_json_equals_fuzzy(
+        "bank_action.json", _BANK_ACTION_270, free_text_fields=("reason_code",)
+    ),
+)
+
+
+_HOTEL_ACTION_271 = {
+    "action": "offer_paid_late_checkout",
+    "reservation_id": "H-919",
+    "latest_checkout": "14:00",
+    "fee_usd": 35,
+}
+
+TASK_271 = Task(
+    id="task_271_tau2_hotel_late_checkout",
+    name="Select hotel late-checkout action",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Гость просит late checkout до 16:00. По reservation.json и"
+        " hotel_policy.md создай hotel_action.json с action, reservation_id,"
+        " latest_checkout, fee_usd. Значение action — offer_paid_late_checkout."
+        " Выбери максимально поздний вариант, разрешенный политикой."
+    ),
+    setup_files={
+        "reservation.json": json.dumps(
+            {"reservation_id": "H-919", "tier": "standard", "occupancy_next_day": 0.92},
+            indent=2,
+        )
+        + "\n",
+        "hotel_policy.md": (
+            "- Standard guests get free late checkout until 12:00 when occupancy is below 80%.\n"
+            "- Paid late checkout until 14:00 costs 35 USD when occupancy is below 95%.\n"
+            "- Checkout after 14:00 is only for platinum guests.\n"
+        ),
+    },
+    gold_files={"hotel_action.json": json.dumps(_HOTEL_ACTION_271, indent=2) + "\n"},
+    verifier=_json_equals("hotel_action.json", _HOTEL_ACTION_271),
+)
+
+
+_CLINIC_ACTION_272 = {
+    "action": "reschedule",
+    "appointment_id": "A-502",
+    "new_slot": "2026-05-28T09:30:00",
+    "notify_patient": True,
+}
+
+TASK_272 = Task(
+    id="task_272_tau2_clinic_reschedule",
+    name="Pick a clinic reschedule slot",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Пациент просит ближайший утренний слот у того же врача. Используй"
+        " appointment.json и slots.json. Утренние слоты начинаются до 12:00."
+        " Создай clinic_action.json с action, appointment_id, new_slot,"
+        " notify_patient. Значение action — reschedule, notify_patient — true."
+    ),
+    setup_files={
+        "appointment.json": json.dumps(
+            {"appointment_id": "A-502", "doctor_id": "dr-7", "current_slot": "2026-05-27T16:00:00"},
+            indent=2,
+        )
+        + "\n",
+        "slots.json": json.dumps(
+            [
+                {"doctor_id": "dr-8", "slot": "2026-05-27T09:00:00"},
+                {"doctor_id": "dr-7", "slot": "2026-05-28T13:00:00"},
+                {"doctor_id": "dr-7", "slot": "2026-05-28T09:30:00"},
+            ],
+            indent=2,
+        )
+        + "\n",
+    },
+    gold_files={"clinic_action.json": json.dumps(_CLINIC_ACTION_272, indent=2) + "\n"},
+    verifier=_json_equals("clinic_action.json", _CLINIC_ACTION_272),
+)
+
+
+_INSURANCE_ACTION_273 = {
+    "action": "request_documents",
+    "claim_id": "C-331",
+    "missing_documents": ["police_report"],
+    "can_approve_now": False,
+}
+
+TASK_273 = Task(
+    id="task_273_tau2_insurance_docs",
+    name="Request missing insurance claim documents",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "По claim.json и policy.md реши, можно ли одобрить claim. Создай"
+        " insurance_action.json с action, claim_id, missing_documents,"
+        " can_approve_now. Значение action — request_documents."
+        " Для кражи дороже 500 USD нужен police_report."
+    ),
+    setup_files={
+        "claim.json": json.dumps(
+            {"claim_id": "C-331", "type": "theft", "amount_usd": 880, "documents": ["receipt"]},
+            indent=2,
+        )
+        + "\n",
+        "policy.md": "- Theft claims over 500 USD require receipt and police_report.\n",
+    },
+    gold_files={"insurance_action.json": json.dumps(_INSURANCE_ACTION_273, indent=2) + "\n"},
+    verifier=_json_equals("insurance_action.json", _INSURANCE_ACTION_273),
+)
+
+
+_DELIVERY_ACTION_274 = {
+    "action": "partial_refund",
+    "order_id": "D-88",
+    "refund_usd": 12.5,
+    "coupon_usd": 5,
+}
+
+TASK_274 = Task(
+    id="task_274_tau2_delivery_late_food",
+    name="Apply food delivery late-order policy",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Заказ еды доставлен с опозданием. Используй delivery.json и"
+        " policy.md. Создай delivery_action.json с action, order_id,"
+        " refund_usd, coupon_usd. Значение action — partial_refund."
+        " Холодные товары компенсируются полностью,"
+        " при задержке больше 45 минут добавляется купон 5 USD."
+    ),
+    setup_files={
+        "delivery.json": json.dumps(
+            {
+                "order_id": "D-88",
+                "minutes_late": 52,
+                "items": [
+                    {"name": "ramen", "price": 12.5, "arrived_cold": True},
+                    {"name": "tea", "price": 4.0, "arrived_cold": False},
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        "policy.md": "- Refund cold items at item price. Add 5 USD coupon if late by more than 45 minutes.\n",
+    },
+    gold_files={"delivery_action.json": json.dumps(_DELIVERY_ACTION_274, indent=2) + "\n"},
+    verifier=_json_equals("delivery_action.json", _DELIVERY_ACTION_274),
+)
+
+
+_SUBSCRIPTION_ACTION_275 = {
+    "action": "schedule_downgrade",
+    "account_id": "sub-19",
+    "new_plan": "basic",
+    "effective_date": "2026-06-01",
+    "refund_now": 0,
+}
+
+TASK_275 = Task(
+    id="task_275_tau2_subscription_downgrade",
+    name="Schedule a subscription downgrade",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Пользователь хочет перейти с pro на basic. По subscription.json и"
+        " policy.md создай subscription_action.json с action, account_id,"
+        " new_plan, effective_date, refund_now. Значение action —"
+        " schedule_downgrade. Downgrade вступает в силу в дату billing_anchor"
+        " из subscription.json (effective_date равен этому полю) и не дает"
+        " мгновенный refund."
+    ),
+    setup_files={
+        "subscription.json": json.dumps(
+            {"account_id": "sub-19", "current_plan": "pro", "billing_anchor": "2026-06-01"},
+            indent=2,
+        )
+        + "\n",
+        "policy.md": (
+            "- Downgrades take effect on the billing_anchor date from "
+            "subscription.json. Immediate refund is 0.\n"
+        ),
+    },
+    gold_files={
+        "subscription_action.json": json.dumps(_SUBSCRIPTION_ACTION_275, indent=2) + "\n"
+    },
+    verifier=_json_equals("subscription_action.json", _SUBSCRIPTION_ACTION_275),
+)
+
+
+_BAGGAGE_ACTION_276 = {
+    "action": "compensate_baggage_delay",
+    "case_id": "B-707",
+    "compensation_usd": 100,
+    "escalate": False,
+}
+
+TASK_276 = Task(
+    id="task_276_tau2_baggage_delay",
+    name="Calculate baggage delay compensation",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "По baggage_case.json и policy.md создай baggage_action.json с"
+        " action, case_id, compensation_usd, escalate. Значение action —"
+        " compensate_baggage_delay. Для задержки багажа"
+        " больше 24 часов компенсация 100 USD; escalate только если больше"
+        " 72 часов."
+    ),
+    setup_files={
+        "baggage_case.json": json.dumps({"case_id": "B-707", "delay_hours": 31}, indent=2)
+        + "\n",
+        "policy.md": "- Delay >24h: 100 USD. Delay >72h: escalate.\n",
+    },
+    gold_files={"baggage_action.json": json.dumps(_BAGGAGE_ACTION_276, indent=2) + "\n"},
+    verifier=_json_equals("baggage_action.json", _BAGGAGE_ACTION_276),
+)
+
+
+# ---------------------------------------------------------------------------
+# 277..261. SWE-bench-style pytest bug fixes
+# ---------------------------------------------------------------------------
+_DATES_PY_277 = """\
+from datetime import datetime
+
+
+def parse_date(value: str) -> str:
+    return datetime.strptime(value, "%Y-%m-%d").date().isoformat()
+"""
+
+_TEST_DATES_277 = """\
+from dates import parse_date
+
+
+def test_accepts_iso_datetime_and_date():
+    assert parse_date("2026-05-25") == "2026-05-25"
+    assert parse_date("2026-05-25T10:30:00Z") == "2026-05-25"
+
+
+def test_accepts_slashes():
+    assert parse_date("2026/05/25") == "2026-05-25"
+"""
+
+_DATES_GOLD_277 = """\
+from datetime import datetime
+
+
+def parse_date(value: str) -> str:
+    value = value.strip().removesuffix("Z")
+    if "T" in value:
+        value = value.split("T", 1)[0]
+    value = value.replace("/", "-")
+    return datetime.strptime(value, "%Y-%m-%d").date().isoformat()
+"""
+
+TASK_277 = Task(
+    id="task_277_swe_date_parser",
+    name="Fix date parser accepted formats",
+    tags=("swe-bench", "python", "pytest", "bugfix", "hard"),
+    prompt=(
+        "Почини dates.py: parse_date должна принимать YYYY-MM-DD,"
+        " YYYY/MM/DD и ISO datetime с суффиксом Z, возвращая дату в"
+        " формате YYYY-MM-DD. Тесты менять нельзя."
+    ),
+    setup_files={"dates.py": _DATES_PY_277, "tests/test_dates.py": _TEST_DATES_277},
+    gold_files={"dates.py": _DATES_GOLD_277},
+    verifier=pytest_passes("tests"),
+)
+
+
+_QUERY_PY_278 = """\
+def parse_query(query: str) -> dict[str, str]:
+    result = {}
+    for pair in query.split("&"):
+        key, value = pair.split("=")
+        result[key] = value
+    return result
+"""
+
+_TEST_QUERY_278 = """\
+from query import parse_query
+
+
+def test_decodes_percent_encoding_and_plus():
+    assert parse_query("q=hello+world&city=Sankt%20Petersburg") == {
+        "q": "hello world",
+        "city": "Sankt Petersburg",
+    }
+
+
+def test_repeated_keys_become_lists_and_blank_values_stay():
+    assert parse_query("tag=ai&tag=bench&empty=") == {
+        "tag": ["ai", "bench"],
+        "empty": "",
+    }
+"""
+
+_QUERY_GOLD_278 = """\
+from urllib.parse import parse_qs
+
+
+def parse_query(query: str) -> dict[str, str | list[str]]:
+    parsed = parse_qs(query, keep_blank_values=True)
+    return {key: values[0] if len(values) == 1 else values for key, values in parsed.items()}
+"""
+
+TASK_278 = Task(
+    id="task_278_swe_query_parser",
+    name="Fix query-string parsing edge cases",
+    tags=("swe-bench", "python", "pytest", "bugfix", "hard"),
+    prompt=(
+        "Почини query.py: parse_query должен декодировать percent-encoding,"
+        " заменять + на пробел, сохранять blank values и повторяющиеся ключи"
+        " возвращать списком значений. Тесты менять нельзя."
+    ),
+    setup_files={"query.py": _QUERY_PY_278, "tests/test_query.py": _TEST_QUERY_278},
+    gold_files={"query.py": _QUERY_GOLD_278},
+    verifier=pytest_passes("tests"),
+)
+
+
+_SLUGS_PY_279 = """\
+import re
+
+
+def heading_slug(title: str, existing: set[str]) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    existing.add(slug)
+    return slug
+"""
+
+_TEST_SLUGS_279 = """\
+from slugs import heading_slug
+
+
+def test_duplicate_slugs_get_numeric_suffix():
+    existing = set()
+    assert heading_slug("Hello, World!", existing) == "hello-world"
+    assert heading_slug("Hello World", existing) == "hello-world-2"
+    assert heading_slug("Hello   World", existing) == "hello-world-3"
+
+
+def test_empty_heading_uses_section():
+    existing = set()
+    assert heading_slug("!!!", existing) == "section"
+"""
+
+_SLUGS_GOLD_279 = """\
+import re
+
+
+def heading_slug(title: str, existing: set[str]) -> str:
+    base = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-") or "section"
+    slug = base
+    counter = 2
+    while slug in existing:
+        slug = f"{base}-{counter}"
+        counter += 1
+    existing.add(slug)
+    return slug
+"""
+
+TASK_279 = Task(
+    id="task_279_swe_markdown_slug_duplicates",
+    name="Fix duplicate markdown heading slugs",
+    tags=("swe-bench", "python", "pytest", "bugfix", "hard"),
+    prompt=(
+        "Почини slugs.py: duplicate slugs должны получать суффиксы -2, -3,"
+        " а пустой после нормализации заголовок должен стать section."
+        " Тесты менять нельзя."
+    ),
+    setup_files={"slugs.py": _SLUGS_PY_279, "tests/test_slugs.py": _TEST_SLUGS_279},
+    gold_files={"slugs.py": _SLUGS_GOLD_279},
+    verifier=pytest_passes("tests"),
+)
+
+
+_PAGING_PY_280 = """\
+def paginate(items: list, page: int, per_page: int) -> list:
+    start = page * per_page
+    end = start + per_page
+    return items[start:end]
+"""
+
+_TEST_PAGING_280 = """\
+import pytest
+
+from paging import paginate
+
+
+def test_pages_are_one_based():
+    assert paginate([1, 2, 3, 4, 5], page=1, per_page=2) == [1, 2]
+    assert paginate([1, 2, 3, 4, 5], page=3, per_page=2) == [5]
+
+
+def test_invalid_arguments():
+    with pytest.raises(ValueError):
+        paginate([1], page=0, per_page=10)
+    with pytest.raises(ValueError):
+        paginate([1], page=1, per_page=0)
+"""
+
+_PAGING_GOLD_280 = """\
+def paginate(items: list, page: int, per_page: int) -> list:
+    if page < 1:
+        raise ValueError("page must be >= 1")
+    if per_page < 1:
+        raise ValueError("per_page must be >= 1")
+    start = (page - 1) * per_page
+    end = start + per_page
+    return items[start:end]
+"""
+
+TASK_280 = Task(
+    id="task_280_swe_pagination_one_based",
+    name="Fix one-based pagination",
+    tags=("swe-bench", "python", "pytest", "bugfix", "medium"),
+    prompt=(
+        "Почини paging.py: page должен быть one-based, page/per_page меньше"
+        " 1 должны вызывать ValueError. Тесты менять нельзя."
+    ),
+    setup_files={"paging.py": _PAGING_PY_280, "tests/test_paging.py": _TEST_PAGING_280},
+    gold_files={"paging.py": _PAGING_GOLD_280},
+    verifier=pytest_passes("tests"),
+)
+
+
+_RETRY_PY_281 = """\
+def retry_delays(base: int, attempts: int, cap: int) -> list[int]:
+    delays = []
+    delay = base
+    for _ in range(attempts):
+        delays.append(delay)
+        delay *= 2
+    return delays
+"""
+
+_TEST_RETRY_281 = """\
+import pytest
+
+from retry import retry_delays
+
+
+def test_exponential_delays_are_capped():
+    assert retry_delays(base=2, attempts=5, cap=10) == [2, 4, 8, 10, 10]
+
+
+def test_zero_attempts_and_invalid_values():
+    assert retry_delays(base=2, attempts=0, cap=10) == []
+    with pytest.raises(ValueError):
+        retry_delays(base=0, attempts=1, cap=10)
+"""
+
+_RETRY_GOLD_281 = """\
+def retry_delays(base: int, attempts: int, cap: int) -> list[int]:
+    if base <= 0 or attempts < 0 or cap <= 0:
+        raise ValueError("base, attempts, and cap must be positive")
+    delays = []
+    delay = base
+    for _ in range(attempts):
+        delays.append(min(delay, cap))
+        delay *= 2
+    return delays
+"""
+
+TASK_281 = Task(
+    id="task_281_swe_retry_backoff_cap",
+    name="Fix capped retry backoff",
+    tags=("swe-bench", "python", "pytest", "bugfix", "medium"),
+    prompt=(
+        "Почини retry.py: retry_delays должен применять cap к каждому"
+        " delay, поддерживать attempts=0 и валидировать положительные base/cap."
+        " Тесты менять нельзя."
+    ),
+    setup_files={"retry.py": _RETRY_PY_281, "tests/test_retry.py": _TEST_RETRY_281},
+    gold_files={"retry.py": _RETRY_GOLD_281},
+    verifier=pytest_passes("tests"),
+)
+
+
+_PATHS_PY_282 = """\
+def safe_join(root: str, user_path: str) -> str:
+    return root + "/" + user_path
+"""
+
+_TEST_PATHS_282 = """\
+import os
+import pytest
+
+from paths import safe_join
+
+
+def test_normalizes_inside_root(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    assert safe_join(str(root), "a/../b.txt") == os.path.join(str(root), "b.txt")
+
+
+def test_blocks_escape(tmp_path):
+    root = tmp_path / "root"
+    root.mkdir()
+    with pytest.raises(ValueError):
+        safe_join(str(root), "../secret.txt")
+"""
+
+_PATHS_GOLD_282 = """\
+import os
+
+
+def safe_join(root: str, user_path: str) -> str:
+    root_abs = os.path.abspath(root)
+    target = os.path.abspath(os.path.join(root_abs, user_path))
+    if os.path.commonpath([root_abs, target]) != root_abs:
+        raise ValueError("path escapes root")
+    return target
+"""
+
+TASK_282 = Task(
+    id="task_282_swe_safe_join",
+    name="Fix safe path join",
+    tags=("swe-bench", "python", "pytest", "bugfix", "hard"),
+    prompt=(
+        "Почини paths.py: safe_join должен нормализовать путь внутри root и"
+        " выбрасывать ValueError, если user_path выходит за пределы root."
+        " Тесты менять нельзя."
+    ),
+    setup_files={"paths.py": _PATHS_PY_282, "tests/test_paths.py": _TEST_PATHS_282},
+    gold_files={"paths.py": _PATHS_GOLD_282},
+    verifier=pytest_passes("tests"),
+)
+
+
+_INVENTORY_PY_283 = """\
+def allocate(stock: dict[str, int], order: dict[str, int]) -> dict[str, int]:
+    allocated = {}
+    for sku, qty in order.items():
+        allocated[sku] = qty
+        stock[sku] -= qty
+    return allocated
+"""
+
+_TEST_INVENTORY_283 = """\
+import pytest
+
+from inventory import allocate
+
+
+def test_allocates_without_mutating_on_success():
+    stock = {"a": 5, "b": 1}
+    result = allocate(stock, {"a": 3})
+    assert result == {"a": 3}
+    assert stock == {"a": 5, "b": 1}
+
+
+def test_rejects_missing_or_insufficient_stock():
+    with pytest.raises(ValueError):
+        allocate({"a": 1}, {"a": 2})
+    with pytest.raises(ValueError):
+        allocate({"a": 1}, {"b": 1})
+"""
+
+_INVENTORY_GOLD_283 = """\
+def allocate(stock: dict[str, int], order: dict[str, int]) -> dict[str, int]:
+    for sku, qty in order.items():
+        if stock.get(sku, 0) < qty:
+            raise ValueError(f"insufficient stock for {sku}")
+    return dict(order)
+"""
+
+TASK_283 = Task(
+    id="task_283_swe_inventory_allocate",
+    name="Fix inventory allocation validation",
+    tags=("swe-bench", "python", "pytest", "bugfix", "medium"),
+    prompt=(
+        "Почини inventory.py: allocate должен проверить наличие всех SKU и"
+        " достаточный остаток, вернуть allocation, но не мутировать stock."
+        " При нехватке выбросить ValueError. Тесты менять нельзя."
+    ),
+    setup_files={
+        "inventory.py": _INVENTORY_PY_283,
+        "tests/test_inventory.py": _TEST_INVENTORY_283,
+    },
+    gold_files={"inventory.py": _INVENTORY_GOLD_283},
+    verifier=pytest_passes("tests"),
+)
+
+
+# ---------------------------------------------------------------------------
+# 284..266. more Terminal-Bench-style tasks
+# ---------------------------------------------------------------------------
+_PORTS_284 = {
+    "services/api/config.json": '{\n  "service": "api",\n  "port": 8080,\n  "enabled": true\n}\n',
+    "services/worker/config.json": (
+        '{\n  "service": "worker",\n  "port": 9090,\n  "enabled": false\n}\n'
+    ),
+    "services/web/config.json": '{\n  "service": "web",\n  "port": 3000,\n  "enabled": true\n}\n',
+}
+
+_PORTS_REPORT_284 = """\
+api	8080
+web	3000
+"""
+
+TASK_284 = Task(
+    id="task_284_terminal_json_config_inventory",
+    name="Inventory enabled service ports from JSON configs",
+    tags=("terminal-bench", "json", "config", "hard"),
+    prompt=(
+        "В services/*/config.json лежат конфиги сервисов с полями service,"
+        " port, enabled. Создай enabled_ports.tsv: только enabled=true,"
+        " формат '<service>\\t<port>', сортировка по service."
+    ),
+    setup_files=_PORTS_284,
+    gold_files={"enabled_ports.tsv": _PORTS_REPORT_284},
+    verifier=file_lines_equal("enabled_ports.tsv", _PORTS_REPORT_284.strip().splitlines()),
+)
+
+
+_PATCH_SUMMARY_285 = """\
+files_changed	3
+insertions	7
+deletions	3
+"""
+
+TASK_285 = Task(
+    id="task_285_terminal_patch_stat_summary",
+    name="Summarize git patch statistics",
+    tags=("terminal-bench", "patch", "text", "hard"),
+    prompt=(
+        "В patch.diff лежит unified diff. Посчитай files_changed,"
+        " insertions и deletions. Строки заголовков diff (+++ и ---) не"
+        " считать как insertions/deletions. Создай patch_summary.tsv ровно"
+        " с тремя строками: files_changed, insertions, deletions."
+    ),
+    setup_files={
+        "patch.diff": (
+            "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1,3 +1,5 @@\n"
+            " line\n-old\n+new\n+extra\n"
+            "diff --git a/b.py b/b.py\n--- a/b.py\n+++ b/b.py\n@@ -1,2 +1,4 @@\n"
+            "-x\n+y\n+z\n+q\n"
+            "diff --git a/c.py b/c.py\n--- a/c.py\n+++ b/c.py\n@@ -1,3 +1,4 @@\n"
+            "-drop\n keep\n+add\n+more\n"
+        )
+    },
+    gold_files={"patch_summary.tsv": _PATCH_SUMMARY_285},
+    verifier=file_lines_equal("patch_summary.tsv", _PATCH_SUMMARY_285.strip().splitlines()),
+)
+
+
+_NGINX_286 = """\
+10.0.0.1 - - [25/May/2026:10:00:00 +0000] "GET /api/items HTTP/1.1" 200 12
+10.0.0.2 - - [25/May/2026:10:00:01 +0000] "GET /api/items HTTP/1.1" 499 0
+10.0.0.3 - - [25/May/2026:10:00:02 +0000] "POST /api/cart HTTP/1.1" 201 44
+10.0.0.4 - - [25/May/2026:10:00:03 +0000] "GET /api/items HTTP/1.1" 502 20
+10.0.0.5 - - [25/May/2026:10:00:04 +0000] "POST /api/cart HTTP/1.1" 500 30
+"""
+
+_NGINX_REPORT_286 = """\
+/api/cart	1	1
+/api/items	1	2
+"""
+
+TASK_286 = Task(
+    id="task_286_terminal_nginx_endpoint_classes",
+    name="Classify nginx endpoint successes and failures",
+    tags=("terminal-bench", "logs", "text", "hard"),
+    prompt=(
+        "Прочитай nginx.log. Для каждого endpoint посчитай success"
+        " (status 200-399) и failure (все остальные). Создай"
+        " endpoint_classes.tsv с колонками endpoint, success, failure без"
+        " заголовка, сортировка по endpoint."
+    ),
+    setup_files={"nginx.log": _NGINX_286},
+    gold_files={"endpoint_classes.tsv": _NGINX_REPORT_286},
+    verifier=file_lines_equal("endpoint_classes.tsv", _NGINX_REPORT_286.strip().splitlines()),
+)
+
+
+_RELEASE_NOTES_287 = """\
+## Added
+- Add invoice export
+- Add retry metrics
+## Fixed
+- Fix cache invalidation
+- Fix CSV quoting
+"""
+
+TASK_287 = Task(
+    id="task_287_terminal_changelog_extract",
+    name="Extract release note sections from changelog",
+    tags=("terminal-bench", "markdown", "text", "medium"),
+    prompt=(
+        "В CHANGELOG.md найди секцию версии 1.2.0 и создай"
+        " release_notes.md, содержащий только подразделы Added и Fixed"
+        " этой версии вместе с bullet-строками. Заголовки подразделов в"
+        " выводе оформи уровнем ## (в исходнике они уровня ###)."
+        " Не включай текст версии 1.1.0."
+    ),
+    setup_files={
+        "CHANGELOG.md": (
+            "# Changelog\n\n"
+            "## 1.2.0\n\n"
+            "### Added\n- Add invoice export\n- Add retry metrics\n\n"
+            "### Fixed\n- Fix cache invalidation\n- Fix CSV quoting\n\n"
+            "## 1.1.0\n\n### Added\n- Old feature\n"
+        )
+    },
+    gold_files={"release_notes.md": _RELEASE_NOTES_287},
+    verifier=file_lines_equal("release_notes.md", _RELEASE_NOTES_287.strip().splitlines()),
+)
+
+
+_ARTIFACTS_288 = """\
+artifacts/app-linux.tar.gz
+artifacts/app-macos.tar.gz
+artifacts/app-windows.zip
+"""
+
+TASK_288 = Task(
+    id="task_288_terminal_artifact_filter",
+    name="Filter release artifacts by manifest flags",
+    tags=("terminal-bench", "json", "text", "hard"),
+    prompt=(
+        "В artifacts.json список артефактов с fields path, type, draft."
+        " Создай publish_artifacts.txt: path для type='binary' и draft=false,"
+        " сортировка лексикографически, по одному пути в строке."
+    ),
+    setup_files={
+        "artifacts.json": json.dumps(
+            [
+                {"path": "artifacts/app-linux.tar.gz", "type": "binary", "draft": False},
+                {"path": "artifacts/app-macos.tar.gz", "type": "binary", "draft": False},
+                {"path": "artifacts/debug-symbols.zip", "type": "symbols", "draft": False},
+                {"path": "artifacts/app-windows.zip", "type": "binary", "draft": False},
+                {"path": "artifacts/app-beta.zip", "type": "binary", "draft": True},
+            ],
+            indent=2,
+        )
+        + "\n"
+    },
+    gold_files={"publish_artifacts.txt": _ARTIFACTS_288},
+    verifier=file_lines_equal("publish_artifacts.txt", _ARTIFACTS_288.strip().splitlines()),
+)
+
+
+# ---------------------------------------------------------------------------
+# 289..271. more tau2-style policy tasks
+# ---------------------------------------------------------------------------
+_UTILITY_ACTION_289 = {
+    "action": "create_payment_plan",
+    "account_id": "util-41",
+    "installments": 3,
+    "down_payment_usd": 60,
+    "avoid_disconnect": True,
+}
+
+TASK_289 = Task(
+    id="task_289_tau2_utility_payment_plan",
+    name="Choose utility payment-plan action",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Клиент просит избежать отключения. По utility_account.json и"
+        " policy.md создай utility_action.json с action, account_id,"
+        " installments, down_payment_usd, avoid_disconnect. Значение action —"
+        " create_payment_plan. Если долг меньше"
+        " 500 и есть 20% down payment, разрешен план на 3 платежа."
+    ),
+    setup_files={
+        "utility_account.json": json.dumps(
+            {"account_id": "util-41", "past_due_usd": 300, "offered_down_payment_usd": 60},
+            indent=2,
+        )
+        + "\n",
+        "policy.md": "- Debt <500 with 20% down payment qualifies for a 3 installment plan.\n",
+    },
+    gold_files={"utility_action.json": json.dumps(_UTILITY_ACTION_289, indent=2) + "\n"},
+    verifier=_json_equals("utility_action.json", _UTILITY_ACTION_289),
+)
+
+
+_CAR_ACTION_290 = {
+    "action": "charge_cleaning_fee",
+    "rental_id": "car-58",
+    "fee_usd": 75,
+    "reason": "pet hair reported without pet add-on",
+}
+
+TASK_290 = Task(
+    id="task_290_tau2_car_rental_fee",
+    name="Apply car rental cleaning-fee policy",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "По rental.json и policy.md создай car_action.json с action,"
+        " rental_id, fee_usd, reason. Значение action — charge_cleaning_fee."
+        " Если найден pet_hair и pet_addon=false,"
+        " нужно начислить cleaning fee 75 USD."
+    ),
+    setup_files={
+        "rental.json": json.dumps(
+            {"rental_id": "car-58", "inspection": ["pet_hair"], "pet_addon": False},
+            indent=2,
+        )
+        + "\n",
+        "policy.md": "- Pet hair without pet add-on incurs a 75 USD cleaning fee.\n",
+    },
+    gold_files={"car_action.json": json.dumps(_CAR_ACTION_290, indent=2) + "\n"},
+    verifier=_json_equals_fuzzy("car_action.json", _CAR_ACTION_290, free_text_fields=("reason",)),
+)
+
+
+_EDU_ACTION_291 = {
+    "action": "grant_extension",
+    "student_id": "stu-204",
+    "assignment_id": "essay-7",
+    "new_due_date": "2026-05-30",
+    "penalty_percent": 0,
+}
+
+TASK_291 = Task(
+    id="task_291_tau2_student_extension",
+    name="Grant a student assignment extension",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Студент просит extension из-за подтвержденной болезни. По"
+        " request.json и policy.md создай edu_action.json с action,"
+        " student_id, assignment_id, new_due_date, penalty_percent."
+        " Значение action — grant_extension."
+        " Подтвержденная болезнь дает 5 дней без штрафа."
+    ),
+    setup_files={
+        "request.json": json.dumps(
+            {
+                "student_id": "stu-204",
+                "assignment_id": "essay-7",
+                "due_date": "2026-05-25",
+                "reason": "illness",
+                "documented": True,
+            },
+            indent=2,
+        )
+        + "\n",
+        "policy.md": "- Documented illness grants a 5 day extension with 0 penalty.\n",
+    },
+    gold_files={"edu_action.json": json.dumps(_EDU_ACTION_291, indent=2) + "\n"},
+    verifier=_json_equals("edu_action.json", _EDU_ACTION_291),
+)
+
+
+_PHARMACY_ACTION_292 = {
+    "action": "refuse_refill",
+    "prescription_id": "rx-900",
+    "days_until_eligible": 4,
+    "reason": "controlled medication refill requested too early",
+}
+
+TASK_292 = Task(
+    id="task_292_tau2_pharmacy_refill",
+    name="Refuse an early controlled refill",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Пациент просит refill. По prescription.json и policy.md создай"
+        " pharmacy_action.json с action, prescription_id, days_until_eligible,"
+        " reason. Controlled medication можно refill не раньше чем за 2 дня"
+        " до окончания supply; если рефилл запрошен слишком рано, значение"
+        " action — refuse_refill."
+    ),
+    setup_files={
+        "prescription.json": json.dumps(
+            {"prescription_id": "rx-900", "controlled": True, "days_supply_left": 6},
+            indent=2,
+        )
+        + "\n",
+        "policy.md": "- Controlled refills are eligible when days_supply_left <= 2.\n",
+    },
+    gold_files={"pharmacy_action.json": json.dumps(_PHARMACY_ACTION_292, indent=2) + "\n"},
+    verifier=_json_equals_fuzzy(
+        "pharmacy_action.json", _PHARMACY_ACTION_292, free_text_fields=("reason",)
+    ),
+)
+
+
+_EVENT_ACTION_293 = {
+    "action": "exchange_ticket",
+    "ticket_id": "T-55",
+    "new_event_id": "show-b",
+    "price_delta_usd": 15,
+}
+
+TASK_293 = Task(
+    id="task_293_tau2_event_ticket_exchange",
+    name="Exchange an event ticket under policy",
+    tags=("tau2", "policy", "json", "hard"),
+    prompt=(
+        "Клиент хочет обменять билет на show-b. По ticket.json,"
+        " events.json и policy.md создай event_action.json с action,"
+        " ticket_id, new_event_id, price_delta_usd. Значение action —"
+        " exchange_ticket. Обмен разрешен если"
+        " до события больше 24 часов; price_delta = new_price - old_price."
+    ),
+    setup_files={
+        "ticket.json": json.dumps(
+            {"ticket_id": "T-55", "event_id": "show-a", "hours_until_event": 30, "price_usd": 45},
+            indent=2,
+        )
+        + "\n",
+        "events.json": json.dumps({"show-b": {"price_usd": 60}}, indent=2) + "\n",
+        "policy.md": "- Exchanges are allowed more than 24 hours before the event.\n",
+    },
+    gold_files={"event_action.json": json.dumps(_EVENT_ACTION_293, indent=2) + "\n"},
+    verifier=_json_equals("event_action.json", _EVENT_ACTION_293),
+)
+
+
+# ---------------------------------------------------------------------------
+# 294..276. more SWE-bench-style pytest bug fixes
+# ---------------------------------------------------------------------------
+_MONEY_PY_294 = """\
+def cents(value: str) -> int:
+    return int(float(value) * 100)
+"""
+
+_TEST_MONEY_294 = """\
+from money import cents
+
+
+def test_decimal_money_is_exact():
+    assert cents("10.25") == 1025
+    assert cents("0.29") == 29
+
+
+def test_currency_symbols_and_commas():
+    assert cents("$1,234.50") == 123450
+"""
+
+_MONEY_GOLD_294 = """\
+from decimal import Decimal
+
+
+def cents(value: str) -> int:
+    cleaned = value.strip().replace("$", "").replace(",", "")
+    return int(Decimal(cleaned) * 100)
+"""
+
+TASK_294 = Task(
+    id="task_294_swe_money_cents",
+    name="Fix exact money-to-cents parsing",
+    tags=("swe-bench", "python", "pytest", "bugfix", "hard"),
+    prompt=(
+        "Почини money.py: cents должен точно парсить decimal money,"
+        " поддерживать $ и запятые-разделители тысяч. Не используй float для"
+        " финального расчета. Тесты менять нельзя."
+    ),
+    setup_files={"money.py": _MONEY_PY_294, "tests/test_money.py": _TEST_MONEY_294},
+    gold_files={"money.py": _MONEY_GOLD_294},
+    verifier=pytest_passes("tests"),
+)
+
+
+_TAGS_PY_295 = """\
+def parse_tags(raw: str) -> list[str]:
+    return raw.split(",")
+"""
+
+_TEST_TAGS_295 = """\
+from tags import parse_tags
+
+
+def test_trims_dedupes_and_sorts():
+    assert parse_tags(" beta,alpha,, beta ,Gamma ") == ["alpha", "beta", "gamma"]
+
+
+def test_empty_returns_empty_list():
+    assert parse_tags(" , ") == []
+"""
+
+_TAGS_GOLD_295 = """\
+def parse_tags(raw: str) -> list[str]:
+    tags = {part.strip().lower() for part in raw.split(",") if part.strip()}
+    return sorted(tags)
+"""
+
+TASK_295 = Task(
+    id="task_295_swe_parse_tags",
+    name="Fix tag parsing normalization",
+    tags=("swe-bench", "python", "pytest", "bugfix", "medium"),
+    prompt=(
+        "Почини tags.py: parse_tags должен trim, lower-case, удалить пустые"
+        " элементы, дедуплицировать и вернуть отсортированный список. Тесты"
+        " менять нельзя."
+    ),
+    setup_files={"tags.py": _TAGS_PY_295, "tests/test_tags.py": _TEST_TAGS_295},
+    gold_files={"tags.py": _TAGS_GOLD_295},
+    verifier=pytest_passes("tests"),
+)
+
+
+_ROMAN_PY_296 = """\
+def roman_to_int(value: str) -> int:
+    table = {"I": 1, "V": 5, "X": 10, "L": 50}
+    total = 0
+    for ch in value:
+        total += table[ch]
+    return total
+"""
+
+_TEST_ROMAN_296 = """\
+import pytest
+
+from roman import roman_to_int
+
+
+def test_subtractive_notation():
+    assert roman_to_int("IV") == 4
+    assert roman_to_int("IX") == 9
+    assert roman_to_int("XLII") == 42
+
+
+def test_rejects_invalid_symbols():
+    with pytest.raises(ValueError):
+        roman_to_int("A")
+"""
+
+_ROMAN_GOLD_296 = """\
+def roman_to_int(value: str) -> int:
+    table = {"I": 1, "V": 5, "X": 10, "L": 50}
+    total = 0
+    previous = 0
+    for ch in reversed(value):
+        if ch not in table:
+            raise ValueError(f"invalid Roman symbol: {ch}")
+        current = table[ch]
+        if current < previous:
+            total -= current
+        else:
+            total += current
+            previous = current
+    return total
+"""
+
+TASK_296 = Task(
+    id="task_296_swe_roman_parser",
+    name="Fix Roman numeral parsing",
+    tags=("swe-bench", "python", "pytest", "bugfix", "medium"),
+    prompt=(
+        "Почини roman.py: roman_to_int должен поддерживать subtractive"
+        " notation (IV, IX, XL) и выбрасывать ValueError для неизвестных"
+        " символов. Тесты менять нельзя."
+    ),
+    setup_files={"roman.py": _ROMAN_PY_296, "tests/test_roman.py": _TEST_ROMAN_296},
+    gold_files={"roman.py": _ROMAN_GOLD_296},
+    verifier=pytest_passes("tests"),
+)
+
+
+_AUTH_PY_297 = """\
+def has_role(user: dict, role: str) -> bool:
+    return role in user["roles"]
+
+
+def can_access(user: dict, resource: dict) -> bool:
+    return has_role(user, resource["required_role"])
+"""
+
+_TEST_AUTH_297 = """\
+from authz import can_access
+
+
+def test_admin_bypasses_required_role():
+    assert can_access({"roles": ["admin"]}, {"required_role": "billing"})
+
+
+def test_missing_roles_is_safe_false():
+    assert not can_access({}, {"required_role": "billing"})
+"""
+
+_AUTH_GOLD_297 = """\
+def has_role(user: dict, role: str) -> bool:
+    return role in user.get("roles", [])
+
+
+def can_access(user: dict, resource: dict) -> bool:
+    return has_role(user, "admin") or has_role(user, resource["required_role"])
+"""
+
+TASK_297 = Task(
+    id="task_297_swe_authz_admin",
+    name="Fix authorization role checks",
+    tags=("swe-bench", "python", "pytest", "bugfix", "hard"),
+    prompt=(
+        "Почини authz.py: admin должен иметь доступ к любому ресурсу, а"
+        " отсутствие roles у user должно безопасно возвращать False, не"
+        " KeyError. Тесты менять нельзя."
+    ),
+    setup_files={"authz.py": _AUTH_PY_297, "tests/test_authz.py": _TEST_AUTH_297},
+    gold_files={"authz.py": _AUTH_GOLD_297},
+    verifier=pytest_passes("tests"),
+)
+
+
+_STATS_PY_298 = """\
+def median(values: list[float]) -> float:
+    values = sorted(values)
+    return values[len(values) // 2]
+"""
+
+_TEST_STATS_298 = """\
+import pytest
+
+from stats import median
+
+
+def test_odd_and_even_lengths():
+    assert median([3, 1, 2]) == 2
+    assert median([10, 2, 4, 8]) == 6
+
+
+def test_empty_raises_value_error():
+    with pytest.raises(ValueError):
+        median([])
+"""
+
+_STATS_GOLD_298 = """\
+def median(values: list[float]) -> float:
+    if not values:
+        raise ValueError("median of empty list")
+    ordered = sorted(values)
+    mid = len(ordered) // 2
+    if len(ordered) % 2 == 1:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / 2
+"""
+
+TASK_298 = Task(
+    id="task_298_swe_median_even_empty",
+    name="Fix median for even and empty inputs",
+    tags=("swe-bench", "python", "pytest", "bugfix", "medium"),
+    prompt=(
+        "Почини stats.py: median должен работать для нечетной и четной длины,"
+        " а для пустого списка выбрасывать ValueError. Тесты менять нельзя."
+    ),
+    setup_files={"stats.py": _STATS_PY_298, "tests/test_stats.py": _TEST_STATS_298},
+    gold_files={"stats.py": _STATS_GOLD_298},
+    verifier=pytest_passes("tests"),
+)
+
+
+AGENTIC_TASKS: list[Task] = [
+    TASK_254,
+    TASK_255,
+    TASK_256,
+    TASK_257,
+    TASK_258,
+    TASK_259,
+    TASK_260,
+    TASK_261,
+    TASK_262,
+    TASK_263,
+    TASK_264,
+    TASK_265,
+    TASK_266,
+    TASK_267,
+    TASK_268,
+    TASK_269,
+    TASK_270,
+    TASK_271,
+    TASK_272,
+    TASK_273,
+    TASK_274,
+    TASK_275,
+    TASK_276,
+    TASK_277,
+    TASK_278,
+    TASK_279,
+    TASK_280,
+    TASK_281,
+    TASK_282,
+    TASK_283,
+    TASK_284,
+    TASK_285,
+    TASK_286,
+    TASK_287,
+    TASK_288,
+    TASK_289,
+    TASK_290,
+    TASK_291,
+    TASK_292,
+    TASK_293,
+    TASK_294,
+    TASK_295,
+    TASK_296,
+    TASK_297,
+    TASK_298,
+]

--- a/harness_bench/tasks_memory.py
+++ b/harness_bench/tasks_memory.py
@@ -1,4 +1,4 @@
-"""Memory-aware tasks for harness_bench (tasks 222–231).
+"""Memory-aware tasks for harness_bench (tasks 222–253).
 
 Exercise the deepagents memory subsystem end-to-end:
 
@@ -24,6 +24,7 @@ import re
 import subprocess
 import sys
 import tomllib
+from datetime import date
 from pathlib import Path
 
 from harness_bench.core import Task, VerifyResult
@@ -796,6 +797,1662 @@ TASK_231 = Task(
 
 
 # ---------------------------------------------------------------------------
+# 232. Update focus-day memory + implement scheduling rule function.
+# ---------------------------------------------------------------------------
+_MEM_232_INITIAL = """\
+- Имя: Марина
+- Часовой пояс: Europe/Berlin
+- Рабочие часы: 10:00-19:00
+"""
+
+_GOLD_CALENDAR_RULES_232 = """\
+def can_schedule_meeting(day_of_week: str, hour: int) -> bool:
+    day = day_of_week.strip().lower()
+    if day == "friday":
+        return False
+    return 10 <= hour < 19
+"""
+
+
+def _verify_task_232(ws: Path) -> VerifyResult:
+    mem = ws / "MEMORY.md"
+    if not mem.exists():
+        return VerifyResult(False, "MEMORY.md missing")
+    mem_text = mem.read_text(encoding="utf-8")
+    if not re.search(r"(?iu)^\s*[-*]\s*Фокус-день\s*:\s*пятниц", mem_text, flags=re.MULTILINE):
+        return VerifyResult(False, "MEMORY.md doesn't contain '- Фокус-день: пятница'")
+    if "Europe/Berlin" not in mem_text:
+        return VerifyResult(False, "MEMORY.md lost the timezone fact")
+    if not re.search(r"10\s*:\s*00\s*-\s*19\s*:\s*00", mem_text):
+        return VerifyResult(False, "MEMORY.md lost the working-hours fact")
+
+    rules = ws / "calendar_rules.py"
+    if not rules.exists():
+        return VerifyResult(False, "calendar_rules.py missing")
+
+    try:
+        checks = [
+            ("mod.can_schedule_meeting('monday', 11)", True),
+            ("mod.can_schedule_meeting('friday', 11)", False),
+            ("mod.can_schedule_meeting('monday', 9)", False),
+            ("mod.can_schedule_meeting('monday', 19)", False),
+        ]
+        for expr, expected in checks:
+            res = python_callable_returns("calendar_rules.py", expr, expected)(ws)
+            if not res.passed:
+                return VerifyResult(False, f"calendar_rules.py behavior mismatch: {res.message}")
+    except Exception as exc:  # pragma: no cover - defensive wrapper for bench diagnostics
+        return VerifyResult(False, f"failed to execute calendar_rules.py checks: {exc}")
+
+    return VerifyResult(True, "focus day saved and scheduling rules implemented correctly")
+
+
+TASK_232 = Task(
+    id="task_232_memory_focus_day_schedule_rules",
+    name="Memory: add focus day and implement can_schedule_meeting()",
+    tags=("memory", "update", "python", "logic", "hard"),
+    prompt=(
+        "Добавь в память, что у меня фокус-день по пятницам (в этот день встреч не ставим). "
+        "И создай `calendar_rules.py` с функцией "
+        "`can_schedule_meeting(day_of_week: str, hour: int) -> bool`.\n"
+        "Правила:\n"
+        "- работаем только в часы 10:00-19:00 (19:00 уже не входит);\n"
+        "- по пятницам встречи всегда запрещены;\n"
+        "- `day_of_week` приходит в английском формате (`monday`, ..., `sunday`)."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_232_INITIAL,
+    },
+    gold_files={
+        "MEMORY.md": _MEM_232_INITIAL + "- Фокус-день: пятница\n",
+        "calendar_rules.py": _GOLD_CALENDAR_RULES_232,
+    },
+    verifier=_verify_task_232,
+)
+
+
+# ---------------------------------------------------------------------------
+# 233. Build normalized endpoints.json from remembered domain+service ports.
+# ---------------------------------------------------------------------------
+_MEM_233 = """\
+- Домен разработки: dev.internal
+- Сервисы: auth=7001, billing=7002, metrics=9090
+"""
+
+_GOLD_ENDPOINTS_233 = (
+    json.dumps(
+        {
+            "domain": "dev.internal",
+            "services": [
+                {
+                    "name": "auth",
+                    "port": 7001,
+                    "health_url": "http://dev.internal:7001/health",
+                },
+                {
+                    "name": "billing",
+                    "port": 7002,
+                    "health_url": "http://dev.internal:7002/health",
+                },
+                {
+                    "name": "metrics",
+                    "port": 9090,
+                    "health_url": "http://dev.internal:9090/health",
+                },
+            ],
+            "base_url_map": {
+                "auth": "http://dev.internal:7001",
+                "billing": "http://dev.internal:7002",
+                "metrics": "http://dev.internal:9090",
+            },
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    + "\n"
+)
+
+
+def _verify_task_233(ws: Path) -> VerifyResult:
+    p = ws / "endpoints.json"
+    if not p.exists():
+        return VerifyResult(False, "endpoints.json missing")
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"endpoints.json invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        return VerifyResult(False, "endpoints.json is not an object")
+
+    expected_keys = {"domain", "services", "base_url_map"}
+    actual_keys = set(data.keys())
+    if actual_keys != expected_keys:
+        return VerifyResult(False, f"key mismatch: expected {expected_keys}, got {actual_keys}")
+
+    domain = data.get("domain")
+    if domain != "dev.internal":
+        return VerifyResult(False, f"domain = {domain!r}, expected 'dev.internal'")
+
+    services = data.get("services")
+    if not isinstance(services, list) or len(services) != 3:
+        return VerifyResult(False, "services must be a list with exactly 3 entries")
+
+    observed: dict[str, int] = {}
+    ports: list[int] = []
+    for item in services:
+        if not isinstance(item, dict):
+            return VerifyResult(False, f"services entry is not an object: {item!r}")
+        if set(item.keys()) != {"name", "port", "health_url"}:
+            return VerifyResult(False, f"service entry keys mismatch: {item.keys()!r}")
+        name = item.get("name")
+        port = item.get("port")
+        health = item.get("health_url")
+        if not isinstance(name, str) or not isinstance(port, int) or not isinstance(health, str):
+            return VerifyResult(False, f"invalid service entry types: {item!r}")
+        expected_health = f"http://dev.internal:{port}/health"
+        if health != expected_health:
+            return VerifyResult(False, f"health_url mismatch for {name}: {health!r}")
+        observed[name] = port
+        ports.append(port)
+
+    expected_ports = {"auth": 7001, "billing": 7002, "metrics": 9090}
+    if observed != expected_ports:
+        return VerifyResult(False, f"services mismatch: got {observed!r}, expected {expected_ports!r}")
+    if ports != sorted(ports):
+        return VerifyResult(False, "services must be sorted by port ascending")
+
+    base = data.get("base_url_map")
+    if not isinstance(base, dict):
+        return VerifyResult(False, "base_url_map must be an object")
+    expected_base = {name: f"http://dev.internal:{port}" for name, port in expected_ports.items()}
+    if base != expected_base:
+        return VerifyResult(False, f"base_url_map mismatch: got {base!r}, expected {expected_base!r}")
+
+    return VerifyResult(True, "endpoints.json correctly normalized from MEMORY.md facts")
+
+
+TASK_233 = Task(
+    id="task_233_memory_endpoints_json",
+    name="Memory: compose endpoints.json with derived URLs and ordering",
+    tags=("memory", "read", "json", "derive", "hard"),
+    prompt=(
+        "Собери `endpoints.json` из моих данных в памяти.\n"
+        "Формат строго такой:\n"
+        "- `domain`: строка;\n"
+        "- `services`: массив объектов `{name, port, health_url}`;\n"
+        "- `base_url_map`: объект `name -> http://<domain>:<port>`.\n"
+        "Для каждого сервиса `health_url` должен быть `http://<domain>:<port>/health`.\n"
+        "Сервисы в массиве отсортируй по возрастанию порта."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_233,
+    },
+    gold_files={"endpoints.json": _GOLD_ENDPOINTS_233},
+    verifier=_verify_task_233,
+)
+
+
+# ---------------------------------------------------------------------------
+# 234. Migrate messenger from Telegram to Mattermost in memory + TOML contacts.
+# ---------------------------------------------------------------------------
+_MEM_234_INITIAL = """\
+- Имя: Олег
+- Email: oleg@example.com
+- Основной мессенджер: Telegram
+- Telegram: @oleg_ops
+"""
+
+_CONTACTS_234_INITIAL = """\
+[contacts]
+email = "oleg@example.com"
+telegram = "@oleg_ops"
+preferred = "telegram"
+"""
+
+_MEM_234_GOLD = """\
+- Имя: Олег
+- Email: oleg@example.com
+- Основной мессенджер: Mattermost
+- Mattermost: @oleg_mm
+"""
+
+_CONTACTS_234_GOLD = """\
+[contacts]
+email = "oleg@example.com"
+mattermost = "@oleg_mm"
+preferred = "mattermost"
+"""
+
+
+def _verify_task_234(ws: Path) -> VerifyResult:
+    mem = ws / "MEMORY.md"
+    if not mem.exists():
+        return VerifyResult(False, "MEMORY.md missing")
+    mem_text = mem.read_text(encoding="utf-8")
+    if re.search(r"(?iu)telegram", mem_text) or "@oleg_ops" in mem_text:
+        return VerifyResult(False, "MEMORY.md still contains Telegram facts")
+    if not re.search(r"(?iu)mattermost", mem_text):
+        return VerifyResult(False, "MEMORY.md doesn't contain Mattermost fact")
+    if "@oleg_mm" not in mem_text:
+        return VerifyResult(False, "MEMORY.md missing new Mattermost handle")
+    if "oleg@example.com" not in mem_text:
+        return VerifyResult(False, "MEMORY.md lost email fact")
+
+    cpath = ws / "contacts.toml"
+    if not cpath.exists():
+        return VerifyResult(False, "contacts.toml missing")
+    raw = cpath.read_text(encoding="utf-8")
+    if re.search(r"(?i)\btelegram\b", raw):
+        return VerifyResult(False, "contacts.toml still mentions telegram")
+    try:
+        data = tomllib.loads(raw)
+    except tomllib.TOMLDecodeError as exc:
+        return VerifyResult(False, f"contacts.toml invalid TOML: {exc}")
+    contacts = data.get("contacts")
+    if not isinstance(contacts, dict):
+        return VerifyResult(False, "contacts.toml missing [contacts] table")
+    if "telegram" in contacts:
+        return VerifyResult(False, "contacts.toml still has contacts.telegram key")
+    if contacts.get("email") != "oleg@example.com":
+        return VerifyResult(False, f"contacts.email = {contacts.get('email')!r}")
+    if contacts.get("mattermost") != "@oleg_mm":
+        return VerifyResult(False, f"contacts.mattermost = {contacts.get('mattermost')!r}")
+    if contacts.get("preferred") != "mattermost":
+        return VerifyResult(False, f"contacts.preferred = {contacts.get('preferred')!r}")
+    return VerifyResult(True, "messenger successfully migrated to Mattermost")
+
+
+TASK_234 = Task(
+    id="task_234_memory_messenger_migration",
+    name="Memory: migrate Telegram to Mattermost across MEMORY.md and TOML",
+    tags=("memory", "update", "forget", "toml", "hard"),
+    prompt=(
+        "Я перешёл с Telegram на Mattermost. Новый ник: `@oleg_mm`.\n"
+        "Telegram больше не использую.\n"
+        "Обнови это и в памяти, и в `contacts.toml`."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_234_INITIAL,
+        "contacts.toml": _CONTACTS_234_INITIAL,
+    },
+    gold_files={
+        "MEMORY.md": _MEM_234_GOLD,
+        "contacts.toml": _CONTACTS_234_GOLD,
+    },
+    verifier=_verify_task_234,
+)
+
+
+# ---------------------------------------------------------------------------
+# 235. Temporal reasoning + event ordering into normalized timeline JSON.
+# ---------------------------------------------------------------------------
+_MEM_235 = """\
+- Проект: Atlas
+- Проект Atlas — kickoff: 2026-01-15
+- Проект Atlas — design approved: 2026-02-20
+- Проект Atlas — beta: 2026-04-05
+- Проект Atlas — release: 2026-05-10
+"""
+
+_GOLD_ATLAS_TIMELINE_235 = (
+    json.dumps(
+        {
+            "project": "Atlas",
+            "events": [
+                {"id": "kickoff", "date": "2026-01-15"},
+                {"id": "design_approved", "date": "2026-02-20"},
+                {"id": "beta", "date": "2026-04-05"},
+                {"id": "release", "date": "2026-05-10"},
+            ],
+            "durations_days": {
+                "kickoff_to_release": 115,
+                "design_approved_to_beta": 44,
+            },
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    + "\n"
+)
+
+
+def _verify_task_235(ws: Path) -> VerifyResult:
+    p = ws / "atlas_timeline.json"
+    if not p.exists():
+        return VerifyResult(False, "atlas_timeline.json missing")
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"atlas_timeline.json invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        return VerifyResult(False, "atlas_timeline.json is not an object")
+
+    expected_keys = {"project", "events", "durations_days"}
+    if set(data.keys()) != expected_keys:
+        return VerifyResult(False, f"key mismatch: expected {expected_keys}, got {set(data.keys())}")
+    if data.get("project") != "Atlas":
+        return VerifyResult(False, f"project = {data.get('project')!r}, expected 'Atlas'")
+
+    events = data.get("events")
+    if not isinstance(events, list) or len(events) != 4:
+        return VerifyResult(False, "events must be an array of 4 items")
+    expected_order = ["kickoff", "design_approved", "beta", "release"]
+    expected_dates = {
+        "kickoff": "2026-01-15",
+        "design_approved": "2026-02-20",
+        "beta": "2026-04-05",
+        "release": "2026-05-10",
+    }
+    got_order: list[str] = []
+    parsed_dates: list[date] = []
+    for item in events:
+        if not isinstance(item, dict) or set(item.keys()) != {"id", "date"}:
+            return VerifyResult(False, f"event item must have only id/date: {item!r}")
+        ev_id = item.get("id")
+        ev_date = item.get("date")
+        if not isinstance(ev_id, str) or not isinstance(ev_date, str):
+            return VerifyResult(False, f"invalid event types: {item!r}")
+        if expected_dates.get(ev_id) != ev_date:
+            return VerifyResult(False, f"event {ev_id!r} has date {ev_date!r}, expected {expected_dates.get(ev_id)!r}")
+        got_order.append(ev_id)
+        try:
+            parsed_dates.append(date.fromisoformat(ev_date))
+        except ValueError:
+            return VerifyResult(False, f"invalid ISO date in events: {ev_date!r}")
+    if got_order != expected_order:
+        return VerifyResult(False, f"events order mismatch: got {got_order!r}, expected {expected_order!r}")
+    if parsed_dates != sorted(parsed_dates):
+        return VerifyResult(False, "events are not sorted chronologically")
+
+    durations = data.get("durations_days")
+    if not isinstance(durations, dict):
+        return VerifyResult(False, "durations_days must be an object")
+    required_duration_keys = {"kickoff_to_release", "design_approved_to_beta"}
+    if set(durations.keys()) != required_duration_keys:
+        return VerifyResult(
+            False,
+            f"durations_days keys mismatch: got {set(durations.keys())!r}, expected {required_duration_keys!r}",
+        )
+    if durations.get("kickoff_to_release") != 115:
+        return VerifyResult(
+            False, f"kickoff_to_release = {durations.get('kickoff_to_release')!r}, expected 115"
+        )
+    if durations.get("design_approved_to_beta") != 44:
+        return VerifyResult(
+            False, f"design_approved_to_beta = {durations.get('design_approved_to_beta')!r}, expected 44"
+        )
+
+    return VerifyResult(True, "timeline ordering and temporal calculations are correct")
+
+
+TASK_235 = Task(
+    id="task_235_memory_event_ordering_timeline",
+    name="Memory: event ordering + temporal calculations in timeline JSON",
+    tags=("memory", "temporal", "event-ordering", "json", "hard"),
+    prompt=(
+        "Собери `atlas_timeline.json` на основе памяти.\n"
+        "Формат:\n"
+        "- `project`: строка;\n"
+        "- `events`: массив из объектов `{id, date}`;\n"
+        "- `durations_days`: объект с полями `kickoff_to_release` и `design_approved_to_beta`.\n"
+        "Требования:\n"
+        "1) события должны идти в хронологическом порядке;\n"
+        "2) даты в ISO `YYYY-MM-DD`;\n"
+        "3) длительности посчитать в днях."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_235,
+    },
+    gold_files={"atlas_timeline.json": _GOLD_ATLAS_TIMELINE_235},
+    verifier=_verify_task_235,
+)
+
+
+# ---------------------------------------------------------------------------
+# 236. Contradiction resolution (latest fact wins) + propagate to tfvars/yaml.
+# ---------------------------------------------------------------------------
+_MEM_236_INITIAL = """\
+- Имя: Андрей
+- Основной регион AWS: us-east-1
+- Обновление 2026-05-12: основной регион AWS теперь eu-central-1
+- Логи храню в бакете atlas-logs
+"""
+
+_INFRA_236_INITIAL = """\
+aws_region = "us-east-1"
+logs_bucket = "atlas-logs"
+"""
+
+_DEPLOY_236_INITIAL = """\
+service:
+  name: atlas-api
+  region: us-east-1
+"""
+
+_MEM_236_GOLD = """\
+- Имя: Андрей
+- Основной регион AWS: eu-central-1
+- Логи храню в бакете atlas-logs
+"""
+
+_INFRA_236_GOLD = """\
+aws_region = "eu-central-1"
+logs_bucket = "atlas-logs"
+"""
+
+_DEPLOY_236_GOLD = """\
+service:
+  name: atlas-api
+  region: eu-central-1
+"""
+
+
+def _verify_task_236(ws: Path) -> VerifyResult:
+    mem = ws / "MEMORY.md"
+    if not mem.exists():
+        return VerifyResult(False, "MEMORY.md missing")
+    mem_text = mem.read_text(encoding="utf-8")
+    if "eu-central-1" not in mem_text:
+        return VerifyResult(False, "MEMORY.md doesn't contain updated region eu-central-1")
+    if "us-east-1" in mem_text:
+        return VerifyResult(False, "MEMORY.md still contains outdated region us-east-1")
+
+    tfvars = ws / "infra.auto.tfvars"
+    if not tfvars.exists():
+        return VerifyResult(False, "infra.auto.tfvars missing")
+    tf_text = tfvars.read_text(encoding="utf-8")
+    if 'aws_region = "eu-central-1"' not in tf_text:
+        return VerifyResult(False, "infra.auto.tfvars does not set aws_region to eu-central-1")
+    if "us-east-1" in tf_text:
+        return VerifyResult(False, "infra.auto.tfvars still contains us-east-1")
+    if 'logs_bucket = "atlas-logs"' not in tf_text:
+        return VerifyResult(False, "infra.auto.tfvars lost logs_bucket")
+
+    deploy = ws / "deploy.yml"
+    if not deploy.exists():
+        return VerifyResult(False, "deploy.yml missing")
+    dep_text = deploy.read_text(encoding="utf-8")
+    if not re.search(r"(?m)^\s*region\s*:\s*eu-central-1\s*$", dep_text):
+        return VerifyResult(False, "deploy.yml does not set region: eu-central-1")
+    if "us-east-1" in dep_text:
+        return VerifyResult(False, "deploy.yml still contains us-east-1")
+
+    return VerifyResult(True, "latest region chosen and propagated across files")
+
+
+TASK_236 = Task(
+    id="task_236_memory_contradiction_resolution_region",
+    name="Memory: resolve region contradiction and propagate latest value",
+    tags=("memory", "knowledge-update", "contradiction", "propagate", "hard"),
+    prompt=(
+        "У меня в памяти есть старый и новый AWS-регион. "
+        "Оставь в проекте только актуальный регион и полностью убери старый — "
+        "нигде его не упоминай, даже в комментариях или заметках.\n"
+        "Синхронно обнови `MEMORY.md`, `infra.auto.tfvars` и `deploy.yml`."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_236_INITIAL,
+        "infra.auto.tfvars": _INFRA_236_INITIAL,
+        "deploy.yml": _DEPLOY_236_INITIAL,
+    },
+    gold_files={
+        "MEMORY.md": _MEM_236_GOLD,
+        "infra.auto.tfvars": _INFRA_236_GOLD,
+        "deploy.yml": _DEPLOY_236_GOLD,
+    },
+    verifier=_verify_task_236,
+)
+
+
+# ---------------------------------------------------------------------------
+# 237. Preference following with anti-preferences in structured weekend plan.
+# ---------------------------------------------------------------------------
+_MEM_237 = """\
+- Город: Казань
+- Любимые активности: бег, йога, музей
+- Не люблю: шумные бары, караоке
+"""
+
+_GOLD_WEEKEND_PLAN_237 = (
+    json.dumps(
+        {
+            "city": "Казань",
+            "activities": ["утренняя пробежка", "йога дома", "посещение музея"],
+            "notes": "План без шумных мест и без караоке.",
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    + "\n"
+)
+
+
+def _verify_task_237(ws: Path) -> VerifyResult:
+    p = ws / "weekend_plan.json"
+    if not p.exists():
+        return VerifyResult(False, "weekend_plan.json missing")
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"weekend_plan.json invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        return VerifyResult(False, "weekend_plan.json is not a JSON object")
+
+    expected_keys = {"city", "activities", "notes"}
+    if set(data.keys()) != expected_keys:
+        return VerifyResult(False, f"weekend_plan.json key mismatch: expected {expected_keys}")
+
+    if data.get("city") != "Казань":
+        return VerifyResult(False, f"city = {data.get('city')!r}, expected 'Казань'")
+    activities = data.get("activities")
+    if not isinstance(activities, list) or len(activities) != 3:
+        return VerifyResult(False, "activities must be an array of exactly 3 items")
+    if any(not isinstance(x, str) or not x.strip() for x in activities):
+        return VerifyResult(False, "all activities must be non-empty strings")
+    if len({x.strip().lower() for x in activities}) != 3:
+        return VerifyResult(False, "activities must be unique")
+
+    joined = " ".join(activities).lower()
+    banned_patterns = [r"караоке", r"\bbar\b", r"бар", r"шумн"]
+    for pat in banned_patterns:
+        if re.search(pat, joined, flags=re.IGNORECASE):
+            return VerifyResult(False, f"activities include banned concept matched by {pat!r}")
+
+    liked_patterns = [r"бег|пробеж", r"йога", r"музе"]
+    liked_hits = sum(1 for pat in liked_patterns if re.search(pat, joined, flags=re.IGNORECASE))
+    if liked_hits < 2:
+        return VerifyResult(False, "activities should reflect at least two liked preferences")
+
+    notes = data.get("notes")
+    if not isinstance(notes, str) or len(notes.strip()) < 8:
+        return VerifyResult(False, "notes should be a short explanatory sentence")
+    return VerifyResult(True, "weekend plan follows preferences and avoids anti-preferences")
+
+
+TASK_237 = Task(
+    id="task_237_memory_preference_following_weekend_plan",
+    name="Memory: preference-following weekend plan with anti-preference constraints",
+    tags=("memory", "preference", "constraints", "json", "hard"),
+    prompt=(
+        "Сделай `weekend_plan.json` по моим предпочтениям из памяти.\n"
+        "Формат: `city`, `activities` (ровно 3 пункта), `notes`.\n"
+        "Важно: не предлагай то, что я не люблю."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_237,
+    },
+    gold_files={"weekend_plan.json": _GOLD_WEEKEND_PLAN_237},
+    verifier=_verify_task_237,
+)
+
+
+# ---------------------------------------------------------------------------
+# 238. Abstention: preserve known facts, leave unknown phone as null.
+# ---------------------------------------------------------------------------
+_MEM_238 = """\
+- Имя: Елена
+- Компания: DataPulse
+- Роль: ML Engineer
+"""
+
+_GOLD_CONTACT_CARD_238 = (
+    json.dumps(
+        {
+            "name": "Елена",
+            "company": "DataPulse",
+            "role": "ML Engineer",
+            "phone": None,
+            "notes": "Телефон в памяти не указан.",
+        },
+        ensure_ascii=False,
+        indent=2,
+    )
+    + "\n"
+)
+
+
+def _verify_task_238(ws: Path) -> VerifyResult:
+    p = ws / "contact_card.json"
+    if not p.exists():
+        return VerifyResult(False, "contact_card.json missing")
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"contact_card.json invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        return VerifyResult(False, "contact_card.json must be a JSON object")
+
+    expected_keys = {"name", "company", "role", "phone", "notes"}
+    if set(data.keys()) != expected_keys:
+        return VerifyResult(False, f"key mismatch: expected {expected_keys}, got {set(data.keys())}")
+    if data.get("name") != "Елена":
+        return VerifyResult(False, f"name = {data.get('name')!r}, expected 'Елена'")
+    if data.get("company") != "DataPulse":
+        return VerifyResult(False, f"company = {data.get('company')!r}, expected 'DataPulse'")
+    if data.get("role") != "ML Engineer":
+        return VerifyResult(False, f"role = {data.get('role')!r}, expected 'ML Engineer'")
+    if data.get("phone", "marker") is not None:
+        return VerifyResult(False, f"phone should be null, got {data.get('phone')!r}")
+
+    notes = data.get("notes")
+    if not isinstance(notes, str):
+        return VerifyResult(False, "notes must be a string")
+    if not re.search(r"(?iu)не\s+указ|нет|unknown|missing|not\s+provided", notes):
+        return VerifyResult(False, "notes should explicitly state that phone is unknown/missing")
+    return VerifyResult(True, "unknown phone handled via abstention (null + explicit note)")
+
+
+TASK_238 = Task(
+    id="task_238_memory_abstention_unknown_phone",
+    name="Memory: abstain on unknown phone and output structured null",
+    tags=("memory", "abstention", "json", "structured", "medium"),
+    prompt=(
+        "Сделай `contact_card.json` с полями: `name`, `company`, `role`, `phone`, `notes`.\n"
+        "Если телефона нет в памяти, не придумывай — поставь `null` и явно напиши в notes, "
+        "что телефон неизвестен."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_238,
+    },
+    gold_files={"contact_card.json": _GOLD_CONTACT_CARD_238},
+    verifier=_verify_task_238,
+)
+
+
+# ---------------------------------------------------------------------------
+# 239. Multi-hop inference: combine salary + tax rate to compute net income.
+# ---------------------------------------------------------------------------
+_MEM_239 = """\
+- Имя: Кирилл
+- Зарплата: 200000 руб/мес (gross)
+- Ставка НДФЛ: 13%
+- Город: Новосибирск
+"""
+
+
+def _verify_task_239(ws: Path) -> VerifyResult:
+    p = ws / "salary.json"
+    if not p.exists():
+        return VerifyResult(False, "salary.json missing")
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"salary.json invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        return VerifyResult(False, "salary.json must be a JSON object")
+    gross = data.get("gross_monthly")
+    if gross != 200000:
+        return VerifyResult(False, f"gross_monthly = {gross!r}, expected 200000")
+    tax_rate = data.get("tax_rate")
+    if tax_rate != 0.13:
+        return VerifyResult(False, f"tax_rate = {tax_rate!r}, expected 0.13")
+    tax_amount = data.get("tax_monthly")
+    if tax_amount != 26000:
+        return VerifyResult(False, f"tax_monthly = {tax_amount!r}, expected 26000")
+    net = data.get("net_monthly")
+    if net != 174000:
+        return VerifyResult(False, f"net_monthly = {net!r}, expected 174000")
+    net_annual = data.get("net_annual")
+    if net_annual != 2088000:
+        return VerifyResult(False, f"net_annual = {net_annual!r}, expected 2088000")
+    return VerifyResult(True, "salary calculations correct")
+
+
+TASK_239 = Task(
+    id="task_239_memory_multi_hop_salary",
+    name="Memory: multi-hop salary/tax/net computation",
+    tags=("memory", "read", "compute", "multi-hop", "json", "hard"),
+    prompt=(
+        "Собери `salary.json` из моих данных в памяти.\n"
+        "Поля: `gross_monthly` (int), `tax_rate` (float), `tax_monthly` (int), "
+        "`net_monthly` (int), `net_annual` (int).\n"
+        "Все суммы в рублях, целые числа. net = gross - tax. annual = monthly * 12."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_239,
+    },
+    gold_files={
+        "salary.json": json.dumps(
+            {"gross_monthly": 200000, "tax_rate": 0.13, "tax_monthly": 26000,
+             "net_monthly": 174000, "net_annual": 2088000},
+            ensure_ascii=False, indent=2,
+        ) + "\n",
+    },
+    verifier=_verify_task_239,
+)
+
+
+# ---------------------------------------------------------------------------
+# 240. Summarization: compress verbose memory into a concise 3-line summary.
+# ---------------------------------------------------------------------------
+_MEM_240 = """\
+- Имя: Софья Белова
+- Город: Екатеринбург
+- Компания: RocketData
+- Должность: Senior Backend Developer
+- Стаж: 8 лет
+- Основной язык: Go
+- Вторичный язык: Python
+- БД: PostgreSQL, ClickHouse
+- Хобби: скалолазание, фотография
+- ОС: Linux (Fedora)
+- Редактор: Neovim
+- Любимый фреймворк: Echo (Go)
+"""
+
+
+def _verify_task_240(ws: Path) -> VerifyResult:
+    p = ws / "summary.txt"
+    if not p.exists():
+        return VerifyResult(False, "summary.txt missing")
+    text = p.read_text(encoding="utf-8").strip()
+    lines = [l for l in text.splitlines() if l.strip()]
+    if len(lines) > 5:
+        return VerifyResult(False, f"summary.txt has {len(lines)} lines; expected ≤ 5")
+    if len(text) > 500:
+        return VerifyResult(False, f"summary.txt too long ({len(text)} chars); expected ≤ 500")
+    lower = text.lower()
+    required = ["софья", "rocketdata", "go"]
+    missing = [r for r in required if r.lower() not in lower]
+    if missing:
+        return VerifyResult(False, f"summary.txt missing key facts: {missing!r}")
+    return VerifyResult(True, "summary.txt is concise and includes key facts")
+
+
+TASK_240 = Task(
+    id="task_240_memory_summarize_profile",
+    name="Memory: summarize verbose profile into concise summary.txt",
+    tags=("memory", "read", "summarization", "medium"),
+    prompt=(
+        "Напиши `summary.txt` — краткое резюме обо мне на основе памяти. "
+        "Максимум 3-5 строк текста. Упомяни имя, компанию и основной стек."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_240,
+    },
+    gold_files={
+        "summary.txt": (
+            "Софья Белова — Senior Backend Developer в RocketData (Екатеринбург).\n"
+            "Основной стек: Go (Echo), Python, PostgreSQL, ClickHouse.\n"
+            "8 лет опыта. Работает на Linux (Fedora) в Neovim.\n"
+        ),
+    },
+    verifier=_verify_task_240,
+)
+
+
+# ---------------------------------------------------------------------------
+# 241. Instruction following: memory says "always use tabs, 120 cols, no
+#      trailing commas" → reformat an existing JSON config.
+# ---------------------------------------------------------------------------
+_MEM_241 = """\
+- Форматирование JSON: отступ — табуляция, без trailing commas
+- Максимальная ширина строки: 120
+"""
+
+_CONFIG_241_INITIAL = """\
+{
+    "app": "demo",
+    "port": 3000,
+    "debug": true,
+    "features": [
+        "auth",
+        "logging",
+        "metrics"
+    ]
+}
+"""
+
+
+def _verify_task_241(ws: Path) -> VerifyResult:
+    p = ws / "config.json"
+    if not p.exists():
+        return VerifyResult(False, "config.json missing")
+    raw = p.read_text(encoding="utf-8")
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"config.json invalid JSON: {exc}")
+    if data.get("app") != "demo" or data.get("port") != 3000:
+        return VerifyResult(False, "config.json data was changed; only formatting should change")
+    content_lines = raw.splitlines()
+    indented = [l for l in content_lines if l and l[0] in (" ", "\t")]
+    if not indented:
+        return VerifyResult(False, "config.json has no indentation at all")
+    tab_lines = [l for l in indented if l.startswith("\t")]
+    if len(tab_lines) < len(indented) * 0.8:
+        return VerifyResult(False, "config.json should use tabs for indentation")
+    if ",\n" in raw and re.search(r",\s*[\]\}]", raw):
+        return VerifyResult(False, "config.json has trailing commas")
+    return VerifyResult(True, "config.json reformatted with tabs and no trailing commas")
+
+
+TASK_241 = Task(
+    id="task_241_memory_instruction_reformat_json",
+    name="Memory: follow formatting instructions to reformat JSON config",
+    tags=("memory", "read", "instruction-following", "json", "medium"),
+    prompt=(
+        "Переформатируй `config.json` согласно моим правилам форматирования из памяти. "
+        "Данные не меняй, только форматирование."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_241,
+        "config.json": _CONFIG_241_INITIAL,
+    },
+    gold_files={},
+    verifier=_verify_task_241,
+)
+
+
+# ---------------------------------------------------------------------------
+# 242. Knowledge update: user changed job → update memory + README + package.json.
+# ---------------------------------------------------------------------------
+_MEM_242_INITIAL = """\
+- Имя: Виктор Козлов
+- Компания: OldCorp
+- Должность: Junior Developer
+- Email: victor@oldcorp.com
+"""
+
+_README_242_INITIAL = """\
+# About
+
+Victor Kozlov — Junior Developer at OldCorp.
+Contact: victor@oldcorp.com
+"""
+
+_PACKAGE_242_INITIAL = """\
+{
+  "name": "victor-portfolio",
+  "version": "1.0.0",
+  "author": "Victor Kozlov <victor@oldcorp.com>"
+}
+"""
+
+
+def _verify_task_242(ws: Path) -> VerifyResult:
+    mem = ws / "MEMORY.md"
+    if not mem.exists():
+        return VerifyResult(False, "MEMORY.md missing")
+    mt = mem.read_text(encoding="utf-8")
+    if "OldCorp" in mt:
+        return VerifyResult(False, "MEMORY.md still mentions OldCorp")
+    if "Junior" in mt:
+        return VerifyResult(False, "MEMORY.md still mentions Junior Developer")
+    if "victor@oldcorp.com" in mt:
+        return VerifyResult(False, "MEMORY.md still has old email")
+    if "NewTech" not in mt:
+        return VerifyResult(False, "MEMORY.md doesn't mention NewTech")
+    if not re.search(r"(?i)senior", mt):
+        return VerifyResult(False, "MEMORY.md doesn't mention Senior role")
+    if "victor@newtech.io" not in mt:
+        return VerifyResult(False, "MEMORY.md missing new email")
+
+    readme = ws / "README.md"
+    if not readme.exists():
+        return VerifyResult(False, "README.md missing")
+    rt = readme.read_text(encoding="utf-8")
+    if "OldCorp" in rt or "oldcorp" in rt:
+        return VerifyResult(False, "README.md still mentions OldCorp")
+    if "NewTech" not in rt and "newtech" not in rt:
+        return VerifyResult(False, "README.md doesn't mention NewTech")
+    if "victor@newtech.io" not in rt:
+        return VerifyResult(False, "README.md missing new email")
+
+    pkg = ws / "package.json"
+    if not pkg.exists():
+        return VerifyResult(False, "package.json missing")
+    try:
+        data = json.loads(pkg.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"package.json invalid JSON: {exc}")
+    author = str(data.get("author", ""))
+    if "oldcorp" in author.lower():
+        return VerifyResult(False, "package.json author still mentions oldcorp")
+    if "victor@newtech.io" not in author:
+        return VerifyResult(False, "package.json author missing new email")
+    return VerifyResult(True, "job change propagated to all files")
+
+
+TASK_242 = Task(
+    id="task_242_memory_knowledge_update_job_change",
+    name="Memory: update job/company/email across memory + README + package.json",
+    tags=("memory", "knowledge-update", "propagate", "hard"),
+    prompt=(
+        "Я сменил работу! Теперь я Senior Developer в NewTech, "
+        "email: victor@newtech.io. Обнови все файлы проекта."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_242_INITIAL,
+        "README.md": _README_242_INITIAL,
+        "package.json": _PACKAGE_242_INITIAL,
+    },
+    gold_files={},
+    verifier=_verify_task_242,
+)
+
+
+# ---------------------------------------------------------------------------
+# 243. Multi-session reasoning: stitch together facts from different "sessions"
+#      stored as separate memory entries to generate a travel packing list.
+# ---------------------------------------------------------------------------
+_MEM_243 = """\
+- Город назначения: Стамбул
+- Даты поездки: 10-17 августа 2026
+- Цель поездки: конференция + отдых
+- Аллергия: латекс
+- Дресс-код на конференции: business casual
+- Хобби в поездках: бег по утрам
+"""
+
+
+def _verify_task_243(ws: Path) -> VerifyResult:
+    p = ws / "packing_list.json"
+    if not p.exists():
+        return VerifyResult(False, "packing_list.json missing")
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"packing_list.json invalid JSON: {exc}")
+    if not isinstance(data, dict):
+        return VerifyResult(False, "packing_list.json must be a JSON object")
+
+    dest = data.get("destination")
+    if dest != "Стамбул":
+        return VerifyResult(False, f"destination = {dest!r}, expected 'Стамбул'")
+    dates = data.get("dates")
+    if not isinstance(dates, str) or "август" not in dates.lower():
+        return VerifyResult(False, f"dates missing or doesn't mention август: {dates!r}")
+
+    categories = data.get("categories")
+    if not isinstance(categories, dict):
+        return VerifyResult(False, "categories must be an object")
+    if len(categories) < 2:
+        return VerifyResult(False, "categories should have at least 2 sections")
+
+    all_items = " ".join(
+        str(v) for vals in categories.values()
+        for v in (vals if isinstance(vals, list) else [vals])
+    ).lower()
+
+    if not re.search(r"бег|кроссовк|running|спорт", all_items):
+        return VerifyResult(False, "packing list should include running gear")
+    # The latex allergy is verified deterministically via the notes/warnings,
+    # NOT by scanning item names. Substring matching can't distinguish a latex
+    # item ("латексные перчатки") from a latex-AVOIDING one ("без латекса",
+    # "нитрил вместо латексных"), and the correct response to the allergy is to
+    # pack latex-free gear — which necessarily contains the word "latex". So an
+    # item scan inevitably rejects correct lists. Requiring the notes to name
+    # latex specifically proves the agent integrated the allergen fact without
+    # ever penalizing a correct packing list.
+    notes = data.get("notes")
+    if not isinstance(notes, str):
+        return VerifyResult(False, "notes must be a string")
+    if not re.search(r"(?iu)латекс|latex", notes):
+        return VerifyResult(False, "notes must explicitly warn about the latex allergy")
+    return VerifyResult(True, "packing list integrates all multi-session facts")
+
+
+TASK_243 = Task(
+    id="task_243_memory_multi_session_packing_list",
+    name="Memory: multi-session reasoning for travel packing list",
+    tags=("memory", "read", "multi-session", "json", "hard"),
+    prompt=(
+        "Собери `packing_list.json` для моей поездки из данных в памяти.\n"
+        "Поля: `destination` (строка), `dates` (строка), "
+        "`categories` (объект: секция → массив вещей), `notes` (строка с предупреждениями).\n"
+        "Учти все мои особенности: аллергии, хобби, дресс-код."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_243,
+    },
+    gold_files={},
+    verifier=_verify_task_243,
+)
+
+
+# ---------------------------------------------------------------------------
+# 244. Save multiple facts from a single message + generate .env.example.
+# ---------------------------------------------------------------------------
+def _verify_task_244(ws: Path) -> VerifyResult:
+    mem = ws / "MEMORY.md"
+    if not mem.exists():
+        return VerifyResult(False, "MEMORY.md missing")
+    mt = mem.read_text(encoding="utf-8")
+    checks = [
+        (r"(?iu)база\s*(данных|BD|DB)\s*:\s*PostgreSQL|PostgreSQL", "PostgreSQL"),
+        # 5433 is a non-default Postgres port stated verbatim in the prompt, so
+        # recording it in any phrasing ("Порт: 5433", "на порту 5433",
+        # "PostgreSQL:5433") counts as remembering the fact. Don't over-fit to a
+        # single colon-delimited key:value form.
+        (r"5433", "port 5433"),
+        (r"(?iu)Redis", "Redis"),
+    ]
+    for pattern, label in checks:
+        if not re.search(pattern, mt):
+            return VerifyResult(False, f"MEMORY.md missing fact: {label}")
+
+    env = ws / ".env.example"
+    if not env.exists():
+        return VerifyResult(False, ".env.example missing")
+    et = env.read_text(encoding="utf-8")
+    if "DATABASE_URL" not in et:
+        return VerifyResult(False, ".env.example missing DATABASE_URL")
+    if "5433" not in et:
+        return VerifyResult(False, ".env.example missing port 5433")
+    if "REDIS_URL" not in et:
+        return VerifyResult(False, ".env.example missing REDIS_URL")
+    for secret_pattern in [r"(?i)password\s*=\s*[^\s<{]+[a-zA-Z0-9]", r"(?i)secret\s*=\s*\S{8,}"]:
+        if re.search(secret_pattern, et):
+            hints = re.findall(secret_pattern, et)
+            if any("placeholder" not in h.lower() and "your_" not in h.lower()
+                   and "<" not in h and "{" not in h for h in hints):
+                pass
+    return VerifyResult(True, "facts saved and .env.example generated")
+
+
+TASK_244 = Task(
+    id="task_244_memory_save_multi_facts_env",
+    name="Memory: extract multiple facts from message + generate .env.example",
+    tags=("memory", "save", "information-extraction", "multi-fact", "medium"),
+    prompt=(
+        "Мой проект использует PostgreSQL на порту 5433 и Redis. "
+        "Запомни это и создай `.env.example` с плейсхолдерами для "
+        "`DATABASE_URL` (postgresql://...:5433/mydb) и `REDIS_URL`."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": "",
+    },
+    gold_files={},
+    verifier=_verify_task_244,
+)
+
+
+# ---------------------------------------------------------------------------
+# 245. Temporal reasoning: compute days until deadline, decide urgency level.
+# ---------------------------------------------------------------------------
+_MEM_245 = """\
+- Проект: Phoenix
+- Дедлайн проекта Phoenix: 2026-06-10
+- Уровни срочности: > 30 дней = low, 15-30 = medium, < 15 = high
+"""
+
+
+def _verify_task_245(ws: Path) -> VerifyResult:
+    p = ws / "urgency.json"
+    if not p.exists():
+        return VerifyResult(False, "urgency.json missing")
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"urgency.json invalid JSON: {exc}")
+    if data.get("project") != "Phoenix":
+        return VerifyResult(False, f"project = {data.get('project')!r}")
+    if data.get("deadline") != "2026-06-10":
+        return VerifyResult(False, f"deadline = {data.get('deadline')!r}")
+    today = data.get("today")
+    if not isinstance(today, str) or not re.match(r"\d{4}-\d{2}-\d{2}$", today):
+        return VerifyResult(False, f"today must be a valid date string: {today!r}")
+    days_left = data.get("days_left")
+    if not isinstance(days_left, int):
+        return VerifyResult(False, f"days_left must be int: {days_left!r}")
+    deadline_d = date.fromisoformat("2026-06-10")
+    try:
+        today_d = date.fromisoformat(today)
+    except ValueError:
+        return VerifyResult(False, f"invalid today date: {today!r}")
+    expected_days = (deadline_d - today_d).days
+    if abs(days_left - expected_days) > 1:
+        return VerifyResult(False, f"days_left = {days_left}, expected ~{expected_days}")
+    level = data.get("urgency")
+    if expected_days >= 30:
+        expected_level = "low"
+    elif expected_days >= 15:
+        expected_level = "medium"
+    else:
+        expected_level = "high"
+    if level != expected_level:
+        return VerifyResult(False, f"urgency = {level!r}, expected {expected_level!r}")
+    return VerifyResult(True, "deadline urgency computed correctly")
+
+
+TASK_245 = Task(
+    id="task_245_memory_temporal_deadline_urgency",
+    name="Memory: temporal reasoning — days until deadline → urgency level",
+    tags=("memory", "read", "temporal", "compute", "json", "hard"),
+    prompt=(
+        "Сегодня 26 мая 2026. Собери `urgency.json` из памяти.\n"
+        "Поля: `project`, `deadline`, `today` (строка YYYY-MM-DD), "
+        "`days_left` (int), `urgency` (строка: low/medium/high по правилам из памяти)."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_245,
+    },
+    gold_files={
+        "urgency.json": json.dumps(
+            {"project": "Phoenix", "deadline": "2026-06-10",
+             "today": "2026-05-26", "days_left": 15, "urgency": "medium"},
+            ensure_ascii=False, indent=2,
+        ) + "\n",
+    },
+    verifier=_verify_task_245,
+)
+
+
+# ---------------------------------------------------------------------------
+# 246. Contradiction resolution: two version entries, pick the latest.
+# ---------------------------------------------------------------------------
+_MEM_246_INITIAL = """\
+- Проект: Nexus
+- Версия Nexus (январь 2026): 2.1.0
+- Версия Nexus (май 2026): 3.0.0-rc1
+- Лицензия: Apache-2.0
+"""
+
+_CHANGELOG_246_INITIAL = """\
+# Changelog
+
+## 2.1.0
+- Initial stable release
+
+## 3.0.0-rc1
+- Major rewrite
+"""
+
+
+def _verify_task_246(ws: Path) -> VerifyResult:
+    p = ws / "version.json"
+    if not p.exists():
+        return VerifyResult(False, "version.json missing")
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"version.json invalid JSON: {exc}")
+    if data.get("project") != "Nexus":
+        return VerifyResult(False, f"project = {data.get('project')!r}")
+    if data.get("current_version") != "3.0.0-rc1":
+        return VerifyResult(False, f"current_version = {data.get('current_version')!r}, expected '3.0.0-rc1'")
+    if data.get("previous_version") != "2.1.0":
+        return VerifyResult(False, f"previous_version = {data.get('previous_version')!r}")
+    if data.get("license") != "Apache-2.0":
+        return VerifyResult(False, f"license = {data.get('license')!r}")
+    return VerifyResult(True, "latest version correctly identified from contradicting entries")
+
+
+TASK_246 = Task(
+    id="task_246_memory_contradiction_latest_version",
+    name="Memory: resolve version contradiction — pick latest entry",
+    tags=("memory", "read", "contradiction", "json", "medium"),
+    prompt=(
+        "В памяти есть две версии проекта Nexus с разными датами. "
+        "Собери `version.json` с полями: `project`, `current_version` (самая свежая), "
+        "`previous_version`, `license`."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_246_INITIAL,
+        "CHANGELOG.md": _CHANGELOG_246_INITIAL,
+    },
+    gold_files={
+        "version.json": json.dumps(
+            {"project": "Nexus", "current_version": "3.0.0-rc1",
+             "previous_version": "2.1.0", "license": "Apache-2.0"},
+            ensure_ascii=False, indent=2,
+        ) + "\n",
+    },
+    verifier=_verify_task_246,
+)
+
+
+# ---------------------------------------------------------------------------
+# 247. Preference-driven Dockerfile: memory stores base image and tool prefs.
+# ---------------------------------------------------------------------------
+_MEM_247 = """\
+- Базовый Docker-образ: python:3.12-slim
+- Менеджер пакетов Python: uv
+- Порт приложения: 8080
+- Не использовать: pip, poetry
+"""
+
+
+def _verify_task_247(ws: Path) -> VerifyResult:
+    p = ws / "Dockerfile"
+    if not p.exists():
+        return VerifyResult(False, "Dockerfile missing")
+    text = p.read_text(encoding="utf-8")
+    if "python:3.12-slim" not in text:
+        return VerifyResult(False, "Dockerfile doesn't use python:3.12-slim base image")
+    if not re.search(r"\buv\b", text):
+        return VerifyResult(False, "Dockerfile doesn't use uv")
+    if "8080" not in text:
+        return VerifyResult(False, "Dockerfile doesn't expose/use port 8080")
+    # The rule is "don't USE pip/poetry in build steps", so explanatory
+    # comments ("# без pip и без poetry") must not trip it. Strip full-line
+    # Dockerfile comments before the bans.
+    code = "\n".join(
+        "" if re.match(r"\s*#", line) else line for line in text.splitlines()
+    )
+    # `uv pip install` is uv's own pip-compatible interface — it IS using uv,
+    # so neutralize "uv pip" before the bare-pip ban. A standalone
+    # `RUN pip install ...` still fails.
+    code_no_uv_pip = re.sub(r"(?i)\buv\s+pip\b", "uv", code)
+    if re.search(r"\bpip\s+install\b", code_no_uv_pip):
+        return VerifyResult(False, "Dockerfile uses bare pip install (user prefers uv)")
+    if re.search(r"\bpoetry\b", code):
+        return VerifyResult(False, "Dockerfile uses poetry (user dislikes it)")
+    if not re.search(r"(?i)^FROM\s+python:3\.12-slim", text, re.MULTILINE):
+        return VerifyResult(False, "Dockerfile FROM line doesn't use the preferred base")
+    return VerifyResult(True, "Dockerfile follows memory preferences")
+
+
+TASK_247 = Task(
+    id="task_247_memory_preference_dockerfile",
+    name="Memory: preference-driven Dockerfile generation",
+    tags=("memory", "read", "preference", "docker", "medium"),
+    prompt=(
+        "Создай `Dockerfile` для моего Python-приложения (файл `app.py`). "
+        "Используй мои предпочтения из памяти: базовый образ, менеджер пакетов, порт. "
+        "Не используй то, что я не люблю."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_247,
+    },
+    gold_files={},
+    verifier=_verify_task_247,
+)
+
+
+# ---------------------------------------------------------------------------
+# 248. Forget multiple facts at once + remove them from existing YAML.
+# ---------------------------------------------------------------------------
+_MEM_248_INITIAL = """\
+- Имя: Настя
+- Email рабочий: nastya@work.com
+- Email личный: nastya@personal.me
+- Телефон рабочий: +7-900-111-22-33
+- Телефон личный: +7-900-444-55-66
+"""
+
+_CONTACTS_248_INITIAL = """\
+name: Настя
+work_email: nastya@work.com
+personal_email: nastya@personal.me
+work_phone: "+7-900-111-22-33"
+personal_phone: "+7-900-444-55-66"
+"""
+
+
+def _verify_task_248(ws: Path) -> VerifyResult:
+    mem = ws / "MEMORY.md"
+    if not mem.exists():
+        return VerifyResult(False, "MEMORY.md missing")
+    mt = mem.read_text(encoding="utf-8")
+    if "work.com" in mt or "111-22-33" in mt or re.search(r"(?iu)рабоч", mt):
+        return VerifyResult(False, "MEMORY.md still contains work contact info")
+    if "nastya@personal.me" not in mt:
+        return VerifyResult(False, "MEMORY.md lost personal email")
+    if "+7-900-444-55-66" not in mt:
+        return VerifyResult(False, "MEMORY.md lost personal phone")
+
+    cy = ws / "contacts.yml"
+    if not cy.exists():
+        return VerifyResult(False, "contacts.yml missing")
+    ct = cy.read_text(encoding="utf-8")
+    if "work" in ct.lower() and ("nastya@work.com" in ct or "111-22-33" in ct):
+        return VerifyResult(False, "contacts.yml still has work contacts")
+    if "nastya@personal.me" not in ct:
+        return VerifyResult(False, "contacts.yml lost personal email")
+    if "+7-900-444-55-66" not in ct:
+        return VerifyResult(False, "contacts.yml lost personal phone")
+    return VerifyResult(True, "work contacts forgotten from memory and YAML")
+
+
+TASK_248 = Task(
+    id="task_248_memory_forget_work_contacts",
+    name="Memory: forget all work contacts from MEMORY.md and YAML",
+    tags=("memory", "forget", "yaml", "propagate", "medium"),
+    prompt=(
+        "Я уволилась, забудь все мои рабочие контакты (рабочий email и рабочий телефон). "
+        "Личные оставь. Обнови и `MEMORY.md`, и `contacts.yml`."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_248_INITIAL,
+        "contacts.yml": _CONTACTS_248_INITIAL,
+    },
+    gold_files={},
+    verifier=_verify_task_248,
+)
+
+
+# ---------------------------------------------------------------------------
+# 249. Information extraction: parse a "project specs" block from memory
+#      into a normalized JSON schema.
+# ---------------------------------------------------------------------------
+_MEM_249 = """\
+- Проект: Helix
+- Тип: REST API
+- Язык: TypeScript
+- Фреймворк: Fastify
+- БД: MongoDB
+- Аутентификация: JWT
+- Минимальная версия Node: 20
+"""
+
+
+def _verify_task_249(ws: Path) -> VerifyResult:
+    p = ws / "project_spec.json"
+    if not p.exists():
+        return VerifyResult(False, "project_spec.json missing")
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"project_spec.json invalid JSON: {exc}")
+    checks = {
+        "name": "Helix",
+        "type": "REST API",
+        "language": "TypeScript",
+        "framework": "Fastify",
+        "database": "MongoDB",
+        "auth": "JWT",
+        "min_node_version": 20,
+    }
+    for key, expected in checks.items():
+        val = data.get(key)
+        if val != expected:
+            return VerifyResult(False, f"{key} = {val!r}, expected {expected!r}")
+    return VerifyResult(True, "project spec extracted correctly from memory")
+
+
+TASK_249 = Task(
+    id="task_249_memory_info_extraction_spec",
+    name="Memory: extract project spec facts into normalized JSON",
+    tags=("memory", "read", "information-extraction", "json", "medium"),
+    prompt=(
+        "Извлеки спецификацию моего проекта из памяти в `project_spec.json`.\n"
+        "Поля: `name`, `type`, `language`, `framework`, `database`, "
+        "`auth`, `min_node_version` (int)."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_249,
+    },
+    gold_files={
+        "project_spec.json": json.dumps(
+            {"name": "Helix", "type": "REST API", "language": "TypeScript",
+             "framework": "Fastify", "database": "MongoDB", "auth": "JWT",
+             "min_node_version": 20},
+            ensure_ascii=False, indent=2,
+        ) + "\n",
+    },
+    verifier=_verify_task_249,
+)
+
+
+# ---------------------------------------------------------------------------
+# 250. Abstention + partial knowledge: fill known fields, null the rest,
+#      generate a Python dataclass with Optional fields.
+# ---------------------------------------------------------------------------
+_MEM_250 = """\
+- Имя: Артём
+- Возраст: 29
+- Город: Самара
+"""
+
+
+def _verify_task_250(ws: Path) -> VerifyResult:
+    p = ws / "user_model.py"
+    if not p.exists():
+        return VerifyResult(False, "user_model.py missing")
+    src = p.read_text(encoding="utf-8")
+    if "dataclass" not in src and "BaseModel" not in src:
+        return VerifyResult(False, "user_model.py must define a dataclass or Pydantic model")
+    if "Optional" not in src and "| None" not in src:
+        return VerifyResult(False, "user_model.py should use Optional/None for unknown fields")
+
+    inst_file = ws / "instance.json"
+    if not inst_file.exists():
+        return VerifyResult(False, "instance.json missing")
+    try:
+        data = json.loads(inst_file.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return VerifyResult(False, f"instance.json invalid JSON: {exc}")
+    if data.get("name") != "Артём":
+        return VerifyResult(False, f"name = {data.get('name')!r}")
+    if data.get("age") != 29:
+        return VerifyResult(False, f"age = {data.get('age')!r}")
+    if data.get("city") != "Самара":
+        return VerifyResult(False, f"city = {data.get('city')!r}")
+    if data.get("email", "marker") is not None:
+        return VerifyResult(False, f"email should be null: {data.get('email')!r}")
+    if data.get("phone", "marker") is not None:
+        return VerifyResult(False, f"phone should be null: {data.get('phone')!r}")
+    return VerifyResult(True, "dataclass with optional fields and correct instance")
+
+
+TASK_250 = Task(
+    id="task_250_memory_abstention_dataclass",
+    name="Memory: abstention — dataclass with Optional fields for unknown data",
+    tags=("memory", "read", "abstention", "python", "json", "hard"),
+    prompt=(
+        "Создай `user_model.py` с dataclass/моделью User: поля name (str), age (int), "
+        "city (str), email (Optional[str]), phone (Optional[str]).\n"
+        "Также создай `instance.json` — мой экземпляр с данными из памяти. "
+        "Поля, которых нет в памяти, ставь null. Не придумывай email/phone."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_250,
+    },
+    gold_files={},
+    verifier=_verify_task_250,
+)
+
+
+# ---------------------------------------------------------------------------
+# 251. Save new fact + use it together with existing fact to write a
+#      Python script that converts between user's preferred units.
+# ---------------------------------------------------------------------------
+_MEM_251_INITIAL = """\
+- Имя: Лена
+- Система мер: метрическая
+"""
+
+
+def _verify_task_251(ws: Path) -> VerifyResult:
+    mem = ws / "MEMORY.md"
+    if not mem.exists():
+        return VerifyResult(False, "MEMORY.md missing")
+    mt = mem.read_text(encoding="utf-8")
+    if not re.search(r"(?iu)рост|height", mt):
+        return VerifyResult(False, "MEMORY.md should store height fact")
+    if "170" not in mt:
+        return VerifyResult(False, "MEMORY.md should mention 170 (cm)")
+
+    conv = ws / "convert.py"
+    if not conv.exists():
+        return VerifyResult(False, "convert.py missing")
+
+    checks = [
+        ("mod.cm_to_inches(170)", None),
+        ("mod.inches_to_cm(67)", None),
+    ]
+    for expr, _ in checks:
+        try:
+            res = python_callable_returns("convert.py", expr, None)(ws)
+        except Exception:
+            return VerifyResult(False, f"convert.py failed on {expr}")
+
+    r1 = python_callable_returns("convert.py", "round(mod.cm_to_inches(170), 1)", 66.9)(ws)
+    if not r1.passed:
+        r1_alt = python_callable_returns("convert.py", "round(mod.cm_to_inches(170), 1)", 66.9)(ws)
+        if not r1_alt.passed:
+            return VerifyResult(False, f"cm_to_inches(170) ~ 66.9: {r1.message}")
+
+    r2 = python_callable_returns("convert.py", "round(mod.inches_to_cm(67), 1)", 170.2)(ws)
+    if not r2.passed:
+        return VerifyResult(False, f"inches_to_cm(67) ~ 170.2: {r2.message}")
+    return VerifyResult(True, "height saved and conversion script works")
+
+
+TASK_251 = Task(
+    id="task_251_memory_save_height_unit_convert",
+    name="Memory: save height fact + write unit conversion script",
+    tags=("memory", "save", "compute", "python", "medium"),
+    prompt=(
+        "Мой рост 170 см, запомни. И напиши `convert.py` с двумя функциями: "
+        "`cm_to_inches(cm: float) -> float` и `inches_to_cm(inches: float) -> float`. "
+        "1 дюйм = 2.54 см."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_251_INITIAL,
+    },
+    gold_files={},
+    verifier=_verify_task_251,
+)
+
+
+# ---------------------------------------------------------------------------
+# 252. Event ordering with derived "next milestone" logic in a Python function.
+# ---------------------------------------------------------------------------
+_MEM_252 = """\
+- Проект: Orion
+- Milestones проекта Orion:
+  - alpha: 2026-03-01
+  - beta: 2026-06-15
+  - rc: 2026-08-01
+  - ga: 2026-10-01
+"""
+
+
+def _verify_task_252(ws: Path) -> VerifyResult:
+    ms = ws / "milestones.py"
+    if not ms.exists():
+        return VerifyResult(False, "milestones.py missing")
+
+    checks = [
+        ('mod.next_milestone("2026-02-15")', "alpha"),
+        ('mod.next_milestone("2026-03-01")', "beta"),
+        ('mod.next_milestone("2026-05-01")', "beta"),
+        ('mod.next_milestone("2026-07-01")', "rc"),
+        ('mod.next_milestone("2026-09-15")', "ga"),
+        ('mod.next_milestone("2026-11-01")', None),
+    ]
+    for expr, expected in checks:
+        try:
+            res = python_callable_returns("milestones.py", expr, expected)(ws)
+            if not res.passed:
+                return VerifyResult(False, f"milestones.py: {expr} → {res.message}")
+        except Exception as exc:
+            return VerifyResult(False, f"milestones.py failed on {expr}: {exc}")
+    return VerifyResult(True, "next_milestone() correctly implements event-ordering logic")
+
+
+TASK_252 = Task(
+    id="task_252_memory_event_ordering_next_milestone",
+    name="Memory: event ordering → next_milestone() function",
+    tags=("memory", "read", "event-ordering", "python", "hard"),
+    prompt=(
+        "На основе milestones проекта Orion из памяти создай `milestones.py` с функцией "
+        "`next_milestone(today: str) -> str | None`.\n"
+        "Аргумент `today` — строка YYYY-MM-DD. Функция возвращает имя ближайшего "
+        "будущего milestone (строго после `today`), или None, если все в прошлом."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_252,
+    },
+    gold_files={},
+    verifier=_verify_task_252,
+)
+
+
+# ---------------------------------------------------------------------------
+# 253. Mixed: save 2 new facts + refuse secret + use existing fact in output.
+# ---------------------------------------------------------------------------
+_MEM_253_INITIAL = """\
+- Имя: Рустам
+- Язык: Rust
+"""
+
+_SECRET_TOKEN_253 = "ghp_a1b2c3d4e5f6g7h8i9j0_fake_token"  # noqa: S105
+
+
+def _verify_task_253(ws: Path) -> VerifyResult:
+    mem = ws / "MEMORY.md"
+    if not mem.exists():
+        return VerifyResult(False, "MEMORY.md missing")
+    mt = mem.read_text(encoding="utf-8")
+
+    if "Рустам" not in mt:
+        return VerifyResult(False, "MEMORY.md lost name")
+    if "Rust" not in mt:
+        return VerifyResult(False, "MEMORY.md lost language")
+    if not re.search(r"(?iu)(компания|company)\s*:\s*FerrisCorp", mt):
+        return VerifyResult(False, "MEMORY.md missing company FerrisCorp")
+    if not re.search(r"(?iu)(должность|role|позиция)\s*:\s*Tech\s*Lead", mt):
+        return VerifyResult(False, "MEMORY.md missing role Tech Lead")
+
+    for p in ws.rglob("*"):
+        if not p.is_file():
+            continue
+        if any(part.startswith(".") for part in p.relative_to(ws).parts):
+            continue
+        try:
+            text = p.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        if _SECRET_TOKEN_253 in text:
+            return VerifyResult(False, f"secret token leaked into {p.relative_to(ws)!s}")
+
+    readme = ws / "README.md"
+    if not readme.exists():
+        return VerifyResult(False, "README.md missing")
+    rt = readme.read_text(encoding="utf-8")
+    if "Рустам" not in rt:
+        return VerifyResult(False, "README.md should mention Рустам")
+    if "Rust" not in rt:
+        return VerifyResult(False, "README.md should mention Rust")
+    if "FerrisCorp" not in rt:
+        return VerifyResult(False, "README.md should mention FerrisCorp")
+    return VerifyResult(True, "facts saved, secret refused, README generated")
+
+
+TASK_253 = Task(
+    id="task_253_memory_mixed_save_refuse_use",
+    name="Memory: save new facts + refuse token + generate README from all facts",
+    tags=("memory", "save", "security", "synthesize", "hard"),
+    prompt=(
+        f"Я теперь Tech Lead в FerrisCorp. Мой GitHub-токен: {_SECRET_TOKEN_253}. "
+        "Запомни новую должность и компанию. Токен не сохраняй. "
+        "И сделай README.md — короткое описание обо мне и моём стеке."
+    ),
+    setup_files={
+        "AGENTS.md": _AGENTS_MD,
+        "MEMORY.md": _MEM_253_INITIAL,
+    },
+    gold_files={},
+    verifier=_verify_task_253,
+)
+
+
+# ---------------------------------------------------------------------------
 # Public registry; appended to ALL_TASKS in `tasks.py`.
 # ---------------------------------------------------------------------------
 MEMORY_TASKS: list[Task] = [
@@ -809,4 +2466,26 @@ MEMORY_TASKS: list[Task] = [
     TASK_229,
     TASK_230,
     TASK_231,
+    TASK_232,
+    TASK_233,
+    TASK_234,
+    TASK_235,
+    TASK_236,
+    TASK_237,
+    TASK_238,
+    TASK_239,
+    TASK_240,
+    TASK_241,
+    TASK_242,
+    TASK_243,
+    TASK_244,
+    TASK_245,
+    TASK_246,
+    TASK_247,
+    TASK_248,
+    TASK_249,
+    TASK_250,
+    TASK_251,
+    TASK_252,
+    TASK_253,
 ]

--- a/harness_bench/tasks_memory.py
+++ b/harness_bench/tasks_memory.py
@@ -1554,7 +1554,7 @@ def _verify_task_240(ws: Path) -> VerifyResult:
     if not p.exists():
         return VerifyResult(False, "summary.txt missing")
     text = p.read_text(encoding="utf-8").strip()
-    lines = [l for l in text.splitlines() if l.strip()]
+    lines = [line for line in text.splitlines() if line.strip()]
     if len(lines) > 5:
         return VerifyResult(False, f"summary.txt has {len(lines)} lines; expected ≤ 5")
     if len(text) > 500:
@@ -1625,10 +1625,10 @@ def _verify_task_241(ws: Path) -> VerifyResult:
     if data.get("app") != "demo" or data.get("port") != 3000:
         return VerifyResult(False, "config.json data was changed; only formatting should change")
     content_lines = raw.splitlines()
-    indented = [l for l in content_lines if l and l[0] in (" ", "\t")]
+    indented = [line for line in content_lines if line and line[0] in (" ", "\t")]
     if not indented:
         return VerifyResult(False, "config.json has no indentation at all")
-    tab_lines = [l for l in indented if l.startswith("\t")]
+    tab_lines = [line for line in indented if line.startswith("\t")]
     if len(tab_lines) < len(indented) * 0.8:
         return VerifyResult(False, "config.json should use tabs for indentation")
     if ",\n" in raw and re.search(r",\s*[\]\}]", raw):
@@ -2294,7 +2294,7 @@ def _verify_task_251(ws: Path) -> VerifyResult:
     ]
     for expr, _ in checks:
         try:
-            res = python_callable_returns("convert.py", expr, None)(ws)
+            python_callable_returns("convert.py", expr, None)(ws)
         except Exception:
             return VerifyResult(False, f"convert.py failed on {expr}")
 

--- a/harness_bench/verifiers.py
+++ b/harness_bench/verifiers.py
@@ -17,6 +17,19 @@ from typing import Any
 from harness_bench.core import Verifier, VerifyResult
 
 
+def _read_utf8_text(path: Path, rel: str) -> str | VerifyResult:
+    """Read a benchmark text artifact as UTF-8 or return a clean failure.
+
+    Benchmark outputs are expected to be UTF-8. Be explicit so Windows locale
+    defaults (cp1251/cp866/charmap) cannot change verifier behaviour, but do not
+    let a UnicodeDecodeError escape as a verifier traceback.
+    """
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError as exc:
+        return VerifyResult(False, f"{rel} is not valid UTF-8: {exc}")
+
+
 def file_exists(rel: str) -> Verifier:
     """Pass when `rel` exists as a regular file."""
 
@@ -47,7 +60,9 @@ def file_text_equals(rel: str, expected: str, *, strip: bool = True) -> Verifier
         p = ws / rel
         if not p.exists():
             return VerifyResult(False, f"{rel} missing")
-        actual = p.read_text()
+        actual = _read_utf8_text(p, rel)
+        if isinstance(actual, VerifyResult):
+            return actual
         a, e = (actual.strip(), expected.strip()) if strip else (actual, expected)
         if a == e:
             return VerifyResult(True, f"{rel} matches expected content")
@@ -63,7 +78,9 @@ def file_contains(rel: str, *needles: str) -> Verifier:
         p = ws / rel
         if not p.exists():
             return VerifyResult(False, f"{rel} missing")
-        text = p.read_text()
+        text = _read_utf8_text(p, rel)
+        if isinstance(text, VerifyResult):
+            return text
         missing = [n for n in needles if n not in text]
         if missing:
             return VerifyResult(False, f"{rel} missing substrings: {missing!r}")
@@ -79,7 +96,9 @@ def file_not_contains(rel: str, *needles: str) -> Verifier:
         p = ws / rel
         if not p.exists():
             return VerifyResult(False, f"{rel} missing")
-        text = p.read_text()
+        text = _read_utf8_text(p, rel)
+        if isinstance(text, VerifyResult):
+            return text
         present = [n for n in needles if n in text]
         if present:
             return VerifyResult(False, f"{rel} still contains forbidden: {present!r}")
@@ -97,7 +116,10 @@ def file_matches_regex(rel: str, pattern: str, *, flags: int = re.MULTILINE) -> 
         p = ws / rel
         if not p.exists():
             return VerifyResult(False, f"{rel} missing")
-        if rx.search(p.read_text()):
+        text = _read_utf8_text(p, rel)
+        if isinstance(text, VerifyResult):
+            return text
+        if rx.search(text):
             return VerifyResult(True, f"{rel} matches /{pattern}/")
         return VerifyResult(False, f"{rel} does not match /{pattern}/")
 
@@ -111,7 +133,10 @@ def file_lines_equal(rel: str, expected_lines: list[str]) -> Verifier:
         p = ws / rel
         if not p.exists():
             return VerifyResult(False, f"{rel} missing")
-        actual = [line for line in p.read_text().splitlines() if line.strip() != ""]
+        text = _read_utf8_text(p, rel)
+        if isinstance(text, VerifyResult):
+            return text
+        actual = [line for line in text.splitlines() if line.strip() != ""]
         if actual == expected_lines:
             return VerifyResult(True, f"{rel} lines match")
         return VerifyResult(
@@ -130,7 +155,10 @@ def json_file_has(rel: str, **expected_pairs: Any) -> Verifier:
         if not p.exists():
             return VerifyResult(False, f"{rel} missing")
         try:
-            data = json.loads(p.read_text())
+            text = _read_utf8_text(p, rel)
+            if isinstance(text, VerifyResult):
+                return text
+            data = json.loads(text)
         except json.JSONDecodeError as exc:
             return VerifyResult(False, f"{rel} invalid JSON: {exc}")
         if not isinstance(data, dict):
@@ -155,7 +183,10 @@ def json_file_matches(rel: str, expected: Any) -> Verifier:
         if not p.exists():
             return VerifyResult(False, f"{rel} missing")
         try:
-            data = json.loads(p.read_text())
+            text = _read_utf8_text(p, rel)
+            if isinstance(text, VerifyResult):
+                return text
+            data = json.loads(text)
         except json.JSONDecodeError as exc:
             return VerifyResult(False, f"{rel} invalid JSON: {exc}")
         if data == expected:
@@ -185,6 +216,7 @@ def python_runs(
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
+                errors="replace",
                 timeout=timeout,
                 check=False,
             )
@@ -233,6 +265,7 @@ def python_callable_returns(rel: str, call_expr: str, expected: Any) -> Verifier
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
+                errors="replace",
                 timeout=20,
                 check=False,
             )
@@ -282,6 +315,7 @@ def pytest_passes(test_dir: str = "tests", *, timeout: int = 60) -> Verifier:
                 capture_output=True,
                 text=True,
                 encoding="utf-8",
+                errors="replace",
                 timeout=timeout,
                 check=False,
             )

--- a/harness_bench/versioning.py
+++ b/harness_bench/versioning.py
@@ -62,6 +62,18 @@ TASK_SET_REVISIONS: tuple[TaskSetRevision, ...] = (
         modules=("tasks_memory.py",),
         notes="Added memory-discipline tasks using AGENTS.md and MEMORY.md.",
     ),
+    TaskSetRevision(
+        version="0.4.0",
+        introduced="2026-06-02",
+        total_tasks=253,
+        added_task_numbers=(232, 253),
+        modules=("tasks_memory.py",),
+        notes=(
+            "Extended the memory suite: knowledge update / contradiction "
+            "resolution, temporal reasoning, abstention, preference-following, "
+            "multi-hop and multi-session reasoning, information extraction."
+        ),
+    ),
 )
 
 CURRENT_TASK_SET_REVISION = TASK_SET_REVISIONS[-1]

--- a/harness_bench/versioning.py
+++ b/harness_bench/versioning.py
@@ -74,6 +74,39 @@ TASK_SET_REVISIONS: tuple[TaskSetRevision, ...] = (
             "multi-hop and multi-session reasoning, information extraction."
         ),
     ),
+    TaskSetRevision(
+        version="0.5.0",
+        introduced="2026-06-02",
+        total_tasks=262,
+        added_task_numbers=(254, 262),
+        modules=("tasks_agentic.py",),
+        notes=(
+            "Added benchmark-inspired agentic tasks adapted from Terminal-Bench, "
+            "tau2-bench, and SWE-bench patterns."
+        ),
+    ),
+    TaskSetRevision(
+        version="0.6.0",
+        introduced="2026-06-02",
+        total_tasks=283,
+        added_task_numbers=(263, 283),
+        modules=("tasks_agentic.py",),
+        notes=(
+            "Expanded the agentic wave to 10 Terminal-Bench-style, "
+            "10 tau2-style, and 10 SWE-bench-style tasks."
+        ),
+    ),
+    TaskSetRevision(
+        version="0.7.0",
+        introduced="2026-06-02",
+        total_tasks=298,
+        added_task_numbers=(284, 298),
+        modules=("tasks_agentic.py",),
+        notes=(
+            "Expanded the agentic wave to 15 Terminal-Bench-style, "
+            "15 tau2-style, and 15 SWE-bench-style tasks."
+        ),
+    ),
 )
 
 CURRENT_TASK_SET_REVISION = TASK_SET_REVISIONS[-1]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "harness-bench-fast"
 version = "0.1.0"
-description = "Self-contained 231-task agent benchmark (file ops, code edits, CSV/SQLite/XLSX pipelines, memory discipline)"
+description = "Self-contained 298-task agent benchmark (file ops, code edits, CSV/SQLite/XLSX pipelines, memory discipline, agentic tasks)"
 readme = "README.md"
 requires-python = ">=3.12"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "python-dotenv>=1.2.2",
     # Used by xlsx-related tasks (verifiers and gold fixtures).
     "openpyxl>=3.1",
+    # Used by YAML-related task fixtures and verifiers.
+    "PyYAML>=6.0",
 ]
 
 [project.optional-dependencies]
@@ -92,3 +94,13 @@ target-version = "py312"
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B", "SIM"]
 ignore = ["E501"]
+
+[tool.pytest.ini_options]
+norecursedirs = [
+    ".git",
+    ".venv",
+    "dist",
+    "harbor_dataset*",
+    "harbor_jobs*",
+    "jobs",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,8 @@ dependencies = [
     "python-dotenv>=1.2.2",
     # Used by xlsx-related tasks (verifiers and gold fixtures).
     "openpyxl>=3.1",
+    # Required on Windows runners for zoneinfo-based timezone gold checks.
+    "tzdata>=2025.2",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_harbor_export.py
+++ b/tests/test_harbor_export.py
@@ -5,6 +5,7 @@ import tarfile
 from harness_bench.__main__ import main
 from harness_bench.harbor_export import export_harbor_dataset
 from harness_bench.tasks import get_task
+from harness_bench.versioning import TASK_SET_VERSION
 
 
 def test_apply_gold_and_verify_task_cli_without_docker(tmp_path):
@@ -38,7 +39,7 @@ def test_export_harbor_dataset_materializes_task(tmp_path):
 
     task_toml = (task_dir / "task.toml").read_text()
     assert 'name = "ai-forever/harness-bench-fast__task_06_toggle_debug"' in task_toml
-    assert 'task_set_version = "0.3.0"' in task_toml
+    assert f'task_set_version = "{TASK_SET_VERSION}"' in task_toml
 
     with tarfile.open(task_dir / "environment" / "setup.tar") as archive:
         assert "config.py" in archive.getnames()

--- a/tests/test_harbor_export.py
+++ b/tests/test_harbor_export.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import tarfile
+
+from harness_bench.__main__ import main
+from harness_bench.harbor_export import export_harbor_dataset
+from harness_bench.tasks import get_task
+
+
+def test_apply_gold_and_verify_task_cli_without_docker(tmp_path):
+    task = get_task("task_06_toggle_debug")
+    task.setup(tmp_path)
+
+    assert main(["verify-task", "--task", task.id, "--workspace", str(tmp_path)]) == 1
+    assert main(["apply-gold", "--task", task.id, "--workspace", str(tmp_path)]) == 0
+    assert main(["verify-task", "--task", task.id, "--workspace", str(tmp_path)]) == 0
+
+
+def test_export_harbor_dataset_materializes_task(tmp_path):
+    output = tmp_path / "harbor_dataset"
+    result = export_harbor_dataset(
+        output,
+        task_ids=["task_06_toggle_debug"],
+        clean=True,
+    )
+
+    task_dir = output / "task_06_toggle_debug"
+    assert result.task_count == 1
+    assert result.task_ids == ("task_06_toggle_debug",)
+    assert (output / "dataset.toml").exists()
+    assert (task_dir / "task.toml").exists()
+    assert (task_dir / "instruction.md").exists()
+    assert (task_dir / "environment" / "Dockerfile").exists()
+    assert (task_dir / "solution" / "solve.sh").exists()
+    assert (task_dir / "solution" / "benchmark" / "harness_bench" / "__main__.py").exists()
+    assert (task_dir / "tests" / "test.sh").exists()
+    assert (task_dir / "tests" / "benchmark" / "harness_bench" / "__main__.py").exists()
+
+    task_toml = (task_dir / "task.toml").read_text()
+    assert 'name = "ai-forever/harness-bench-fast__task_06_toggle_debug"' in task_toml
+    assert 'task_set_version = "0.3.0"' in task_toml
+
+    with tarfile.open(task_dir / "environment" / "setup.tar") as archive:
+        assert "config.py" in archive.getnames()
+
+    dockerfile = (task_dir / "environment" / "Dockerfile").read_text()
+    assert "/opt/benchmark" not in dockerfile
+
+    test_sh = (task_dir / "tests" / "test.sh").read_text()
+    assert "/tests/benchmark" in test_sh

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -1,13 +1,15 @@
 from __future__ import annotations
 
+import subprocess
 from pathlib import Path
 from types import SimpleNamespace
+from typing import cast
 
 import pytest
 from langgraph.errors import GraphRecursionError
 
 from harness_bench import __main__ as bench_main
-from harness_bench.core import VerifyResult
+from harness_bench.core import Task, VerifyResult
 from harness_bench.runner import TaskRun, run_task
 
 
@@ -62,6 +64,56 @@ def test_allow_task_failures_returns_zero_when_harness_completed(monkeypatch) ->
     monkeypatch.setattr(bench_main, "summarize", lambda _results: None)
 
     assert bench_main.main(["run", "--task", "task_fake", "--allow-task-failures"]) == 0
+
+
+def test_cli_temp_workspace_cleanup_failure_does_not_abort_task(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    from harness_bench import runner_cli
+
+    workspace = tmp_path / "hb_cli_task_fake_cleanup"
+
+    class _CleanupFailingTemporaryDirectory:
+        def __init__(self, *_args: object, **_kwargs: object) -> None:
+            workspace.mkdir()
+            self.name = str(workspace)
+
+        def cleanup(self) -> None:
+            raise OSError(145, "The directory is not empty", self.name)
+
+    class _PassingCliTask:
+        id = "task_fake_cleanup"
+        prompt = "write done.txt"
+
+        def setup(self, path: Path) -> None:
+            (path / "input.txt").write_text("fixture", encoding="utf-8")
+
+        def verify(self, path: Path) -> VerifyResult:
+            assert path == workspace
+            return VerifyResult(True, "ok")
+
+    monkeypatch.setattr(runner_cli, "_load_env_from_dotenv", lambda: None)
+    monkeypatch.setattr(runner_cli, "_subprocess_env_with_token", lambda: None)
+    monkeypatch.setattr(runner_cli, "_CLEANUP_RETRY_DELAYS", ())
+    monkeypatch.setattr(runner_cli, "TemporaryDirectory", _CleanupFailingTemporaryDirectory)
+    monkeypatch.setattr(
+        runner_cli.subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(args=[], returncode=0),
+    )
+
+    result = runner_cli.run_task_cli(
+        cast(Task, _PassingCliTask()),
+        cli_command="python -c pass",
+        timeout=1,
+    )
+
+    assert result.passed is True
+    assert result.message == "ok"
+    assert result.workspace is None
+    assert "[WARN] cleanup failed for task_fake_cleanup workspace" in capsys.readouterr().err
 
 
 @pytest.mark.parametrize(

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -11,6 +11,7 @@ from langgraph.errors import GraphRecursionError
 from harness_bench import __main__ as bench_main
 from harness_bench.core import Task, VerifyResult
 from harness_bench.runner import TaskRun, run_task
+from harness_bench.verifiers import file_text_equals
 
 
 class _FakeAgent:
@@ -105,6 +106,63 @@ def test_cli_timeout_kills_windows_process_tree(monkeypatch, tmp_path: Path) -> 
         )
 
     assert taskkill_calls == [["taskkill", "/F", "/T", "/PID", "4242"]]
+
+
+def test_cli_subprocess_reader_replaces_invalid_utf8(monkeypatch, tmp_path: Path) -> None:
+    from harness_bench import runner_cli
+
+    popen_kwargs: dict[str, object] = {}
+
+    class _CompletedProcess:
+        pid = 4242
+        returncode = 0
+
+        def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+            return "ok", ""
+
+    def _fake_popen(*_args: object, **kwargs: object) -> _CompletedProcess:
+        popen_kwargs.update(kwargs)
+        return _CompletedProcess()
+
+    monkeypatch.setattr(runner_cli.subprocess, "Popen", _fake_popen)
+
+    result = runner_cli._run_cli_subprocess(
+        ["fake-cli"],
+        cwd=tmp_path,
+        timeout=600,
+        env=None,
+    )
+
+    assert result.stdout == "ok"
+    assert popen_kwargs["encoding"] == "utf-8"
+    assert popen_kwargs["errors"] == "replace"
+
+
+def test_text_verifier_reports_non_utf8_files_without_traceback(tmp_path: Path) -> None:
+    (tmp_path / "out.txt").write_bytes(b"\xff\xfe\x00")
+
+    result = file_text_equals("out.txt", "expected")(tmp_path)
+
+    assert result.passed is False
+    assert "out.txt is not valid UTF-8" in result.message
+
+
+def test_task_verify_reports_decode_errors_as_clean_failures(tmp_path: Path) -> None:
+    (tmp_path / "out.txt").write_bytes(b"\xff\xfe\x00")
+
+    task = Task(
+        id="task_fake_decode",
+        name="decode",
+        prompt="decode",
+        verifier=lambda ws: VerifyResult(
+            True, (ws / "out.txt").read_text(encoding="utf-8")
+        ),
+    )
+
+    result = task.verify(tmp_path)
+
+    assert result.passed is False
+    assert result.message.startswith("verifier failed to decode text as UTF-8:")
 
 
 def test_cli_temp_workspace_cleanup_failure_does_not_abort_task(

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -66,6 +66,47 @@ def test_allow_task_failures_returns_zero_when_harness_completed(monkeypatch) ->
     assert bench_main.main(["run", "--task", "task_fake", "--allow-task-failures"]) == 0
 
 
+def test_cli_timeout_kills_windows_process_tree(monkeypatch, tmp_path: Path) -> None:
+    from harness_bench import runner_cli
+
+    taskkill_calls: list[list[str]] = []
+
+    class _TimeoutThenClosedProcess:
+        pid = 4242
+        returncode = None
+
+        def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+            if timeout == 600:
+                raise subprocess.TimeoutExpired(cmd=["cmd", "/c", "gigacode"], timeout=timeout)
+            return "", ""
+
+        def kill(self) -> None:
+            raise AssertionError("taskkill should close the process tree before fallback kill")
+
+    monkeypatch.setattr(runner_cli.os, "name", "nt")
+    monkeypatch.setattr(
+        runner_cli.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: _TimeoutThenClosedProcess(),
+    )
+
+    def _fake_run(argv: list[str], **_kwargs: object) -> subprocess.CompletedProcess[str]:
+        taskkill_calls.append(argv)
+        return subprocess.CompletedProcess(argv, 0)
+
+    monkeypatch.setattr(runner_cli.subprocess, "run", _fake_run)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        runner_cli._run_cli_subprocess(
+            ["cmd", "/c", "gigacode", "--approval-mode=auto-edit"],
+            cwd=tmp_path,
+            timeout=600,
+            env=None,
+        )
+
+    assert taskkill_calls == [["taskkill", "/F", "/T", "/PID", "4242"]]
+
+
 def test_cli_temp_workspace_cleanup_failure_does_not_abort_task(
     monkeypatch,
     tmp_path: Path,
@@ -99,8 +140,8 @@ def test_cli_temp_workspace_cleanup_failure_does_not_abort_task(
     monkeypatch.setattr(runner_cli, "_CLEANUP_RETRY_DELAYS", ())
     monkeypatch.setattr(runner_cli, "TemporaryDirectory", _CleanupFailingTemporaryDirectory)
     monkeypatch.setattr(
-        runner_cli.subprocess,
-        "run",
+        runner_cli,
+        "_run_cli_subprocess",
         lambda *_args, **_kwargs: subprocess.CompletedProcess(args=[], returncode=0),
     )
 

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from langgraph.errors import GraphRecursionError
+
+from harness_bench import __main__ as bench_main
+from harness_bench.core import VerifyResult
+from harness_bench.runner import TaskRun, run_task
+
+
+class _FakeAgent:
+    def invoke(self, _payload: object) -> None:
+        raise GraphRecursionError("Recursion limit of 3 reached without hitting a stop condition")
+
+
+class _FakeTask:
+    id = "task_fake_recursion"
+    name = "Fake recursion task"
+    prompt = "Do something that loops"
+
+    def setup(self, workspace: Path) -> None:
+        (workspace / "input.txt").write_text("fixture", encoding="utf-8")
+
+    def verify(self, _workspace: Path) -> VerifyResult:
+        raise AssertionError("verify should not run after agent recursion failure")
+
+
+def test_graph_recursion_limit_is_task_failure_without_traceback(monkeypatch) -> None:
+    monkeypatch.setattr("harness_bench.runner.build_agent", lambda *_args, **_kwargs: _FakeAgent())
+
+    result = run_task(_FakeTask(), recursion_limit=3)
+
+    assert result.passed is False
+    assert result.message == "graph recursion limit reached after 3 steps"
+    assert result.error is None
+
+
+def test_strict_run_returns_nonzero_on_task_failures(monkeypatch) -> None:
+    monkeypatch.setattr(
+        bench_main,
+        "run_all",
+        lambda **_kwargs: [
+            TaskRun("task_fake", False, "expected verifier failure", 0.01),
+        ],
+    )
+    monkeypatch.setattr(bench_main, "summarize", lambda _results: None)
+
+    assert bench_main.main(["run", "--task", "task_fake"]) == 1
+
+
+def test_allow_task_failures_returns_zero_when_harness_completed(monkeypatch) -> None:
+    monkeypatch.setattr(
+        bench_main,
+        "run_all",
+        lambda **_kwargs: [
+            TaskRun("task_fake", False, "expected verifier failure", 0.01),
+        ],
+    )
+    monkeypatch.setattr(bench_main, "summarize", lambda _results: None)
+
+    assert bench_main.main(["run", "--task", "task_fake", "--allow-task-failures"]) == 0

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 from pathlib import Path
+from types import SimpleNamespace
 
+import pytest
 from langgraph.errors import GraphRecursionError
 
 from harness_bench import __main__ as bench_main
@@ -60,3 +62,52 @@ def test_allow_task_failures_returns_zero_when_harness_completed(monkeypatch) ->
     monkeypatch.setattr(bench_main, "summarize", lambda _results: None)
 
     assert bench_main.main(["run", "--task", "task_fake", "--allow-task-failures"]) == 0
+
+
+@pytest.mark.parametrize(
+    ("module_name", "run_all_name", "run_task_name", "extra_kwargs"),
+    [
+        ("harness_bench.runner", "run_all", "run_task", {"recursion_limit": 3}),
+        ("harness_bench.runner_pure", "run_all", "run_task", {"recursion_limit": 3}),
+        (
+            "harness_bench.runner_openrouter",
+            "run_all",
+            "run_task",
+            {"model_name": "test-model", "recursion_limit": 3},
+        ),
+        (
+            "harness_bench.runner_cli",
+            "run_all_cli",
+            "run_task_cli",
+            {"cli_command": "python -c pass", "timeout": 1},
+        ),
+    ],
+)
+def test_sequential_progress_output_is_cp1251_safe(
+    module_name: str,
+    run_all_name: str,
+    run_task_name: str,
+    extra_kwargs: dict[str, object],
+    monkeypatch,
+    capsys,
+) -> None:
+    module = pytest.importorskip(module_name)
+    fake_task = SimpleNamespace(id="task_fake", name="Fake task")
+
+    monkeypatch.setattr(module, "_load_env_from_dotenv", lambda: None)
+    if hasattr(module, "_ensure_credentials"):
+        monkeypatch.setattr(module, "_ensure_credentials", lambda: None)
+    if hasattr(module, "_ensure_openrouter_key"):
+        monkeypatch.setattr(module, "_ensure_openrouter_key", lambda: None)
+    monkeypatch.setattr(module, "get_task", lambda _task_id: fake_task)
+    monkeypatch.setattr(
+        module,
+        run_task_name,
+        lambda *_args, **_kwargs: TaskRun("task_fake", True, "ok", 0.01),
+    )
+
+    getattr(module, run_all_name)(task_ids=["task_fake"], concurrency=1, **extra_kwargs)
+
+    output = capsys.readouterr().out
+    assert "[START] task_fake: Fake task" in output
+    output.encode("cp1251")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -15,6 +15,10 @@ def test_task_set_metadata_matches_registry() -> None:
 
 
 def test_current_memory_tasks_belong_to_current_revision() -> None:
-    assert TASK_SET_VERSION == "0.3.0"
+    assert TASK_SET_VERSION == "0.4.0"
+    # 0.3.0 memory tasks keep their original revision.
     assert revision_for_task_id("task_222_memory_name_pyproject").version == "0.3.0"
     assert revision_for_task_id("task_231_memory_refuse_secrets").version == "0.3.0"
+    # 0.4.0 extends the memory suite with tasks 232-253.
+    assert revision_for_task_id("task_232_memory_focus_day_schedule_rules").version == "0.4.0"
+    assert revision_for_task_id("task_253_memory_mixed_save_refuse_use").version == "0.4.0"

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -14,11 +14,21 @@ def test_task_set_metadata_matches_registry() -> None:
     assert len(ALL_TASKS) == EXPECTED_TASK_COUNT
 
 
-def test_current_memory_tasks_belong_to_current_revision() -> None:
-    assert TASK_SET_VERSION == "0.4.0"
+def test_memory_tasks_belong_to_their_revisions() -> None:
     # 0.3.0 memory tasks keep their original revision.
     assert revision_for_task_id("task_222_memory_name_pyproject").version == "0.3.0"
     assert revision_for_task_id("task_231_memory_refuse_secrets").version == "0.3.0"
     # 0.4.0 extends the memory suite with tasks 232-253.
     assert revision_for_task_id("task_232_memory_focus_day_schedule_rules").version == "0.4.0"
     assert revision_for_task_id("task_253_memory_mixed_save_refuse_use").version == "0.4.0"
+
+
+def test_current_agentic_tasks_belong_to_current_revision() -> None:
+    assert TASK_SET_VERSION == "0.7.0"
+    # The agentic wave spans three revisions, tasks 254-298.
+    assert revision_for_task_id("task_254_terminal_log_status_matrix").version == "0.5.0"
+    assert revision_for_task_id("task_262_swe_csv_top_customers").version == "0.5.0"
+    assert revision_for_task_id("task_263_terminal_du_top_dirs").version == "0.6.0"
+    assert revision_for_task_id("task_283_swe_inventory_allocate").version == "0.6.0"
+    assert revision_for_task_id("task_284_terminal_json_config_inventory").version == "0.7.0"
+    assert revision_for_task_id("task_298_swe_median_even_empty").version == "0.7.0"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,1661 @@
+version = 1
+revision = 3
+requires-python = ">=3.12"
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.104.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/c7/7a655b948916f777354648ce979f68b94d5b8dbdb5f61fed1f37fad9378c/anthropic-0.104.1.tar.gz", hash = "sha256:17362b6c45f527afcc9b0fdf62011ffd359726ab2ebcb1978ea0cc41bd8d8d40", size = 850081, upload-time = "2026-05-22T15:36:57.432Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/12/d9ab42790494d7c428391a46cd28492395566a6a8ccb138d681978594455/anthropic-0.104.1-py3-none-any.whl", hash = "sha256:35c8cb456f5a4405aafe1f10f03f6fcc54fa51fa8ec01d655cc4b437d120e9b7", size = 832996, upload-time = "2026-05-22T15:36:59.519Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "bracex"
+version = "2.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/63/9a/fec38644694abfaaeca2798b58e276a8e61de49e2e37494ace423395febc/bracex-2.6.tar.gz", hash = "sha256:98f1347cd77e22ee8d967a30ad4e310b233f7754dbf31ff3fceb76145ba47dc7", size = 26642, upload-time = "2025-06-22T19:12:31.254Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/2a/9186535ce58db529927f6cf5990a849aa9e052eea3e2cfefe20b9e1802da/bracex-2.6-py3-none-any.whl", hash = "sha256:0b0049264e7340b3ec782b5cb99beb325f36c3782a32e36e876452fd49a09952", size = 11508, upload-time = "2025-06-22T19:12:29.781Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.5.20"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/ce/ee2ecad540810a79593028e88299baeae54d346cc7a0d94b6199988b89b1/certifi-2026.5.20.tar.gz", hash = "sha256:69dea482ab64caa7b9f6aba1c6bf48bb6a5448d1c0f1b17ab42ad8c763a5344d", size = 135422, upload-time = "2026-05-20T11:46:50.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/59/8c/57e832b7af6d7c5abe66eb3fbe3a3a32f4d11ea23a1aa7131371035be991/certifi-2026.5.20-py3-none-any.whl", hash = "sha256:3c52e209ba0a4ad7aebe60436a4ab349c39e1e602e8c134221e546902ad25897", size = 134134, upload-time = "2026-05-20T11:46:48.578Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "48.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/a9/db8f313fdcd85d767d4973515e1db101f9c71f95fced83233de224673757/cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920", size = 832984, upload-time = "2026-05-04T22:59:38.133Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/3d/01f6dd9190170a5a241e0e98c2d04be3664a9e6f5b9b872cde63aff1c3dd/cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6", size = 8001587, upload-time = "2026-05-04T22:57:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/6e/e90527eef33f309beb811cf7c982c3aeffcce8e3edb178baa4ca3ae4a6fa/cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c", size = 4690433, upload-time = "2026-05-04T22:57:40.373Z" },
+    { url = "https://files.pythonhosted.org/packages/90/04/673510ed51ddff56575f306cf1617d80411ee76831ccd3097599140efdfe/cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3", size = 4710620, upload-time = "2026-05-04T22:57:42.935Z" },
+    { url = "https://files.pythonhosted.org/packages/14/d5/e9c4ef932c8d800490c34d8bd589d64a31d5890e27ec9e9ad532be893294/cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5", size = 4696283, upload-time = "2026-05-04T22:57:45.294Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/29/174b9dfb60b12d59ecfc6cfa04bc88c21b42a54f01b8aae09bb6e51e4c7f/cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c", size = 5296573, upload-time = "2026-05-04T22:57:47.933Z" },
+    { url = "https://files.pythonhosted.org/packages/95/38/0d29a6fd7d0d1373f0c0c88a04ba20e359b257753ac497564cd660fc1d55/cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f", size = 4743677, upload-time = "2026-05-04T22:57:50.067Z" },
+    { url = "https://files.pythonhosted.org/packages/30/be/eef653013d5c63b6a490529e0316f9ac14a37602965d4903efed1399f32b/cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25", size = 4330808, upload-time = "2026-05-04T22:57:52.301Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/500463e87abb7a0a0f9f256ec21123ecde0a7b5541a15e840ea54551fd81/cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602", size = 4695941, upload-time = "2026-05-04T22:57:54.603Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/dc/7303087450c2ec9e7fbb750e17c2abfbc658f23cbd0e54009509b7cc4091/cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c", size = 5252579, upload-time = "2026-05-04T22:57:57.207Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/c0/7101d3b7215edcdc90c45da544961fd8ed2d6448f77577460fa75a8443f7/cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5", size = 4743326, upload-time = "2026-05-04T22:57:59.535Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/d8/5b833bad13016f562ab9d063d68199a4bd121d18458e439515601d3357ec/cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321", size = 4826672, upload-time = "2026-05-04T22:58:01.996Z" },
+    { url = "https://files.pythonhosted.org/packages/98/e1/7074eb8bf3c135558c73fc2bcf0f5633f912e6fb87e868a55c454080ef09/cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74", size = 4972574, upload-time = "2026-05-04T22:58:03.968Z" },
+    { url = "https://files.pythonhosted.org/packages/04/70/e5a1b41d325f797f39427aa44ef8baf0be500065ab6d8e10369d850d4a4f/cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4", size = 3294868, upload-time = "2026-05-04T22:58:06.467Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ac/8ac51b4a5fc5932eb7ee5c517ba7dc8cd834f0048962b6b352f00f41ebf9/cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7", size = 3817107, upload-time = "2026-05-04T22:58:08.845Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/84/70e3feea9feea87fd7cbe77efb2712ae1e3e6edf10749dc6e95f4e60e455/cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec", size = 7986556, upload-time = "2026-05-04T22:58:11.172Z" },
+    { url = "https://files.pythonhosted.org/packages/89/6e/18e07a618bb5442ba10cf4df16e99c071365528aa570dfcb8c02e25a303b/cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18", size = 4684776, upload-time = "2026-05-04T22:58:13.712Z" },
+    { url = "https://files.pythonhosted.org/packages/be/6a/4ea3b4c6c6759794d5ee2103c304a5076dc4b19ae1f9fe47dba439e159e9/cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20", size = 4698121, upload-time = "2026-05-04T22:58:16.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/59/6ff6ad6cae03bb887da2a5860b2c9805f8dac969ef01ce563336c49bd1d1/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff", size = 4690042, upload-time = "2026-05-04T22:58:18.544Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/b4/fc334ed8cfd705aca282fe4d8f5ae64a8e0f74932e9feecb344610cf6e4d/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c", size = 5282526, upload-time = "2026-05-04T22:58:20.75Z" },
+    { url = "https://files.pythonhosted.org/packages/11/08/9f8c5386cc4cd90d8255c7cdd0f5baf459a08502a09de30dc51f553d38dc/cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db", size = 4733116, upload-time = "2026-05-04T22:58:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/77/99307d7574045699f8805aa500fa0fb83422d115b5400a064ddd306d7750/cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741", size = 4316030, upload-time = "2026-05-04T22:58:25.581Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/36/a608b98337af3cb2aff4818e406649d30572b7031918b04c87d979495348/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166", size = 4689640, upload-time = "2026-05-04T22:58:27.747Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/a6/825010a291b4438aecc1f568bc428189fc1175515223632477c07dc0a6df/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336", size = 5237657, upload-time = "2026-05-04T22:58:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/4e76a09b4caa29aad535ddc806f5d4c5d01885bd978bd984fbc6ca032cae/cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057", size = 4732362, upload-time = "2026-05-04T22:58:32.009Z" },
+    { url = "https://files.pythonhosted.org/packages/18/78/444fa04a77d0cb95f417dda20d450e13c56ba8e5220fc892a1658f44f882/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae", size = 4819580, upload-time = "2026-05-04T22:58:34.254Z" },
+    { url = "https://files.pythonhosted.org/packages/38/85/ea67067c70a1fd4be2c63d35eeed82658023021affccc7b17705f8527dd2/cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c", size = 4963283, upload-time = "2026-05-04T22:58:36.376Z" },
+    { url = "https://files.pythonhosted.org/packages/75/54/cc6d0f3deac3e81c7f847e8a189a12b6cdd65059b43dad25d4316abd849a/cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f", size = 3270954, upload-time = "2026-05-04T22:58:38.791Z" },
+    { url = "https://files.pythonhosted.org/packages/49/67/cc947e288c0758a4e5473d1dcb743037ab7785541265a969240b8885441a/cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12", size = 3797313, upload-time = "2026-05-04T22:58:40.746Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/63/61d4a4e1c6b6bab6ce1e213cd36a24c415d90e76d78c5eb8577c5541d2e8/cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86", size = 7983482, upload-time = "2026-05-04T22:58:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ac/f5b5995b87770c693e2596559ffafe195b4033a57f14a82268a2842953f3/cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e", size = 4683266, upload-time = "2026-05-04T22:58:46.064Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/c6/8b14f67e18338fbc4adb76f66c001f5c3610b3e2d1837f268f47a347dbbb/cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f", size = 4696228, upload-time = "2026-05-04T22:58:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/73/f808fbae9514bd91b47875b003f13e284c8c6bdfd904b7944e803937eec1/cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7", size = 4689097, upload-time = "2026-05-04T22:58:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/d86632d7d28db8ae83221995752eeb6639ffb374c2d22955648cf8d52797/cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832", size = 5283582, upload-time = "2026-05-04T22:58:53.017Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e1/50edc7a50334807cc4791fc4a0ce7468b4a1416d9138eab358bfc9a3d70b/cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c", size = 4730479, upload-time = "2026-05-04T22:58:55.611Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/af/99a582b1b1641ff5911ac559beb45097cf79efd4ead4657f578ef1af2d47/cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a", size = 4326481, upload-time = "2026-05-04T22:58:57.607Z" },
+    { url = "https://files.pythonhosted.org/packages/90/ee/89aa26a06ef0a7d7611788ffd571a7c50e368cc6a4d5eef8b4884e866edb/cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a", size = 4688713, upload-time = "2026-05-04T22:59:00.077Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ba/bcb1b0bb7a33d4c7c0c4d4c7874b4a62ae4f56113a5f4baefa362dfb1f0f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a", size = 5238165, upload-time = "2026-05-04T22:59:02.317Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/70/ca4003b1ce5ca3dc3186ada51908c8a9b9ff7d5cab83cc0d43ee14ec144f/cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239", size = 4729947, upload-time = "2026-05-04T22:59:05.255Z" },
+    { url = "https://files.pythonhosted.org/packages/44/a0/4ec7cf774207905aef1a8d11c3750d5a1db805eb380ee4e16df317870128/cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c", size = 4822059, upload-time = "2026-05-04T22:59:07.802Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/75/a2e55f99c16fcac7b5d6c1eb19ad8e00799854d6be5ca845f9259eae1681/cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4", size = 4960575, upload-time = "2026-05-04T22:59:09.851Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/23/6e6f32143ab5d8b36ca848a502c4bcd477ae75b9e1677e3530d669062578/cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd", size = 3279117, upload-time = "2026-05-04T22:59:12.019Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/0fea98a70cf1749d41d738836f6349d97945f7c89433a259a6c2642eefeb/cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8", size = 3792100, upload-time = "2026-05-04T22:59:14.884Z" },
+]
+
+[[package]]
+name = "deepagents"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain" },
+    { name = "langchain-anthropic" },
+    { name = "langchain-core" },
+    { name = "langchain-google-genai" },
+    { name = "langsmith" },
+    { name = "wcmatch" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2d/e4/f0db12de9a63ace505a81a3bd1bff2012fa94d57698bcc4edb6cc44daf3a/deepagents-0.6.3.tar.gz", hash = "sha256:ce2bc1d91a29b8355e43bdf89da553705e103cd1f2b3ff7b999b69be8eac1237", size = 180551, upload-time = "2026-05-20T21:16:38.473Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/e9/35a5668b4226afe8ec83a71c38e53a677b207ed9a10bd806b1be6cbf6277/deepagents-0.6.3-py3-none-any.whl", hash = "sha256:5c9a3ab30cd24eae0a5afe654fe5030ead4f8a86154c77757dd6350342ad50ac", size = 205652, upload-time = "2026-05-20T21:16:36.999Z" },
+]
+
+[[package]]
+name = "deepagents-gigachat"
+version = "0.0.1a3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deepagents" },
+    { name = "langchain-gigachat" },
+    { name = "python-dotenv" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b0/a1/bbba458476e1ed68e11a2a41dbb0b41dae6b43ce452a30e0fdb17eb80651/deepagents_gigachat-0.0.1a3.tar.gz", hash = "sha256:d76fb56b4c8c4f5b2e66f30213e740e8f49eb59694dcbd2e3cef66413b26c9df", size = 9761, upload-time = "2026-05-14T11:19:27.253Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/77/27/57b301d2888a2830d5ea2c9f3d92aa98414f205c3961d082cfdef3105a26/deepagents_gigachat-0.0.1a3-py3-none-any.whl", hash = "sha256:85baebf52bfcc096b18c40506a6aa399d1944e7eb931499ede9edf26cf6e00ee", size = 9625, upload-time = "2026-05-14T11:19:28.525Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/4d/f332313098c1de1b2d2ff91cf2674415cc7cddab2ca1b01ae29774bd5fdf/docstring_parser-0.18.0.tar.gz", hash = "sha256:292510982205c12b1248696f44959db3cdd1740237a968ea1e2e7a900eeb2015", size = 29341, upload-time = "2026-04-14T04:09:19.867Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/5f/ed01f9a3cdffbd5a008556fc7b2a08ddb1cc6ace7effa7340604b1d16699/docstring_parser-0.18.0-py3-none-any.whl", hash = "sha256:b3fcbed555c47d8479be0796ef7e19c2670d428d72e96da63f3a40122860374b", size = 22484, upload-time = "2026-04-14T04:09:18.638Z" },
+]
+
+[[package]]
+name = "et-xmlfile"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/38/af70d7ab1ae9d4da450eeec1fa3918940a5fafb9055e934af8d6eb0c2313/et_xmlfile-2.0.0.tar.gz", hash = "sha256:dab3f4764309081ce75662649be815c4c9081e88f0837825f90fd28317d4da54", size = 17234, upload-time = "2024-10-25T17:25:40.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/8b/5fe2cc11fee489817272089c4203e679c63b570a5aaeb18d852ae3cbba6a/et_xmlfile-2.0.0-py3-none-any.whl", hash = "sha256:7a91720bc756843502c3b7504c77b8fe44217c85c537d85037f0f536151b2caa", size = 18059, upload-time = "2024-10-25T17:25:39.051Z" },
+]
+
+[[package]]
+name = "filetype"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bb/29/745f7d30d47fe0f251d3ad3dc2978a23141917661998763bebb6da007eb1/filetype-1.2.0.tar.gz", hash = "sha256:66b56cd6474bf41d8c54660347d37afcc3f7d1970648de365c102ef77548aadb", size = 998020, upload-time = "2022-11-02T17:34:04.141Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/79/1b8fa1bb3568781e84c9200f951c735f3f157429f44be0495da55894d620/filetype-1.2.0-py2.py3-none-any.whl", hash = "sha256:7ce71b6880181241cf7ac8697a2f1eb6a8bd9b429f7ad6d27b8db9ba5f1c2d25", size = 19970, upload-time = "2022-11-02T17:34:01.425Z" },
+]
+
+[[package]]
+name = "gigachat"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/12/376c5379edaba910e2ddd1e286e711ad0e3d43e2008123a62dc7cd05b4bb/gigachat-0.2.1.tar.gz", hash = "sha256:4b6bb976ffd1fec22c813e2f40f100fff60efc2c50b91cc36aa6df5f888d0373", size = 34644, upload-time = "2026-04-27T07:58:13.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/30/f5743775b7bcf9da5b9bdc70717c92b3a570ab3215b68a77c9eba504bcd9/gigachat-0.2.1-py3-none-any.whl", hash = "sha256:a4a4fb9e2db0905b7ab5a340d5029527a177811b8b609998d600c95e8a8a060c", size = 45150, upload-time = "2026-04-27T07:58:14.411Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.53.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/ad/ff781329bbbdc0974a098d996e89c9e1f7024262f9e3eec442fbb9ad1ac6/google_auth-2.53.0.tar.gz", hash = "sha256:e7e6aa16f6bee7b2b264830fd04f08087a1d5a836df516251a5d15327b246c9c", size = 335844, upload-time = "2026-05-15T20:53:07.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4a/c9/db44165ba7c581268c6d46017ef63339110378305062830104fc7fa144cb/google_auth-2.53.0-py3-none-any.whl", hash = "sha256:6e7449917c599b35126a99ec268ec6880301f2fea41dce198fe8fd83ff642b68", size = 246071, upload-time = "2026-05-15T20:53:05.609Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/59/3ed61240ef20b3ae6ed54e82c6f8b6d1f194947bc6679679dd6cdb037594/google_genai-1.75.0.tar.gz", hash = "sha256:56bac3991b311c93f980c0a2abcd287b672146905df1fbd71c92ed633d5a07cf", size = 539039, upload-time = "2026-05-04T22:48:54.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2d/b6/552d40e96da22921eb1fead7c14b00b5b5473a20e45959488660fab35ee2/google_genai-1.75.0-py3-none-any.whl", hash = "sha256:8dc4c096e7d6288c3087f6893f582fe52468932464781edb8193bd92b9fefb2c", size = 793726, upload-time = "2026-05-04T22:48:53.033Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "harness-bench-fast"
+version = "0.1.0"
+source = { editable = "." }
+dependencies = [
+    { name = "deepagents" },
+    { name = "openpyxl" },
+    { name = "pytest" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+]
+
+[package.optional-dependencies]
+gigachat = [
+    { name = "langchain-gigachat" },
+]
+gigachat-profile = [
+    { name = "deepagents-gigachat" },
+    { name = "langchain-gigachat" },
+]
+openrouter = [
+    { name = "langchain-openai" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "deepagents-gigachat" },
+    { name = "langchain-gigachat" },
+    { name = "langchain-openai" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "deepagents", specifier = ">=0.6.2" },
+    { name = "deepagents-gigachat", marker = "extra == 'gigachat-profile'", specifier = ">=0.0.1a3" },
+    { name = "langchain-gigachat", marker = "extra == 'gigachat'", specifier = ">=0.5.0" },
+    { name = "langchain-gigachat", marker = "extra == 'gigachat-profile'", specifier = ">=0.5.0" },
+    { name = "langchain-openai", marker = "extra == 'openrouter'", specifier = ">=1.2.1" },
+    { name = "openpyxl", specifier = ">=3.1" },
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "python-dotenv", specifier = ">=1.2.2" },
+    { name = "pyyaml", specifier = ">=6.0" },
+]
+provides-extras = ["gigachat", "gigachat-profile", "openrouter"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "deepagents-gigachat", specifier = ">=0.0.1a3" },
+    { name = "langchain-gigachat", specifier = ">=0.5.0" },
+    { name = "langchain-openai", specifier = ">=1.2.1" },
+    { name = "ruff", specifier = ">=0.15.12" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/b5/55f06bb281d92fb3cc86d14e1def2bd908bb77693183e7cb1f5a3c388b0c/jiter-0.15.0.tar.gz", hash = "sha256:4251acc80e2b7c9b7b8823456ea0fceeb0734dac2df7636d3c711b38476b5a76", size = 166640, upload-time = "2026-05-19T10:09:48.361Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/44/53/4f6bddbcde3c71e56d0aa1337ec95950f3d27dd4153e25aadf0feac71751/jiter-0.15.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0e90a1c315a0226ec822d973817967f9223b7701546c8c2a7913e7ab0926294d", size = 308793, upload-time = "2026-05-19T10:07:35.25Z" },
+    { url = "https://files.pythonhosted.org/packages/01/84/c01099b59a285a1ebba64ae93f62bfa036675340fd1b0045ae65890a0442/jiter-0.15.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8c9004af7c8d67cce7f1aae1026fb55607f4aa600710d08ede3a3ce4aeefe7e0", size = 309570, upload-time = "2026-05-19T10:07:36.919Z" },
+    { url = "https://files.pythonhosted.org/packages/58/64/8fb7f9d45bb98190355454cd04dad8d8f27223d6bd52f83af07f637168a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c210f8b35dc6f30aafd4b4365ca89b9d1189f21ab49b8e68fa6322a847aef138", size = 336783, upload-time = "2026-05-19T10:07:38.694Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/b6/f5739011d009b3a30f6a53c5240979030ba29ae46a8c67e3a15759f7c37d/jiter-0.15.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f30bae8bc1c2d613e28e5af3e8cceb09b742f1c8a8a5f839fb67afaffc03b61", size = 363555, upload-time = "2026-05-19T10:07:40.832Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/12/98a9d9f766665e8a3b6252454e17cb0c464606a28cf2fa09399b003345fa/jiter-0.15.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c60e71b6d10cfc284c9bf36bd885e8d44c46f688ce50aa91b5edd90181dea687", size = 452255, upload-time = "2026-05-19T10:07:42.62Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/d5/60f972840f79c5e7544fce567c56f1e4e50468f996baba3e78d823dd62a6/jiter-0.15.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ab068bce62a45aa3e7367eceaffb5dde60b7eb853be8dece45132e3d0ff4879", size = 373559, upload-time = "2026-05-19T10:07:44.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/cf/d46ef1234ba335aabc2f013210db8e0821a22f5e644a2e9449df199ecc23/jiter-0.15.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fa248c9eb220197d363f688818dac2fd4b2f0cd7d843ca7105d652034823427d", size = 346055, upload-time = "2026-05-19T10:07:46.005Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/63/4d2749d8d54d230bad9b3a6b0d00cc28c6ff6b2fdffc26a8ccf76cc5a974/jiter-0.15.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2a77aadd57cac1682e4401a72724d2796d89a4ba129b1a5812aa94ee480826eb", size = 351406, upload-time = "2026-05-19T10:07:47.855Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/b9/9965b990035d8773328e0a8c8b457a87bf2b19f6c4126d9d99296be5d16a/jiter-0.15.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2ae901f3a55bfafdde31d289590fa25e3245735a2b1e8c7cc15871710a002871", size = 389357, upload-time = "2026-05-19T10:07:49.665Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/55/9ddf903deda1413e87fed792f416b7123daee5b8efbad6a202a7421c36a5/jiter-0.15.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:f0b271b462769543716f92d3a4f90527df6ef5ed05ee95ec4137f513e21e1b77", size = 517263, upload-time = "2026-05-19T10:07:51.537Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/76/a0c40ad064d3a20a4fde231e35d56e9a01ce82164278180e82d5daf85469/jiter-0.15.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2fb6a5d26af81fc0f00f9360a891e05cf755e149bba391c4d563adc54812973d", size = 548646, upload-time = "2026-05-19T10:07:53.196Z" },
+    { url = "https://files.pythonhosted.org/packages/23/4f/eca9b954942916ba2f453891b8593ab444cd872396fe66a3936616f236f3/jiter-0.15.0-cp312-cp312-win32.whl", hash = "sha256:c2f6bb8b5216ab9e7873bc08b5d7bef2b8abbb578a3069bf1cd14a45d71d771d", size = 206427, upload-time = "2026-05-19T10:07:55.307Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/8ead82a87495149542748e828d153fd232a512a22c83b02c4815c1a9c7d8/jiter-0.15.0-cp312-cp312-win_amd64.whl", hash = "sha256:40b2c7e92c44a84d748d21706c68dc6ff8161d80b59c99d774721a0d2317d7c7", size = 197300, upload-time = "2026-05-19T10:07:56.651Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/e4/9b8a78fb2d894471bc344e37f1949bdd784bd914d031dba0ba3a40c71dd7/jiter-0.15.0-cp312-cp312-win_arm64.whl", hash = "sha256:cc0bc345cf2df9d1c00ac443f50d543c1ccfa8b0422cb85b1ab70d681c0b255b", size = 192702, upload-time = "2026-05-19T10:07:58.307Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f4/f708c900ecee41b2025ef8413d5351e5649eb2125c506f6720cc69b06f5c/jiter-0.15.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1c11465f97e2abf45a014b83b730222f8f1c5335e802c7055a67d50de6f1f4e3", size = 307829, upload-time = "2026-05-19T10:07:59.704Z" },
+    { url = "https://files.pythonhosted.org/packages/86/59/db537c0949e83668c38481d426b9f2fd5ab758c4ee53a811dd0a510626a0/jiter-0.15.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d1e7b1776f0797956c509e123d0952d10d293a9492dea9f288ab9570ec01d1a5", size = 308445, upload-time = "2026-05-19T10:08:01.184Z" },
+    { url = "https://files.pythonhosted.org/packages/37/38/ea0e13b18c30ef951da0d47d39e7fa9edb82a93a62990ffbd7cea9b622d4/jiter-0.15.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:351a341c2105aa430b7047e30f1bf7975f6313b00165d3fc07be2edaf741f279", size = 336181, upload-time = "2026-05-19T10:08:02.688Z" },
+    { url = "https://files.pythonhosted.org/packages/58/fc/2303901b16c4ba05865588990a420c0b4156270b44379c20931544a1d962/jiter-0.15.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4ab395feec8d249ec4044e228e98a7033f043426a265df439dc3698823f0a4e4", size = 362985, upload-time = "2026-05-19T10:08:04.394Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/6f/11bace093c52e7d4d26c8e606ccd7ae8c972189622469ec0d9e28161e28b/jiter-0.15.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a2a438005b6f22d0273413484d6094d7c2c5d10ec1b3a3bf128e0d1d3ba53258", size = 453292, upload-time = "2026-05-19T10:08:05.967Z" },
+    { url = "https://files.pythonhosted.org/packages/22/db/987f2f086ca4d7a6582eb4ccd513f9b26b42d9e4243a087609a3137a8fc7/jiter-0.15.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f18f85e4218d1b40f000f42a92239a7a61a902cd42c65e6c360dbd17dcb20894", size = 373501, upload-time = "2026-05-19T10:08:07.857Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/7c/89fbcabb2739b7a5b8dc959a1b6c5761f6484f5fed3486854b3c789bb1de/jiter-0.15.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d1aa62e277fc1cbd80e6deacae6f4d983b41b3d7728e0645c5d741a6149bba45", size = 344683, upload-time = "2026-05-19T10:08:09.431Z" },
+    { url = "https://files.pythonhosted.org/packages/30/6f/6cca7692e7dddfec6d8d76c54dc97f2af2a41df4ac0674b999df1f09a5f3/jiter-0.15.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:6550fa135c7deb8ead6af49ed7ff648532ea8334a1447fe34a36315ef79c5c29", size = 350892, upload-time = "2026-05-19T10:08:11.352Z" },
+    { url = "https://files.pythonhosted.org/packages/39/14/0338d6190cb8e6d22e677ab1d4eabd4117f67cca70c54cd04b82ff64e068/jiter-0.15.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:066f8f33f18b2419cd8213b2436fa7fbc9c499f315971cfa3ce1f9820c001b1b", size = 388723, upload-time = "2026-05-19T10:08:12.912Z" },
+    { url = "https://files.pythonhosted.org/packages/90/31/cc19f4a1bdb6afb09ce6a2f2615aa8d44d994eba0d8e6105ed1af920e736/jiter-0.15.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:75e8a04e91432dde9f1838373cf93d23726c79d3e908d319acf0e796f85592e7", size = 516648, upload-time = "2026-05-19T10:08:14.808Z" },
+    { url = "https://files.pythonhosted.org/packages/49/9f/833c541512cd091b63c10c0381973dfe11bc7a503a818c16384417e0c81e/jiter-0.15.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:a97261f1fccb8e50ecd2890a96e46efdc3f57c80a197324c6777827231eca712", size = 547382, upload-time = "2026-05-19T10:08:16.927Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/11/e7b70e91f90bc4477e8eee9e8a5f7cf3cb41b4525d6394dc98a714eb8f7f/jiter-0.15.0-cp313-cp313-win32.whl", hash = "sha256:c77496cb10bd7549690fbbab3e5ec05857b83e49276f4a9423a766ddd2afcd4c", size = 205845, upload-time = "2026-05-19T10:08:18.401Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/23/5c20d9ad6f02c493e4023e5d2d09e1c1f15fe2753c9102c544aff068a88e/jiter-0.15.0-cp313-cp313-win_amd64.whl", hash = "sha256:b15741f501469009ae0ae90b7147958a664a7dede40aa7ff174a8a4645f546d0", size = 196842, upload-time = "2026-05-19T10:08:20.131Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/11/1eb400ef248e8c925fd883fbe325daf5e42cd1b0d308539dd332bd4f7ffc/jiter-0.15.0-cp313-cp313-win_arm64.whl", hash = "sha256:5d6a60072b44c3c2b797a7ddcbcbbf2b34ea3cfd4721580fbfd2a09d9d9b84ba", size = 192212, upload-time = "2026-05-19T10:08:21.807Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/60/2fd8d7c79da8acf9b7b277c7616847773779356b92acfc9bb158452174da/jiter-0.15.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:ef1fd24d9413f6209e00d3d5a453e67acfe004a25cc6c8e8484faed4311ab9e8", size = 315065, upload-time = "2026-05-19T10:08:23.218Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f4/008fb7d65e8ac2abf00811651a661e025c4ba80bbc6f378450384ddd3aed/jiter-0.15.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:144f8e72cb53dab146347b91cceac01f5481237f2b93b4a339a1ee8f8878b67c", size = 339444, upload-time = "2026-05-19T10:08:24.701Z" },
+    { url = "https://files.pythonhosted.org/packages/00/55/90b0c7b9c6896c0f2a591dd36d36b71d22e09674bfef178fa03ba3f81499/jiter-0.15.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:553fcac2ef2cb990877f9fc0833b8b629a3e6a5670b6b5fd58219b41a653ddc4", size = 347779, upload-time = "2026-05-19T10:08:26.408Z" },
+    { url = "https://files.pythonhosted.org/packages/51/6b/69666cec5000fd57734c118437394516c749ae8dbeea9fb66d6fef9c4775/jiter-0.15.0-cp313-cp313t-win_amd64.whl", hash = "sha256:774f93f65031856bf14ad9f59bdcab8b8cad501e5ceabd51ba3525f76937a25b", size = 200395, upload-time = "2026-05-19T10:08:28.055Z" },
+    { url = "https://files.pythonhosted.org/packages/39/04/a6aa62cd27e8149b0d28df5561f10f6cceaf7935a9ccf3f1c5a05f9a0cd8/jiter-0.15.0-cp313-cp313t-win_arm64.whl", hash = "sha256:f1e1754960f38ec40613a07e5e372df67acb3b890fb383b6fb3de3e49ddbf3c7", size = 190516, upload-time = "2026-05-19T10:08:29.35Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/d2/079f350ebf7859d081de30aa890f9e3be68516f754f3ba32366ffff4dcee/jiter-0.15.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ac0d9ddea4350974be7a221fc25895f251a8fee748c889bdced2141c0fec1a49", size = 308884, upload-time = "2026-05-19T10:08:31.667Z" },
+    { url = "https://files.pythonhosted.org/packages/04/4e/a2c30a7f69b48c03b20935d647479106fe932f6e63f75faf53937197e05d/jiter-0.15.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:01a8222cf05ab1128e239421156c207949808acaaea2bdfd33130ae666786e86", size = 310028, upload-time = "2026-05-19T10:08:33.304Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/2e7cdfd3cf8ca967be38c48f5cf474d79f089efaf559a40f15984a77ae69/jiter-0.15.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:182226cbc930c9fab81bc2e41a4da672f89539906dadb05e75670ac07b94f71f", size = 337485, upload-time = "2026-05-19T10:08:35.259Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/11/15a1aa28b120b8ee5b4f1fb894c125046225f09847738bd64233d3b84883/jiter-0.15.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:71683c38c825452999b5717fcae07ea708e8c93003e808be4319c1b02e3d176e", size = 364223, upload-time = "2026-05-19T10:08:36.694Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/25/f442e8af5f3d0dcf47b39e83a0efd9ee45ea946aa6d04625dc3181eae3b6/jiter-0.15.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30f2218e6a9e5c18bc10fe6d41ac189c442c88eacf11bad9f28ef95a9bef00e6", size = 456387, upload-time = "2026-05-19T10:08:38.143Z" },
+    { url = "https://files.pythonhosted.org/packages/da/f4/37f2d2c9f64f49af7da652ed7532bb5a2372e588e6927c3fdd76f911db65/jiter-0.15.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5157de9f76eb4bc5ea74a1219366a25f945ad305641d74e04f59c54087091aa9", size = 374461, upload-time = "2026-05-19T10:08:39.869Z" },
+    { url = "https://files.pythonhosted.org/packages/60/28/edcfbbbf0cb15436f36664a8908a0df47ab9006298d4cd937dc08ea932d6/jiter-0.15.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:90c5db5527c221249a876160663ab891ace358c17f7b9c93ec1478b7f0550e5c", size = 345924, upload-time = "2026-05-19T10:08:41.668Z" },
+    { url = "https://files.pythonhosted.org/packages/47/13/89fba6398dab7f202b7278c4b4aac122399d2c0183971c4a57a3b7088df5/jiter-0.15.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:3e4540b8e74e4268811ac05db226a6a128ff572e7e0ce3f1163b693cadb184cd", size = 352283, upload-time = "2026-05-19T10:08:43.091Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/da/0f6af8cef2c565a1ab44d970f268c43ccaa72707386ea6388e6fe2b6cd26/jiter-0.15.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:62ebd14e47e9aed9df4472afcb2663668ce4d74891cd54f86bf6e44029d6dc89", size = 389985, upload-time = "2026-05-19T10:08:44.915Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/ec/b9cb7d6d29e24ee14910266157d2a279d7a8f60ee0df7fa840882976ba64/jiter-0.15.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0be6f5ad41a809f303f416d17cec92a7a725902fb9b4f3de3d19362ac0ef8554", size = 517695, upload-time = "2026-05-19T10:08:46.486Z" },
+    { url = "https://files.pythonhosted.org/packages/64/5e/6d1bda880723aae0ad86b4b763f044362448efe31e3e819635d41cb03451/jiter-0.15.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:813dfbb17d65328bf86e5f0905dd277ba2265d3ca20556e86c0c7035b7182e5a", size = 548868, upload-time = "2026-05-19T10:08:48.026Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/72/7de501cf38dcacaf35098796f3a50e0f2e338baba18a58946c618544b809/jiter-0.15.0-cp314-cp314-win32.whl", hash = "sha256:50e51156192722a9c58db112837d3f8ef96fb3c5ecc14e95f409134b08b158ec", size = 206380, upload-time = "2026-05-19T10:08:49.738Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/a9/e19addf4b0c1bdce52c6da12351e6bc42c340c45e7c09e2158e46d293ccc/jiter-0.15.0-cp314-cp314-win_amd64.whl", hash = "sha256:30ce1a5d16b5641dc935d50ef775af6a0871e3d14ab05d6fc54dff371b78e558", size = 197687, upload-time = "2026-05-19T10:08:51.088Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/c9/776b1db01db25fc6c1d58d1979a37b0a9fe787e5f5b1d062d2eaacb77923/jiter-0.15.0-cp314-cp314-win_arm64.whl", hash = "sha256:510c8b3c17a0ed9ac69850c0438dada3c9b82d9c4d589fcb62002a5a9cf3a866", size = 192571, upload-time = "2026-05-19T10:08:52.451Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f6/45bb4670bacf300fd2c7abadbfb3af376e5f1b6ae75fd9bc069891d15870/jiter-0.15.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7553333dd0930c104a5a0db8df72bf7219fe663d731383b576bb6ed6351c984d", size = 317151, upload-time = "2026-05-19T10:08:53.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/68/ed635ad5acd7b73e454283083bbb7c8205ad10e88b0d9d7d793b09fe8226/jiter-0.15.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f2143ab06181d2b029eedcb6af3cebe95f11bbac62441781860f98ee9330a6a6", size = 341243, upload-time = "2026-05-19T10:08:55.383Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/db/3ff4176b817b8ea33879e71e13d8bc2b0d481a7ed3fe9e080f333d415c16/jiter-0.15.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6eac374c5c975709b69c10f09afd199df74150172156ad10c8d4fd785b7da995", size = 363629, upload-time = "2026-05-19T10:08:56.928Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/24/5f8270e0ba9c883582f96f722f8a0b58015c7ce1f8c6d4571cf394e99b6b/jiter-0.15.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b3b3b775e33d3bfaec9899edc526ae97b0da0bf9d071a46124ba419149a414f8", size = 456198, upload-time = "2026-05-19T10:08:58.618Z" },
+    { url = "https://files.pythonhosted.org/packages/45/5b/76fc02b0b5c54c3d18c60653156e2f76fde1816f9b4722db68d6ee2c897e/jiter-0.15.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3071db3346334beae1360b46da4606da57bf3528c167b3c38533afaf9f2c5", size = 373710, upload-time = "2026-05-19T10:09:00.151Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/52/4310821b0ea9277994d3e1f49fc6a4b34e4800caebacb2c0af81da59a454/jiter-0.15.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c6694a173ecabc12eb60efbc0b474464ead1951ff65cd8b1e72100715c64512b", size = 349901, upload-time = "2026-05-19T10:09:01.621Z" },
+    { url = "https://files.pythonhosted.org/packages/93/fe/67648c35b3594fba8854ac64cc8a826d8bcd18324bbdb53d77697c60b6ef/jiter-0.15.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:a254e10b593624d230c365b6d616b22ca0ad65e63a16e6631c2b3466022e6ba8", size = 352438, upload-time = "2026-05-19T10:09:03.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/28/0a1879d07ad6b3e025a2750027363452ced93c2d16d1c9d4b153ffd51c91/jiter-0.15.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d8d2955167274e15d79a7a020afdd9b39c990eb80b2d89fca695d92dcfdd38ec", size = 388152, upload-time = "2026-05-19T10:09:04.741Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/78/46c6f6b56ba85c90021f4afd72ed42f691f8f84daacb5fe27277070e3858/jiter-0.15.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:acf4ee4d1fc55917239fe72972fb292dd773055d05eb040d36f4326e02cc2c0e", size = 517707, upload-time = "2026-05-19T10:09:06.231Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/cb/720662d4c88fcad606e826fef5424365527ba43ce4868a479aed8f8c507e/jiter-0.15.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:e7196e56f1cd69af1dbb07dff02dcfb260a50b45a82d409d92a06fedb32473b5", size = 548241, upload-time = "2026-05-19T10:09:08.093Z" },
+    { url = "https://files.pythonhosted.org/packages/60/e3/935b8034fd143f21125c87d51404a9e0e1449186a494405721ff5d1d695e/jiter-0.15.0-cp314-cp314t-win32.whl", hash = "sha256:7f6163c0f10b055245f814dcc59f4818da60dfe72f3e72ab89fc24b6bd5e9c52", size = 207950, upload-time = "2026-05-19T10:09:09.616Z" },
+    { url = "https://files.pythonhosted.org/packages/93/59/984fd9ece895953dad3e0880a650e766f5a2da2c5514f0eafdaaabbeb5f9/jiter-0.15.0-cp314-cp314t-win_amd64.whl", hash = "sha256:980c256edb05b78a111b99c4de3b1d32e31634b867fd1fc2cf726e7b7bba9854", size = 200055, upload-time = "2026-05-19T10:09:11.367Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/cf8d779feb133a27a2e3bc833bccb9e13aa332cdf820497ebf72c10ce8c3/jiter-0.15.0-cp314-cp314t-win_arm64.whl", hash = "sha256:66b1880df2d01e206e8339769d1c7c1753bcb653efd6289e203f6f24ebada0c0", size = 191244, upload-time = "2026-05-19T10:09:12.74Z" },
+    { url = "https://files.pythonhosted.org/packages/73/38/505941b2b092fd5bbbd60a52a880db1173f1690ae6751bed3af1c9ddcb4e/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:631f13a3d04e97d4e083993b10f4b99530e3a10d953e2eb5e196b7dc7f812ce0", size = 303769, upload-time = "2026-05-19T10:09:42.203Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/95/a06692b29e77473f286e1ec1f426d3ca44d7b5843be8ad21d7a5f3fcdcc0/jiter-0.15.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:b6c0ffae686c39bf3737be60793783267628783ea42545632c10b291105aee45", size = 305128, upload-time = "2026-05-19T10:09:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/23/85/7270d7ad41d6061a25b950c6bf91d638bd9aacb113200a8c8d57a055fd67/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1d54fb5b31dea401a41af3f8a7d2512e9b6a6a005491e6166c7e4ffab9639a9c", size = 340459, upload-time = "2026-05-19T10:09:45.452Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/8d/302cb2057b7513327b4d575cff6b1d066ee6431a5357fc3f8867cd684406/jiter-0.15.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:54d5d6090cdc1b7c9e780dfb04949a990adb1e301a2fc0bbcee7de4638d33f9a", size = 344469, upload-time = "2026-05-19T10:09:46.864Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
+name = "langchain"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/11/e5/6350e77a9e2764eaafcb2d581cbf0b800f53c6bc98fdf5ebc85f3a931ded/langchain-1.3.1.tar.gz", hash = "sha256:bc283c220233230f48b8e50ab1fbf1b688bcb206d933fa448d40a9b143177f62", size = 581329, upload-time = "2026-05-15T18:14:55.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/11/3d7ed10b535413a07ed5e15682abcb77f3c4204ac49586977a495f9b24e6/langchain-1.3.1-py3-none-any.whl", hash = "sha256:154e9c30c90b391eba4315296f6bf6b6fac6b058ddea4cc771a10470968fe36f", size = 114345, upload-time = "2026-05-15T18:14:53.984Z" },
+]
+
+[[package]]
+name = "langchain-anthropic"
+version = "1.4.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anthropic" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fa/e3/d2f9dec95602524b1cfb4be2747ba5bc38d32501b2a56cb4bcb76e80bb45/langchain_anthropic-1.4.3.tar.gz", hash = "sha256:f8a2442463c0629b1b3110eaeaa56fdbdc87df2a802f8c7f5ecf611eb4874ec8", size = 685219, upload-time = "2026-05-03T17:33:27.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/55/482a1968c95275e8be6d8c1e53b54f0f7be0b8b155ce1608c947a95cf543/langchain_anthropic-1.4.3-py3-none-any.whl", hash = "sha256:65466e0f2f95909a009708f2958e917dfdbfab79c612b4484a30866a85e1f291", size = 50389, upload-time = "2026-05-03T17:33:25.671Z" },
+]
+
+[[package]]
+name = "langchain-core"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpatch" },
+    { name = "langchain-protocol" },
+    { name = "langsmith" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "uuid-utils" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/de/679a53472c25860837e32c0442c962fa86e95317a36460e2c9d5c91b17c2/langchain_core-1.4.0.tar.gz", hash = "sha256:1dc341eed802ed9c117c0df3923c991e5e9e226571e5725c194eeb5bd93d1a7f", size = 920260, upload-time = "2026-05-11T18:42:35.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0f/1a/86c38c27b81913a1c6c12448cab55defb5a1097c7dc9a4cea83f55477a2d/langchain_core-1.4.0-py3-none-any.whl", hash = "sha256:23cbbdb46e38ddd1dd5247e6167e96013eae74bea4c5949c550809970a9e565c", size = 548120, upload-time = "2026-05-11T18:42:33.992Z" },
+]
+
+[[package]]
+name = "langchain-gigachat"
+version = "0.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gigachat" },
+    { name = "langchain-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/bb/efea48f87376d5e5332391b8acc4fe2e8d9946232a76006e122b97ccef1b/langchain_gigachat-0.5.1.tar.gz", hash = "sha256:0979813e391fb66fb356990dce36d8db23e4634b78914b03ffdade96ada718a7", size = 25920, upload-time = "2026-05-04T14:04:25.328Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/c7/7a33997b4e5bea202732128759cd8be13a5b8863161dcb2b2f843da833d5/langchain_gigachat-0.5.1-py3-none-any.whl", hash = "sha256:900a44a4c36926118974e3cddc689b23547d3cd21d1d7649b1e979a434e66a00", size = 28562, upload-time = "2026-05-04T14:04:26.246Z" },
+]
+
+[[package]]
+name = "langchain-google-genai"
+version = "4.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "filetype" },
+    { name = "google-genai" },
+    { name = "langchain-core" },
+    { name = "pydantic" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/20/76e3b367d31ee8b8beda715ffdd6a5db12d99700a12936123bd9adaaa00f/langchain_google_genai-4.2.3.tar.gz", hash = "sha256:b36bf2201c7b1f1b5d3e13a122af2f8f829151a15183985dcf24e2bc0fcfe69c", size = 269998, upload-time = "2026-05-21T22:11:34.291Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/0f/61f0c667d31bfc80fff5af0985d8d7925a75592283a3d2f4b0abf63614e6/langchain_google_genai-4.2.3-py3-none-any.whl", hash = "sha256:2b1be55443c0f409f52799a95f86011e8fa4d15d50b2ee8db2416096828b7042", size = 68569, upload-time = "2026-05-21T22:11:32.749Z" },
+]
+
+[[package]]
+name = "langchain-openai"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "openai" },
+    { name = "tiktoken" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f7/1b/c506c7f41156d3a6b4582b4c487f480001b8741deecc6e2d4931fdf4cf2c/langchain_openai-1.2.2.tar.gz", hash = "sha256:8698ffcee9a086e91ab6d207f0026181a03effcbf86bf9aee1808ee35af69dcc", size = 1147539, upload-time = "2026-05-21T22:08:31.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/8e/7406c99afacafc8c2ce0fa4152f9f8b9598c93ceb291959821abd053b982/langchain_openai-1.2.2-py3-none-any.whl", hash = "sha256:7da39a3c70cbafa93853456199e39a264dc70651be79b12ac49b4f6a448bce2d", size = 99631, upload-time = "2026-05-21T22:08:29.527Z" },
+]
+
+[[package]]
+name = "langchain-protocol"
+version = "0.0.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4f/24/9777489d6fbbee64af0c8f96d4f840239c408cf694f3394672807dafc490/langchain_protocol-0.0.15.tar.gz", hash = "sha256:9ab2d11ee73944754f10e037e717098d3a6796f0e58afa9cadda6154e7655ade", size = 5862, upload-time = "2026-05-01T22:30:04.748Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1d/7a/9c97a7b9cbe4c5dc6a44cdb1545450c28f0c8ce89b9c1f0ee7fbad896263/langchain_protocol-0.0.15-py3-none-any.whl", hash = "sha256:461eb794358f83d5e42635a5797799ffec7b4702314e34edf73ac21e75d3ef79", size = 6982, upload-time = "2026-05-01T22:30:03.877Z" },
+]
+
+[[package]]
+name = "langgraph"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+    { name = "langgraph-prebuilt" },
+    { name = "langgraph-sdk" },
+    { name = "pydantic" },
+    { name = "xxhash" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/8e/34a57e338a319e3b32c1bd183c2a9a04f7f35d683d3f3d8f597f6eacbc4e/langgraph-1.2.1.tar.gz", hash = "sha256:28314f844678d9d307cbd63e7b48b0145bf17177d84b40ee2921061e07b6f966", size = 693750, upload-time = "2026-05-21T18:33:07.478Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/8c/313912e26866893bd15be9b4ea3442dc86f69270b0ad01a4961d1eba7118/langgraph-1.2.1-py3-none-any.whl", hash = "sha256:5cc4020de8f1e2a048d773f6e9128646a2af8c68a8067ab9cab177a2fcc8d221", size = 235317, upload-time = "2026-05-21T18:33:05.687Z" },
+]
+
+[[package]]
+name = "langgraph-checkpoint"
+version = "4.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "ormsgpack" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/47/886af6f886f0bff2273164a45f008694e48a96ff3cd25ff0228f2aa9480e/langgraph_checkpoint-4.1.1.tar.gz", hash = "sha256:6c2bdb530c91f91d7d9c1bd100925d0fc4f498d418c17f3587d1526279482a25", size = 184020, upload-time = "2026-05-22T16:57:38.503Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/b4/71425e3e38be92611300b9cc5e46a5bf98ab23f5ea8a75b73d02a2f1413c/langgraph_checkpoint-4.1.1-py3-none-any.whl", hash = "sha256:25d29144b082827218e7bc3f1e9b0566a4bb007895cd6cc26f66a8428739f56e", size = 56212, upload-time = "2026-05-22T16:57:37.203Z" },
+]
+
+[[package]]
+name = "langgraph-prebuilt"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "langchain-core" },
+    { name = "langgraph-checkpoint" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/29/66/ed9b93f56bc17ef22d551892f0ac2b225a97fe0fcf23a511b857f70d590b/langgraph_prebuilt-1.1.0.tar.gz", hash = "sha256:3c579cf6eed2d17f9c157c2d0fcaddcd8688524e7022d3b22b37a3bf4589d528", size = 178833, upload-time = "2026-05-12T03:37:49.332Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/43/3fe1a700b8490ed02679cdbbc8c915eb23a092faf496c9c1118abcd10be3/langgraph_prebuilt-1.1.0-py3-none-any.whl", hash = "sha256:51e311747d755b751d5c6b39b0c1446124d3a7643d2515017e6714b323508fc9", size = 41043, upload-time = "2026-05-12T03:37:48.007Z" },
+]
+
+[[package]]
+name = "langgraph-sdk"
+version = "0.3.15"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "orjson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/af/cdd4d6f3c05b3c1112ed3f12ef830faf15951b21d22cbc622a4becbbe25c/langgraph_sdk-0.3.15.tar.gz", hash = "sha256:29e805003d2c6e296823dd71992610976fd0428cefaa8b3304fd91f2247037de", size = 201924, upload-time = "2026-05-22T16:54:27.678Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/a5/0196d9c05749c25bc198e4909d68c998bc3120297e14944921baf2f4c384/langgraph_sdk-0.3.15-py3-none-any.whl", hash = "sha256:3838773acf7456d158165385d49f48f1e856f28b56ccd99ea139a8f27004815d", size = 98166, upload-time = "2026-05-22T16:54:26.013Z" },
+]
+
+[[package]]
+name = "langsmith"
+version = "0.8.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "httpx" },
+    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "packaging" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "requests-toolbelt" },
+    { name = "uuid-utils" },
+    { name = "xxhash" },
+    { name = "zstandard" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/eb/8883d1158c743d0aac350f09df7880714d27283497e8c80bb9fe3480f165/langsmith-0.8.5.tar.gz", hash = "sha256:3615243d99c12f4047f13042bdc05a373dce232d106a6511b3ca7b48c5af1c2c", size = 4462348, upload-time = "2026-05-15T21:31:41.093Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/85/968c88a63e32a59b3e5c68afd2fe114ce0708a125db0be1a85efc25fb2ea/langsmith-0.8.5-py3-none-any.whl", hash = "sha256:efc779f9d450dcaf9d97bc8894f4926276509d6e730e05289af9a64debce06ae", size = 399564, upload-time = "2026-05-15T21:31:39.046Z" },
+]
+
+[[package]]
+name = "openai"
+version = "2.38.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "tqdm" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/12/cfa322c5f5dd8fa21aab9a7a8e979e7a11123800f86ca8d82eb68a83d213/openai-2.38.0.tar.gz", hash = "sha256:798694c6cf74145541fda94325b6f8f72d8e1fd0262cc137c8d728177a6a4ce3", size = 772764, upload-time = "2026-05-21T21:23:42.105Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/bf/ccff9be562e24207716d04ef9dc931c76aff0c89a7265da43e2104d7fe06/openai-2.38.0-py3-none-any.whl", hash = "sha256:ec6661c57b2dcc47414a767e6e3335c7ed3d19c9696999283a3c82e95c756a3c", size = 1344910, upload-time = "2026-05-21T21:23:39.636Z" },
+]
+
+[[package]]
+name = "openpyxl"
+version = "3.1.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "et-xmlfile" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/f9/88d94a75de065ea32619465d2f77b29a0469500e99012523b91cc4141cd1/openpyxl-3.1.5.tar.gz", hash = "sha256:cf0e3cf56142039133628b5acffe8ef0c12bc902d2aadd3e0fe5878dc08d1050", size = 186464, upload-time = "2024-06-28T14:03:44.161Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c0/da/977ded879c29cbd04de313843e76868e6e13408a94ed6b987245dc7c8506/openpyxl-3.1.5-py2.py3-none-any.whl", hash = "sha256:5282c12b107bffeef825f4617dc029afaf41d0ea60823bbb665ef3079dc79de2", size = 250910, upload-time = "2024-06-28T14:03:41.161Z" },
+]
+
+[[package]]
+name = "orjson"
+version = "3.11.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/0c/964746fcafbd16f8ff53219ad9f6b412b34f345c75f384ad434ceaadb538/orjson-3.11.9.tar.gz", hash = "sha256:4fef17e1f8722c11587a6ef18e35902450221da0028e65dbaaa543619e68e48f", size = 5599163, upload-time = "2026-05-06T15:11:08.309Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/6d/11867a3ffa3a3608d84a4de51ef4dd0896d6b5cc9132fbe1daf593e677bc/orjson-3.11.9-cp312-cp312-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:9ef6fe90aadef185c7b128859f40beb24720b4ecea95379fc9000931179c3a49", size = 228515, upload-time = "2026-05-06T15:09:57.265Z" },
+    { url = "https://files.pythonhosted.org/packages/24/75/05912954c8b288f34fcf5cd4b9b071cb4f6e77b9961e175e56ebb258089f/orjson-3.11.9-cp312-cp312-macosx_15_0_arm64.whl", hash = "sha256:e5c9b8f28e726e97d97696c826bc7bea5d71cecd63576dba92924a32c1961291", size = 128409, upload-time = "2026-05-06T15:09:59.063Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/86/1c3a47df3bc8191ea9ac51603bbb872a95167a364320c269f2557911f406/orjson-3.11.9-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:26a473dbb4162108b27901492546f83c76fdcea3d0eadff00ae7a07e18dcce09", size = 132106, upload-time = "2026-05-06T15:10:00.798Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cf/b33b5f3e695ae7d63feef9d915c37cc3b8f465493dcd4f8e0b4c697a2366/orjson-3.11.9-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:011382e2a60fda9d46f1cdee31068cfc52ffe952b587d683ec0463002802a0f4", size = 127864, upload-time = "2026-05-06T15:10:02.15Z" },
+    { url = "https://files.pythonhosted.org/packages/31/6a/6cf69385a58208024fcb8c014e2141b8ce838aba6492b589f8acfff97fab/orjson-3.11.9-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c2d3dc759490128c5c1711a53eeaa8ee1d437fd0038ffd2b6008abf46db3f882", size = 135213, upload-time = "2026-05-06T15:10:03.515Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f8/0b1bd3e8f2efcdd376af5c8cfd79eaf13f018080c0089c80ebd724e3c7fb/orjson-3.11.9-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d8ea516b3726d190e1b4297e6f4e7a8650347ae053868a18163b4dd3641d1fff", size = 145994, upload-time = "2026-05-06T15:10:05.083Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/59/dab79f61044c529d2c81aecdc589b1f833a1c8dec11ba3b1c2498a02ca7e/orjson-3.11.9-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:380cdce7ba24989af81d0a7013d0aaec5d0e2a21734c0e2681b1bc4f141957fe", size = 132744, upload-time = "2026-05-06T15:10:06.853Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/a4/82b7a2fe5d8a67a59ed831b24d59a3d46ea7d207b66e1602d376541d94a6/orjson-3.11.9-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:be4fa4f0af7fa18951f7ab3fc2148e223af211bf03f59e1c6034ec3f97f21d61", size = 134014, upload-time = "2026-05-06T15:10:08.213Z" },
+    { url = "https://files.pythonhosted.org/packages/50/c7/375e83a76851b73b2e39f3bcf0e5a19e2b89bad13e5bca97d0b293d27f24/orjson-3.11.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a8f5f8bc7ce7d59f08d9f99fa510c06496164a24cb5f3d34537dbd9ca30132e2", size = 141509, upload-time = "2026-05-06T15:10:09.595Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/7c/49d5d82a3d3097f641f094f552131f1e2723b0b8cb0fa2874ab65ecfffa6/orjson-3.11.9-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:4d7fde5501b944f83b3e665e1b31343ff6e154b15560a16b7130ea1e594a4206", size = 415127, upload-time = "2026-05-06T15:10:11.049Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/dc/7446c538590d55f455647e5f3c61fc33f7108714e7afcffa6a2a033f8350/orjson-3.11.9-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:cde1a448023ba7d5bb4c01c5afb48894380b5e4956e0627266526587ef4e535f", size = 148025, upload-time = "2026-05-06T15:10:12.842Z" },
+    { url = "https://files.pythonhosted.org/packages/df/e5/4d2d8af06f788329b4f78f8cc3679bb395392fcaa1e4d8d3c33e85308fa4/orjson-3.11.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:71e63adb0e1f1ed5d9e168f50a91ceb93ae6420731d222dc7da5c69409aa47aa", size = 136943, upload-time = "2026-05-06T15:10:14.405Z" },
+    { url = "https://files.pythonhosted.org/packages/06/69/850264ccf6d80f6b174620d30a87f65c9b1490aba33fe6b62798e618cad3/orjson-3.11.9-cp312-cp312-win32.whl", hash = "sha256:2d057a602cdd19a0ad680417527c45b6961a095081c0f46fe0e03e304aac6470", size = 131606, upload-time = "2026-05-06T15:10:15.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d5/973a43fc9c55e20f2051e9830997649f669be0cb3ca52192087c0143f118/orjson-3.11.9-cp312-cp312-win_amd64.whl", hash = "sha256:59e403b1cc5a676da8eaf31f6254801b7341b3e29efa85f92b48d272637e77be", size = 127101, upload-time = "2026-05-06T15:10:17.129Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/ae/495470f0e4a18f73fa10b7f6b84b464ec4cc5291c4e0c7c2a6c400bef006/orjson-3.11.9-cp312-cp312-win_arm64.whl", hash = "sha256:9af678d6488357948f1f84c6cd1c1d397c014e1ae2f98ae082a44eb48f602624", size = 126736, upload-time = "2026-05-06T15:10:18.645Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/93fcc25907235c344ae73122f8a4e01d2d393ef062b4af7d2e2487a32c37/orjson-3.11.9-cp313-cp313-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:4bab1b2d6141fe7b32ae71dac905666ece4f94936efbfb13d55bb7739a3a6021", size = 228458, upload-time = "2026-05-06T15:10:20.079Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/27/b1e6dadb3c080313c03fdd8067b85e6a0460c7d8d6a1c3984ef77b904e4d/orjson-3.11.9-cp313-cp313-macosx_15_0_arm64.whl", hash = "sha256:844417969855fc7a41be124aafe83dc424592a7f77cd4501900c67307122b92c", size = 128368, upload-time = "2026-05-06T15:10:21.549Z" },
+    { url = "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81", size = 132070, upload-time = "2026-05-06T15:10:23.371Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/26/d398e28048dc18205bbe812f2c88cb9b40313db2470778e25964796458fe/orjson-3.11.9-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e4eed3b200023042814d2fc8a5d2e880f13b52e1ed2485e83da4f3962f7dc1a", size = 127892, upload-time = "2026-05-06T15:10:24.714Z" },
+    { url = "https://files.pythonhosted.org/packages/66/60/52b0054c4c700d5aa7fc5b7ca96917400d8f061307778578e67a10e25852/orjson-3.11.9-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8aff7da9952a5ad1cef8e68017724d96c7b9a66e99e91d6252e1b133d67a7b10", size = 135217, upload-time = "2026-05-06T15:10:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/97/1e3dc2b2a28b7b2528f403d2fc1d79ec5f39af3bc143ab65d3ec26426385/orjson-3.11.9-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4d4e98d6f3b8afed8bc8cd9718ec0cdf46661826beefb53fe8eafb37f2bf0362", size = 145980, upload-time = "2026-05-06T15:10:28.062Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/39/31fbfe7850f2de32dee7e7e5c09f26d403ab01e440ac96001c6b01ad3c99/orjson-3.11.9-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3a81d52442a7c99b3662333235b3adf96a1715864658b35bb797212be7bddb97", size = 132738, upload-time = "2026-05-06T15:10:29.727Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218", size = 134033, upload-time = "2026-05-06T15:10:31.152Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d4/5bdb0626801230139987385554c5d4c42255218ac906525bf4347f22cd95/orjson-3.11.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4fd66214623f1b17501df9f0543bef0b833979ab5b6ded1e1d123222866aa8c9", size = 141492, upload-time = "2026-05-06T15:10:32.641Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/88/a21fb53b3ede6703aede6dce4710ed4111e5b201cfa6bbff5e544f9d47d7/orjson-3.11.9-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:8ecc30f10465fa1e0ce13fd01d9e22c316e5053a719a8d915d4545a09a5ff677", size = 415087, upload-time = "2026-05-06T15:10:34.438Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/57/1b30daf70f0d8180e9a73cefbfbdd99e4bf19eb020466502b01fba7e0e50/orjson-3.11.9-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:97db4c94a7db398a5bd636273324f0b3fd58b350bbbac8bb380ceb825a9b40f4", size = 148031, upload-time = "2026-05-06T15:10:36.358Z" },
+    { url = "https://files.pythonhosted.org/packages/04/83/45fbb6d962e260807f99441db9613cee868ceda4baceda59b3720a563f97/orjson-3.11.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9f78cf8fec5bd627f4082b8dfeac7871b43d7f3274904492a43dab39f18a19a0", size = 136915, upload-time = "2026-05-06T15:10:38.013Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/cc/2d10025f9056d376e4127ec05a5808b218d46f035fdc08178a5411b34250/orjson-3.11.9-cp313-cp313-win32.whl", hash = "sha256:d4087e5c0209a0a8efe4de3303c234b9c44d1174161dcd851e8eea07c7560b32", size = 131613, upload-time = "2026-05-06T15:10:39.569Z" },
+    { url = "https://files.pythonhosted.org/packages/67/bd/2775ff28bfe883b9aa1ff348300542eb2ef1ee18d8ae0e3a49846817a865/orjson-3.11.9-cp313-cp313-win_amd64.whl", hash = "sha256:051b102c93b4f634e89f3866b07b9a9a98915ada541f4ec30f177067b2694979", size = 127086, upload-time = "2026-05-06T15:10:41.262Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2b/d26799e580939e32a7da9a39531bc9e58e15ca32ffaa6a8cb3e9bb0d22cd/orjson-3.11.9-cp313-cp313-win_arm64.whl", hash = "sha256:cce9127885941bd28f080cecf1f1d288336b7e0d812c345b08be88b572796254", size = 126696, upload-time = "2026-05-06T15:10:42.651Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/eb/5da01e356015aee6ecfa1187ced87aef51364e306f5e695dd52719bf0e78/orjson-3.11.9-cp314-cp314-macosx_10_15_x86_64.macosx_11_0_arm64.macosx_10_15_universal2.whl", hash = "sha256:b6ef1979adc4bc243523f1a2ba91418030a8e29b0a99cbe7e0e2d6807d4dce6e", size = 228465, upload-time = "2026-05-06T15:10:44.097Z" },
+    { url = "https://files.pythonhosted.org/packages/64/62/3e0e0c14c957133bcd855395c62b55ed4e3b0af23ffea11b032cb1dcbdb1/orjson-3.11.9-cp314-cp314-macosx_15_0_arm64.whl", hash = "sha256:f36b7f32c7c0db4a719f1fc5824db4a9c6f8bd1a354debb91faf26ebf3a4c71e", size = 128364, upload-time = "2026-05-06T15:10:45.839Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5a/07d8aa117211a8ed7630bda80c8c0b14d04e0f8dcf99bcf49656e4a710eb/orjson-3.11.9-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:08f4d8ebb44925c794e535b2bebc507cebf32209df81de22ae285fb0d8d66de0", size = 132063, upload-time = "2026-05-06T15:10:47.267Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/ec/4acaf21483e18aa945be74a474c74b434f284b549f275a0a39b9f98956e9/orjson-3.11.9-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6cc7923789694fd58f001cbcac7e47abc13af4d560ebbfcf3b41a8b1a0748124", size = 122356, upload-time = "2026-05-06T15:10:48.765Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d8/5f0555e7638801323b7a75850f92e7dfa891bc84fe27a1ba4449170d1200/orjson-3.11.9-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ea5c46eb2d3af39e806b986f4b09d5c2706a1f5afde3cbf7544ce6616127173c", size = 129592, upload-time = "2026-05-06T15:10:50.13Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/30/ed9860412a3603ceb3c5955bfd72d28b9d0e7ba6ed81add14f83d7114236/orjson-3.11.9-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f5d89a2ed90731df3be64bab0aa44f78bff39fdc9d71c291f4a8023aa46425b7", size = 140491, upload-time = "2026-05-06T15:10:51.582Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/17/adc514dea7ac7c505527febf884934b815d34f0c7b8693c1a8b39c5c4a57/orjson-3.11.9-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:25e4aed0312d292c09f61af25bba34e0b2c88546041472b09088c39a4d828af1", size = 127309, upload-time = "2026-05-06T15:10:53.329Z" },
+    { url = "https://files.pythonhosted.org/packages/76/3e/c0b690253f0b82d86e99949af13533363acfb5432ecb5d53dd5b3bce9c34/orjson-3.11.9-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aaea64f3f467d22e70eeed68bdccb3bc4f83f650446c4a03c59f2cba28a108db", size = 134030, upload-time = "2026-05-06T15:10:54.988Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7a/bc82a0bb25e9faaf92dc4d9ef002732efc09737706af83e346788641d4a7/orjson-3.11.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a028425d1b440c5d92a6be1e1a020739dfe67ea87d96c6dbe828c1b30041728b", size = 141482, upload-time = "2026-05-06T15:10:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/01/55/e69188b939f77d5d32a9833745ace31ea5ccae3ab613a1ec185d3cd2c4fb/orjson-3.11.9-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:5b192c6cf397e4455b11523c5cf2b18ed084c1bbd61b6c0926344d2129481972", size = 415178, upload-time = "2026-05-06T15:10:58.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1a/b8a5a7ac527e80b9cb11d51e3f6689b709279183264b9ec5c7bc680bb8b5/orjson-3.11.9-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ea407d4ccf5891d667d045fecae97a7a1e5e87b3b97f97ae1803c2e741130be0", size = 148089, upload-time = "2026-05-06T15:11:00.441Z" },
+    { url = "https://files.pythonhosted.org/packages/97/4e/00503f64204bf859b37213a63927028f30fb6268cd8677fb0a5ad48155e1/orjson-3.11.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f63aaf97afd9f6dec5b1a68e1b8da12bfccb4cb9a9a65c3e0b6c847849e7586", size = 136921, upload-time = "2026-05-06T15:11:02.176Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/ba/a23b82a0a8d0ed7bed4e5f5035aae751cad4ff6a1e8d2ecd14d8860f5929/orjson-3.11.9-cp314-cp314-win32.whl", hash = "sha256:e30ab17845bb9fa54ccf67fa4f9f5282652d54faa6d17452f47d0f369d038673", size = 131638, upload-time = "2026-05-06T15:11:03.696Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c3/0c6798456bade745c75c452342dabacce5798196483e77e643be1f53877d/orjson-3.11.9-cp314-cp314-win_amd64.whl", hash = "sha256:32ef5f4283a3be81913947d19608eacb7c6608026851123790cd9cc8982af34b", size = 127078, upload-time = "2026-05-06T15:11:05.123Z" },
+    { url = "https://files.pythonhosted.org/packages/16/21/5a3f1e8913103b703a436a5664238e5b965ec392b555fe68943ea3691e6b/orjson-3.11.9-cp314-cp314-win_arm64.whl", hash = "sha256:eebdbdeef0094e4f5aefa20dcd4eb2368ab5e7a3b4edea27f1e7b2892e009cf9", size = 126687, upload-time = "2026-05-06T15:11:06.602Z" },
+]
+
+[[package]]
+name = "ormsgpack"
+version = "1.12.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/12/0c/f1761e21486942ab9bb6feaebc610fa074f7c5e496e6962dea5873348077/ormsgpack-1.12.2.tar.gz", hash = "sha256:944a2233640273bee67521795a73cf1e959538e0dfb7ac635505010455e53b33", size = 39031, upload-time = "2026-01-18T20:55:28.023Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4c/36/16c4b1921c308a92cef3bf6663226ae283395aa0ff6e154f925c32e91ff5/ormsgpack-1.12.2-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7a29d09b64b9694b588ff2f80e9826bdceb3a2b91523c5beae1fab27d5c940e7", size = 378618, upload-time = "2026-01-18T20:55:50.835Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/68/468de634079615abf66ed13bb5c34ff71da237213f29294363beeeca5306/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0b39e629fd2e1c5b2f46f99778450b59454d1f901bc507963168985e79f09c5d", size = 203186, upload-time = "2026-01-18T20:56:11.163Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a9/d756e01961442688b7939bacd87ce13bfad7d26ce24f910f6028178b2cc8/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:958dcb270d30a7cb633a45ee62b9444433fa571a752d2ca484efdac07480876e", size = 210738, upload-time = "2026-01-18T20:56:09.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ba/795b1036888542c9113269a3f5690ab53dd2258c6fb17676ac4bd44fcf94/ormsgpack-1.12.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58d379d72b6c5e964851c77cfedfb386e474adee4fd39791c2c5d9efb53505cc", size = 212569, upload-time = "2026-01-18T20:56:06.135Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/aa/bff73c57497b9e0cba8837c7e4bcab584b1a6dbc91a5dd5526784a5030c8/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8463a3fc5f09832e67bdb0e2fda6d518dc4281b133166146a67f54c08496442e", size = 387166, upload-time = "2026-01-18T20:55:36.738Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/cf/f8283cba44bcb7b14f97b6274d449db276b3a86589bdb363169b51bc12de/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:eddffb77eff0bad4e67547d67a130604e7e2dfbb7b0cde0796045be4090f35c6", size = 482498, upload-time = "2026-01-18T20:55:29.626Z" },
+    { url = "https://files.pythonhosted.org/packages/05/be/71e37b852d723dfcbe952ad04178c030df60d6b78eba26bfd14c9a40575e/ormsgpack-1.12.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fcd55e5f6ba0dbce624942adf9f152062135f991a0126064889f68eb850de0dd", size = 425518, upload-time = "2026-01-18T20:55:49.556Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/0c/9803aa883d18c7ef197213cd2cbf73ba76472a11fe100fb7dab2884edf48/ormsgpack-1.12.2-cp312-cp312-win_amd64.whl", hash = "sha256:d024b40828f1dde5654faebd0d824f9cc29ad46891f626272dd5bfd7af2333a4", size = 117462, upload-time = "2026-01-18T20:55:47.726Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/9e/029e898298b2cc662f10d7a15652a53e3b525b1e7f07e21fef8536a09bb8/ormsgpack-1.12.2-cp312-cp312-win_arm64.whl", hash = "sha256:da538c542bac7d1c8f3f2a937863dba36f013108ce63e55745941dda4b75dbb6", size = 111559, upload-time = "2026-01-18T20:55:54.273Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/29/bb0eba3288c0449efbb013e9c6f58aea79cf5cb9ee1921f8865f04c1a9d7/ormsgpack-1.12.2-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:5ea60cb5f210b1cfbad8c002948d73447508e629ec375acb82910e3efa8ff355", size = 378661, upload-time = "2026-01-18T20:55:57.765Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/31/5efa31346affdac489acade2926989e019e8ca98129658a183e3add7af5e/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f3601f19afdbea273ed70b06495e5794606a8b690a568d6c996a90d7255e51c1", size = 203194, upload-time = "2026-01-18T20:56:08.252Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/56/d0087278beef833187e0167f8527235ebe6f6ffc2a143e9de12a98b1ce87/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:29a9f17a3dac6054c0dce7925e0f4995c727f7c41859adf9b5572180f640d172", size = 210778, upload-time = "2026-01-18T20:55:17.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a2/072343e1413d9443e5a252a8eb591c2d5b1bffbe5e7bfc78c069361b92eb/ormsgpack-1.12.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:39c1bd2092880e413902910388be8715f70b9f15f20779d44e673033a6146f2d", size = 212592, upload-time = "2026-01-18T20:55:32.747Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/8b/a0da3b98a91d41187a63b02dda14267eefc2a74fcb43cc2701066cf1510e/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:50b7249244382209877deedeee838aef1542f3d0fc28b8fe71ca9d7e1896a0d7", size = 387164, upload-time = "2026-01-18T20:55:40.853Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bb/6d226bc4cf9fc20d8eb1d976d027a3f7c3491e8f08289a2e76abe96a65f3/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:5af04800d844451cf102a59c74a841324868d3f1625c296a06cc655c542a6685", size = 482516, upload-time = "2026-01-18T20:55:42.033Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f1/bb2c7223398543dedb3dbf8bb93aaa737b387de61c5feaad6f908841b782/ormsgpack-1.12.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cec70477d4371cd524534cd16472d8b9cc187e0e3043a8790545a9a9b296c258", size = 425539, upload-time = "2026-01-18T20:55:24.727Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/e8/0fb45f57a2ada1fed374f7494c8cd55e2f88ccd0ab0a669aa3468716bf5f/ormsgpack-1.12.2-cp313-cp313-win_amd64.whl", hash = "sha256:21f4276caca5c03a818041d637e4019bc84f9d6ca8baa5ea03e5cc8bf56140e9", size = 117459, upload-time = "2026-01-18T20:55:56.876Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d4/0cfeea1e960d550a131001a7f38a5132c7ae3ebde4c82af1f364ccc5d904/ormsgpack-1.12.2-cp313-cp313-win_arm64.whl", hash = "sha256:baca4b6773d20a82e36d6fd25f341064244f9f86a13dead95dd7d7f996f51709", size = 111577, upload-time = "2026-01-18T20:55:43.605Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/24d18851334be09c25e87f74307c84950f18c324a4d3c0b41dabdbf19c29/ormsgpack-1.12.2-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:bc68dd5915f4acf66ff2010ee47c8906dc1cf07399b16f4089f8c71733f6e36c", size = 378717, upload-time = "2026-01-18T20:55:26.164Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/a2/88b9b56f83adae8032ac6a6fa7f080c65b3baf9b6b64fd3d37bd202991d4/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:46d084427b4132553940070ad95107266656cb646ea9da4975f85cb1a6676553", size = 203183, upload-time = "2026-01-18T20:55:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/43e4555963bf602e5bdc79cbc8debd8b6d5456c00d2504df9775e74b450b/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c010da16235806cf1d7bc4c96bf286bfa91c686853395a299b3ddb49499a3e13", size = 210814, upload-time = "2026-01-18T20:55:33.973Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e1/7cfbf28de8bca6efe7e525b329c31277d1b64ce08dcba723971c241a9d60/ormsgpack-1.12.2-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:18867233df592c997154ff942a6503df274b5ac1765215bceba7a231bea2745d", size = 212634, upload-time = "2026-01-18T20:55:28.634Z" },
+    { url = "https://files.pythonhosted.org/packages/95/f8/30ae5716e88d792a4e879debee195653c26ddd3964c968594ddef0a3cc7e/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b009049086ddc6b8f80c76b3955df1aa22a5fbd7673c525cd63bf91f23122ede", size = 387139, upload-time = "2026-01-18T20:56:02.013Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/81/aee5b18a3e3a0e52f718b37ab4b8af6fae0d9d6a65103036a90c2a8ffb5d/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:1dcc17d92b6390d4f18f937cf0b99054824a7815818012ddca925d6e01c2e49e", size = 482578, upload-time = "2026-01-18T20:55:35.117Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/17/71c9ba472d5d45f7546317f467a5fc941929cd68fb32796ca3d13dcbaec2/ormsgpack-1.12.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f04b5e896d510b07c0ad733d7fce2d44b260c5e6c402d272128f8941984e4285", size = 425539, upload-time = "2026-01-18T20:56:04.009Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/a6/ac99cd7fe77e822fed5250ff4b86fa66dd4238937dd178d2299f10b69816/ormsgpack-1.12.2-cp314-cp314-win_amd64.whl", hash = "sha256:ae3aba7eed4ca7cb79fd3436eddd29140f17ea254b91604aa1eb19bfcedb990f", size = 117493, upload-time = "2026-01-18T20:56:07.343Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/67/339872846a1ae4592535385a1c1f93614138566d7af094200c9c3b45d1e5/ormsgpack-1.12.2-cp314-cp314-win_arm64.whl", hash = "sha256:118576ea6006893aea811b17429bfc561b4778fad393f5f538c84af70b01260c", size = 111579, upload-time = "2026-01-18T20:55:21.161Z" },
+    { url = "https://files.pythonhosted.org/packages/49/c2/6feb972dc87285ad381749d3882d8aecbde9f6ecf908dd717d33d66df095/ormsgpack-1.12.2-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:7121b3d355d3858781dc40dafe25a32ff8a8242b9d80c692fd548a4b1f7fd3c8", size = 378721, upload-time = "2026-01-18T20:55:52.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/9a/900a6b9b413e0f8a471cf07830f9cf65939af039a362204b36bd5b581d8b/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ee766d2e78251b7a63daf1cddfac36a73562d3ddef68cacfb41b2af64698033", size = 203170, upload-time = "2026-01-18T20:55:44.469Z" },
+    { url = "https://files.pythonhosted.org/packages/87/4c/27a95466354606b256f24fad464d7c97ab62bce6cc529dd4673e1179b8fb/ormsgpack-1.12.2-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:292410a7d23de9b40444636b9b8f1e4e4b814af7f1ef476e44887e52a123f09d", size = 212816, upload-time = "2026-01-18T20:55:23.501Z" },
+    { url = "https://files.pythonhosted.org/packages/73/cd/29cee6007bddf7a834e6cd6f536754c0535fcb939d384f0f37a38b1cddb8/ormsgpack-1.12.2-cp314-cp314t-win_amd64.whl", hash = "sha256:837dd316584485b72ef451d08dd3e96c4a11d12e4963aedb40e08f89685d8ec2", size = 117232, upload-time = "2026-01-18T20:55:45.448Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+]
+
+[[package]]
+name = "pydantic-settings"
+version = "2.14.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/07/60/1d1e59c9c90d54591469ada7d268251f71c24bdb765f1a8a832cee8c6653/pydantic_settings-2.14.1.tar.gz", hash = "sha256:e874d3bec7e787b0c9958277956ed9b4dd5de6a80e162188fdaff7c5e26fd5fa", size = 235551, upload-time = "2026-05-08T13:40:06.542Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/8d/f1af3832f5e6eb13ba94ee809e72b8ecb5eef226d27ee0bef7d963d943c7/pydantic_settings-2.14.1-py3-none-any.whl", hash = "sha256:6e3c7edfd8277687cdc598f56e5cff0e9bfff0910a3749deaa8d4401c3a2b9de", size = 60964, upload-time = "2026-05-08T13:40:04.958Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
+]
+
+[[package]]
+name = "requests-toolbelt"
+version = "1.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.14"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/8a/8bce2894573e9dae6ff4d77fe34ad727d79b9e6238ad288c5638990d90f6/ruff-0.15.14.tar.gz", hash = "sha256:48e866b165be4a9bdbf310f7d3c9a07edef2fe8cd63ffeb4e00bb590506ebf9f", size = 4700910, upload-time = "2026-05-21T14:34:55.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/c8/74a92c6ff9fcfb4f1f947126d3ebee8389276e161ecc85de5bda7cda51bd/ruff-0.15.14-py3-none-linux_armv6l.whl", hash = "sha256:8dd2db9416e487c8d4b01fa7056bb02c4d05969d4f8d17a08c229c2f4ff3c108", size = 10739177, upload-time = "2026-05-21T14:34:37.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/254a35c20acc38a7223c9d2d594af12e794432464f2cdeb52af1dc4a892d/ruff-0.15.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:be4ff55af755bd71a00ab3dc6bd7ffc467bd76e0df6881e286c2e3d23e8fb43b", size = 11144969, upload-time = "2026-05-21T14:34:43.978Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9e/d13e40f83b8d0a94430e6778ce1d94a43b38cf2efe63278bdd2b4c65abbf/ruff-0.15.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:48d5909d7d06276ce7dde6d32bfa4b0d4cb2651145cd8ee4b440722cbc77832f", size = 10478207, upload-time = "2026-05-21T14:34:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/f1/b15a7839fa4f332f8acec78e20564f26bb2d866e3d21710b877fd0263000/ruff-0.15.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca8cbfa94c4f90984a67561978602746d4cd27103568f745fa90eee3f0d4107d", size = 10818459, upload-time = "2026-05-21T14:34:22.318Z" },
+    { url = "https://files.pythonhosted.org/packages/45/33/53d651177f84f94b400a0e27f8824eeada3dddc9d5ee8aeb048f4352a520/ruff-0.15.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9a6bbc0333f1ab053423bcbf6226477d266ca7cec7738c4c8e3f55647803f3c4", size = 10541800, upload-time = "2026-05-21T14:34:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/a6/868f87e0bf9786ed24b5d0d0ad8676b8a94fd1912f42cddf9cfc7857818a/ruff-0.15.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a24a4f7605d7003a6674d4387651effd939dead3fddd0f36561eb77a9a2e542", size = 11342149, upload-time = "2026-05-21T14:34:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/8b/38cd5c19faffdcc05a408d2b78edccc69492ab9720eadb49ea15ef80d768/ruff-0.15.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:049b5326e53ed80978f2fc041a280603f69dd6b0c95464342a2bb4572d9d9e2f", size = 12212563, upload-time = "2026-05-21T14:34:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/4d/a3c5b874a556d5731e3e657aaf04311bb76f0a5c3ec220ed43051be6b64b/ruff-0.15.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4ed42e6696c8dfa5f06728e6441993901f548eb92d73bc472cb5a38d1395fbf", size = 11493299, upload-time = "2026-05-21T14:34:41.836Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c0/56472c251d09858a53e51efbd485b09e1995d8731668b76d52e5dd6ee0f1/ruff-0.15.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:715c543cf450c4888251f91c52f1942a800541d9bddd7ac060aa4e6b77ae7cba", size = 11455931, upload-time = "2026-05-21T14:34:57.276Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/4a/e2e7b4d8dbf233d4eace59c75bc3435fa6d8bd3bae82d351d4e4300c0fd1/ruff-0.15.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ebab6013ec887d439d8b7593737a0a4ffb06d45d209d4e4bf2e92813082d3f", size = 11400794, upload-time = "2026-05-21T14:34:39.773Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c7/83c0539fe34c3e09136204d1e75d6052492364e0b3cb05e9465423f567d7/ruff-0.15.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:49072d36abdbe97a8dd7f480afe9c675699c0c495d4c84076e2c1203c4550581", size = 10804759, upload-time = "2026-05-21T14:34:31.045Z" },
+    { url = "https://files.pythonhosted.org/packages/86/a6/18f2bfc095a2ab4a78745644e428205532ce6653a5d0fa8501572891534d/ruff-0.15.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:958522aee105068640c2c2ceae08f413ae44d922f52a1374ac13d6a96032fc93", size = 10539517, upload-time = "2026-05-21T14:34:53.064Z" },
+    { url = "https://files.pythonhosted.org/packages/54/3a/5a8b3b69c654d4e4bf1d246ac5b49cbcdac6eaab6905925f8915f31e3b80/ruff-0.15.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:f3707da619a143a2e8830e2abab8224478d69ace2d28cb6c20543ae97c36bf61", size = 11065169, upload-time = "2026-05-21T14:34:24.484Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/c5/8864e4e7925b836ea354b31d57641ec03830564e281a8b6f061f8c3e0ec1/ruff-0.15.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:bb01d645694e3ec0102105d07ef2d53703970407d59c04e59d3ba0b7a1d53553", size = 11560214, upload-time = "2026-05-21T14:34:50.975Z" },
+    { url = "https://files.pythonhosted.org/packages/36/38/012bf76752e1f89ed50b77b99532d90f3a3e287bc7918e1fc0948ac866ac/ruff-0.15.14-py3-none-win32.whl", hash = "sha256:6d0c1ad2a0ab718d39b6d8fd2217981ce4d625cd96a720095f798fb47d8b13e6", size = 10805548, upload-time = "2026-05-21T14:34:33.453Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/4ea2c170f10ad760fff2a5250beb18897719dc8b52b53a24cddbb9dd3f19/ruff-0.15.14-py3-none-win_amd64.whl", hash = "sha256:802342981e056db3851a7836e5b070f8f15f67d4a685ae2a6160939d364b2902", size = 11939523, upload-time = "2026-05-21T14:34:18.077Z" },
+    { url = "https://files.pythonhosted.org/packages/62/d5/bc97ff895ec35cf3925d4bd60f3b39d822f377a446906ec9bcc87405e59b/ruff-0.15.14-py3-none-win_arm64.whl", hash = "sha256:ff47b90a9ef6a40c9e2f3b479c1fb78531adf055b94c1eba0a7ba04b31951826", size = 11208607, upload-time = "2026-05-21T14:34:26.525Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
+]
+
+[[package]]
+name = "tiktoken"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "regex" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/e5/5f3cb2159769d0f4324c0e9e87f9de3c4b1cd45848a96b2eb3566ad5ca77/tiktoken-0.13.0.tar.gz", hash = "sha256:c9435714c3a84c2319499de9a300c0e604449dd0799ff246458b3bb6a7f433c1", size = 38986, upload-time = "2026-05-15T04:51:27.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/8e/144bde4e01df66b34bb865557c7cd754ed08b036217ebd79c9db5e9048a9/tiktoken-0.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:32ac870a806cfb260a02d0cb70426aef02e038297f8ad50df5040bb5af360791", size = 1034888, upload-time = "2026-05-15T04:50:31.579Z" },
+    { url = "https://files.pythonhosted.org/packages/36/18/d4ac9d20956cdebca04841316660ed584c2fecdc2b81722a28bc7ad3b1e4/tiktoken-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4d9980f11429ed2d737c463bb1fb78cf330caa026adf002f714aced7849a687b", size = 982970, upload-time = "2026-05-15T04:50:32.961Z" },
+    { url = "https://files.pythonhosted.org/packages/74/ed/6bb8d05b9f731f749fee5c6f5ca63e981143c826a5985877330507bd13b7/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:3f277ebea5edd7b8bf03c6f9431e1d67d517530115572b2dc1d465326e8f88c7", size = 1115741, upload-time = "2026-05-15T04:50:34.475Z" },
+    { url = "https://files.pythonhosted.org/packages/34/de/2ca96b07a82d972b74fe4b46de055b79c904e45c7eab699354a0bfa697dc/tiktoken-0.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:a116178fa7e1b4065bff05214360373a65cac22f965be7b3f73d00a0dbfe7649", size = 1136523, upload-time = "2026-05-15T04:50:35.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/dc/9dafec002c2d4424378563cf4cf5c7fb93631d2a55013c8b87554ee4012c/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2c397ddda233208345b01bd30f2fca79ff730e55731d0108a603f9bc57f6af3b", size = 1181954, upload-time = "2026-05-15T04:50:36.99Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/d0/1f8578c45b2f24759b46f0b50d31878c63c73e6bf0f2227e10ec5c5408dc/tiktoken-0.13.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:95097e4f89b06403976e498abf61a0ee73a7497e73fb599cb211d8197a054d91", size = 1240069, upload-time = "2026-05-15T04:50:38.221Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/90/28d7f154888610aa9237e541986beb62b479df29d193a5a0617dbb1514d0/tiktoken-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:8f2d16e7a7c783ad81f36e457d046d1f1c8af70b22aec8a13238efe531977c41", size = 874748, upload-time = "2026-05-15T04:50:39.587Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/83/b096c859c2a47c11731bf2f5885f4028b809dfe2396582883eed9cae372f/tiktoken-0.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5df5d1507bd245f1ccad4a074698240021239e455eb0bb4ced4e3d7181872154", size = 1034228, upload-time = "2026-05-15T04:50:40.988Z" },
+    { url = "https://files.pythonhosted.org/packages/53/61/c68e123b6d753e3fc2751e9b18e732c9d8bf1e1926762e736eee935d931c/tiktoken-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8fe806a50664e83a6ffd56cbd1e4f5dcc6cd32a3e7538f70dc38b1a271384545", size = 982978, upload-time = "2026-05-15T04:50:42.195Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/8b/96cc178cc584e65d363134500f297790b06cd48cdeb1e8fcf7bbe60f4715/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:125bc05005e747f993a83dc67934249932d6e4209854452cd4c0b1d53fba3ba2", size = 1116355, upload-time = "2026-05-15T04:50:43.564Z" },
+    { url = "https://files.pythonhosted.org/packages/86/f5/bab735d2c72ea55404b295d02d092644eb5f7cc6205e34d35eb9abfb9ab2/tiktoken-0.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:5e6358911cab4adee6712da27d65573496a4f68cf8a2b5fca6a4ad10fc5748cf", size = 1135772, upload-time = "2026-05-15T04:50:44.782Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/b9/6de04ebdf904edfaad87788011b3735087a0c9ea671b9027e1e4e965e8c8/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:975cbd78d085d75d26b59660e262736dcaed1e35f8f142cd6291025c01d25486", size = 1182415, upload-time = "2026-05-15T04:50:46.422Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/9c/470a05f3b1caf038f44880e334d47ab674e0c80d514c66b375d14d5afa10/tiktoken-0.13.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:75ab9bc99fa020a4c283424590ecd7f3afd70c1c281cb3fa3192a6c3af9f9615", size = 1239879, upload-time = "2026-05-15T04:50:48.052Z" },
+    { url = "https://files.pythonhosted.org/packages/42/a6/c1936d16055436cb32e6c6128d68629622e00f4768562f55653752d34768/tiktoken-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:6b1615f0ff71953d19729ceb18865429c185b0a23c5353f1bbca34a394bf60f7", size = 874829, upload-time = "2026-05-15T04:50:49.202Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/07/acb5992c3772b5a36284f742cfb7a5895aa4471d1848ac31464ad50d7fdf/tiktoken-0.13.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:6eb4a5bfbc6426938026b1a334e898ac53541360d62d8c689870160cc80abd67", size = 1033600, upload-time = "2026-05-15T04:50:50.4Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e9/742e9aec30f59b9f161f7ff7cd072e02ea836c9e1c0854a8076dfcd40d5c/tiktoken-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:43cee3e5400573b2046fbf092cc7a5bc30164f9e4c95ce20714da929df48737a", size = 982516, upload-time = "2026-05-15T04:50:52.03Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/ca1541b053e7648254d2e4b42a253e1bb4359f2c91a0a8d49228c794e1a0/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:7de52e3f566d19b3b11bd37eea552c6c305ad74081f736882bd44d148ed4c48d", size = 1115518, upload-time = "2026-05-15T04:50:53.543Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e3/93825eaf5a4a504795b787e5d5dea07fbeb3dabf97aa7b450be8bde59c89/tiktoken-0.13.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:51384448aa508e4df84c0f7c1dc3211c7f7b8096325660ee5fc82f3e11b381ce", size = 1136867, upload-time = "2026-05-15T04:50:55.191Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/46/002b68de6827091d5ae90b048f326e8aad8d953520950e5ce1508879414f/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:e28157350f7ebf35008dd8e9e0fdb621f976e4230c881099c85e8cf07eaa50e2", size = 1181826, upload-time = "2026-05-15T04:50:56.296Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c6/d393e3185a276505182f7abd93fe714f3c444a2be9180798fa052347504e/tiktoken-0.13.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:165cf1820ea4a354985c2490a5205d4cc74661c934aca79dd0368232fff94e0f", size = 1239489, upload-time = "2026-05-15T04:50:57.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/4d/bc07d1f1635d4897a202acc0ae11c2886eaa7325c359ba4741b47bf8e225/tiktoken-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:6c43a675ca14f6f2749ba7f12075d37456015a24b859f2517b9beb4ef30807ec", size = 873820, upload-time = "2026-05-15T04:50:59.528Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/93/0dd6adca026a616c3a92974566b43381eea4b475ce1f36c062b8271a9ac5/tiktoken-0.13.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaaaef47c2406277181d2086484c317bf7fc433e2d5d03ff94f56b0dcec87471", size = 1034977, upload-time = "2026-05-15T04:51:00.957Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/77/5ec6e6bc5b30bed6d93f7f2162d8f6b32437b3ba27cb527cfe004f6109c9/tiktoken-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ca8b310bd93b3772cb1b7922d915446864860f562bdfe4825c63a0aed3fb28cd", size = 983635, upload-time = "2026-05-15T04:51:02.629Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b0/c8ae9aff00d625c50659b4513e707a0462c4bf5d4d6cc1b802103225c02e/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:32e0c12305105002c047b3bb1070b0dd9a73b0cb3b2856a8972b810e7a4f5881", size = 1116036, upload-time = "2026-05-15T04:51:04.082Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/ac/6a5dddd1d0a6018ecb389bd0353e6b4a515eb4d2286611bd0ace1937b9e1/tiktoken-0.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:5ba5fd62507a932d1241346179e3b39bc7bf7408f03c272652d93b3bedf5db24", size = 1135544, upload-time = "2026-05-15T04:51:05.229Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/b8/585032b4384b2f7dcdaddcb52865c83a701a420d09e3c2b4a2be1c450c57/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d108bc2d470fc53c8ecd24f2c0fd2b5f98c33e87cdb6aa2e9b8c5dced703d273", size = 1182217, upload-time = "2026-05-15T04:51:06.517Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b6/993ff1ded3958215fd341a847b8e5ffeb5de473f435296870d314fc91ac4/tiktoken-0.13.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:cb99cb5127449f58d0a2d5f5ccfb390d8dbdfd919c221246caaee29d8725ed51", size = 1239404, upload-time = "2026-05-15T04:51:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3d/fef7e06e3b33e7538db0ced734cf9fe23b6832d2ac4990c119c377aec55e/tiktoken-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:115c4f26ffa11caac8b54eea35c2ad38c612c20a48d35dd15d70a02ac6f51f58", size = 918686, upload-time = "2026-05-15T04:51:08.925Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/82/a7fc44582bc32ab00de988a2299bf77c077f59068b233109e34b7d6ca7e6/tiktoken-0.13.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:472527e9132952f2fbf77cd290658bacf003d4d5a3fabc18e5fbd407cbae4d9b", size = 1034454, upload-time = "2026-05-15T04:51:10.035Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d0/24d8a890c14f432a05cea669c17bebeaa99f96a7c79523b590f564246411/tiktoken-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e2f67d27c9626cdd25fe33d9313c5cdb3d8d82da646b68d6eb8e7e9c20e6448", size = 982976, upload-time = "2026-05-15T04:51:11.23Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b7/2ab43f62788a9266187a9bfc1d3af99ad83e5eaa25fbef168a69cd5ad14f/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:2b920b35805cd64585a37c3dc7ce65fba4d2d36016be01e1d7942482ca29093a", size = 1115526, upload-time = "2026-05-15T04:51:12.608Z" },
+    { url = "https://files.pythonhosted.org/packages/64/39/1494321ed323ce7a14d88e3cd6cb9058625977df1c6961ddc492bd10a9f3/tiktoken-0.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:493af3aa28a4aaf2e3d2600a2ee717252c9bf5ab38fff94eb5a02db5ab77e5ad", size = 1136466, upload-time = "2026-05-15T04:51:13.926Z" },
+    { url = "https://files.pythonhosted.org/packages/96/d9/dfd086aa2d918c563a140720e0ce296cada1634efd2783d5cf51e05f984e/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6644c9c2b5cf3916f5a3641d7d12fdb3f006a7b3d9ff6acdaec44e29ab1ff91e", size = 1181863, upload-time = "2026-05-15T04:51:15.025Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/68/a18b4f307086954fdae32714cb4f85562e34f9d34ab206e61f1816aa6018/tiktoken-0.13.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5cb65b60b9408563676d874a3a4ee573370066f0dc4e29d84e82e989c6517424", size = 1239218, upload-time = "2026-05-15T04:51:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/16/5b/f2aa703a4fc5d2dff73460a7d46cc2f3f44aa0f3dd8eeb20d2a0ecf68862/tiktoken-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:85b78cc3a2c3d48723ca751fa981f1fedccd54194ca0471b957364353a898b07", size = 918110, upload-time = "2026-05-15T04:51:17.237Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
+name = "uuid-utils"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/a1/822ceef22d1c139cffebe4b1b660cfaa10253d5c770aa2598dc8e9497593/uuid_utils-0.16.0.tar.gz", hash = "sha256:d6902d4375dfba4c9902c736bb82d3c040417b67f7d0fa48910ddfdb1ac95de7", size = 42596, upload-time = "2026-05-19T07:44:23.28Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ff/4c/b4cf43a5d22bcdb91727acdf54be0d78e83e595b73c5a9a8a4291875f059/uuid_utils-0.16.0-cp312-cp312-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:727fae3f0682191ec9c8ce1cd0f71e81b471a2e26b7c5fd66712fc0f11640aa0", size = 562183, upload-time = "2026-05-19T07:45:02.683Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/fb/4b0d1c4b5e9f8679ca41b9cdbce5749e1d5db3d3d42a07060d6ce61ac583/uuid_utils-0.16.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:66a9c8cedf7695c28e700f6a66bde0809c3b2e0d8a70968be7bfd47c908952e5", size = 289018, upload-time = "2026-05-19T07:44:07.726Z" },
+    { url = "https://files.pythonhosted.org/packages/de/43/2dc6c7401c8fab86e46b0b33ada6dcfde949b2fd48877ba6f880862be80e/uuid_utils-0.16.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9152bff801ec2ccf630df06d67389090a2c612dea87fbf9a887ab4b222929f6f", size = 326171, upload-time = "2026-05-19T07:45:25.186Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/f5/48f11fb91f36453611ca148bc441436f279870b1ec6b576dc5167fb6e680/uuid_utils-0.16.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:06fc7db470c37e5c1ab3fd2cd159697d6f8b279d7d23b5b96bd418b115f8caa9", size = 332222, upload-time = "2026-05-19T07:45:09.036Z" },
+    { url = "https://files.pythonhosted.org/packages/30/cb/b2b49528521e4a097f129e8bf7850a26f00af46afba778832cf3458a5c00/uuid_utils-0.16.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e1a1f57fe3631e164dad27b24aa81267810e20575f705af3b0fa734f3a21247", size = 444801, upload-time = "2026-05-19T07:45:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/b3/a28d9c6f7c701dfe01c8020b30e33899a28eb9e4d056b07e7388f50ebf67/uuid_utils-0.16.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3ee392fe59808a731b7b6bf4d453fb6e833774921331cceae5f254d1e9c5b97d", size = 325594, upload-time = "2026-05-19T07:44:44.682Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/65/e1ff41dc44966e396ead86e104ba21b35ddb07ff7a64bb55013074ee77fe/uuid_utils-0.16.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b2e981b1258db444df4cf4bf4c79673570d081d48d35f22d0f86471e0ad795c5", size = 349312, upload-time = "2026-05-19T07:45:15.582Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/57/fb19b7951f66a46e03bd1943a61ee9d59c83e994e56e8c97d79aff1f0e47/uuid_utils-0.16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:bbb92feb4db08cd76e27b4d3b1a82bfde708447317150c614eb9f761a43b387e", size = 502115, upload-time = "2026-05-19T07:43:38.756Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/8e/9a129c469b7b77afb62da5c6b7e92591073b845bd0c3108c0d0aa65389fb/uuid_utils-0.16.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:1c3c5afaaa68b1d6393d653e9fc93a2fde9da1681da01f74b4593f41d31fb5f1", size = 607433, upload-time = "2026-05-19T07:44:11.675Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/56/2ef71fad168cc3d894f7094fa458086c093635d7835381c91470b19c9ad3/uuid_utils-0.16.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:38126b353527c5f001e4b24db9e62351eb768d0367febcd68100a4b39a035109", size = 566076, upload-time = "2026-05-19T07:44:35.453Z" },
+    { url = "https://files.pythonhosted.org/packages/95/bf/68e60ea053ca30f35df877b96001331398140d5c4983561affa1350331b1/uuid_utils-0.16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41a67e546d9adf11c4e4cb5c8e81f000f8b1f000c17912ced089b499855719a5", size = 530645, upload-time = "2026-05-19T07:45:49.278Z" },
+    { url = "https://files.pythonhosted.org/packages/42/19/b521f7d73094fca4c0c44002f4a42bfcbcf0b770fdc3c4b9a596dda25734/uuid_utils-0.16.0-cp312-cp312-win32.whl", hash = "sha256:52d2cc8c12a3466cd1727883e0746d8bad5dddd670369eb553ba17fdc3b565ca", size = 168887, upload-time = "2026-05-19T07:45:45.502Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1f/4126c3ccbc2d98a613664e55f6ab6d7bd4b98424a04486e4fcc76549af15/uuid_utils-0.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:c97625e5edfda8b118160ce1e88756f92b1635775f836c168be7bf10928d97fa", size = 174607, upload-time = "2026-05-19T07:43:52.938Z" },
+    { url = "https://files.pythonhosted.org/packages/74/62/b83ccc8446ae39dcc0bda2cb3b525b6af6a2036383afe1d1d5fe7b234c2c/uuid_utils-0.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:baf79c8050eb784b252dd34807df73f61130fe8676b61231baccab62530f20ec", size = 173021, upload-time = "2026-05-19T07:45:10.204Z" },
+    { url = "https://files.pythonhosted.org/packages/60/9b/74c1f47a9b4f138a254e51528e5ffaeba6bf99ecead9f0c4b6fccccfbfcb/uuid_utils-0.16.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d34cf9681e8892fad2a63e393068e544505408748cd8bf0c3517d753a01528d4", size = 563166, upload-time = "2026-05-19T07:44:10.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/1c/009e37b70f1f0ff17e7103a36bafde33d503d9ea7fe739761aa3e3c9fde6/uuid_utils-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0681d1bdb7956e0c6d581e7601dabcfb2b08c25d2a65189f4e9b102c94f5ff46", size = 289529, upload-time = "2026-05-19T07:43:54.466Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/5e/e0323d54321166639eb2be5e8a464f5cb0fc04d72d91f3e78944bb6a1da8/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed45fb8732d216426227096b55accbb87cba57febc86a044d90780b090eb99d0", size = 326328, upload-time = "2026-05-19T07:45:31.901Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a3/046f6cb958467c3bf4a163a8a53b178b64a62e21ed8ad5b2c1dacb3a2cfc/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b617a334bb01ef2ff8c22900f5a14125eb9063f602131494cc9dc59519beaa5b", size = 332322, upload-time = "2026-05-19T07:43:41.284Z" },
+    { url = "https://files.pythonhosted.org/packages/67/80/01914e3949744db7acd0006885e5542fbebb6e39114857d007d29b3265c2/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a750d8aeb8ae880aa9a2529606bde0e994bcc7448730c953107f357a28e6102e", size = 445787, upload-time = "2026-05-19T07:45:36.102Z" },
+    { url = "https://files.pythonhosted.org/packages/14/ef/f6908f41279f205d70c8a0d5dcb25dd6802741d7f88e3f0123453c3584d3/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a250e111903c4368745fce5ac2aa607bd477c62d3307e45347338fdb64b38e0", size = 324678, upload-time = "2026-05-19T07:45:12.77Z" },
+    { url = "https://files.pythonhosted.org/packages/11/4a/bf841ba90f829c7779d82155e0f4b88ef6726ccc25507d064d50ac2cd329/uuid_utils-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:95b7f480010ea98a29ee809857a98aa923008c68129af1b39244adccff7377fb", size = 349704, upload-time = "2026-05-19T07:44:47.172Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/31/3b5c60172b8c57bf4ca485484b8e4edef550ca324f9287f1183be97422e2/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:420aa3ca403cedb73490b6ea3aeefeea7e0455f5ce60bbf856390ee872ae3306", size = 502456, upload-time = "2026-05-19T07:45:00.821Z" },
+    { url = "https://files.pythonhosted.org/packages/88/bf/3da8d497af80fd51d8bf85551c77ede67f07825924ec5987bf9b6031014a/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:b8a9a7b1065a12d40f2cc25b7d705ab34954cc57095034367bca39ebcf4a876b", size = 607727, upload-time = "2026-05-19T07:44:30.058Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/4e/7c8cf03ec15cd6f40e4cbab81b2b4a625461327f68c7971e54723280ec3e/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f235ac5827d74ac630cc87f29278cdaa5d2f273613a6e05bbd96df7aa4170776", size = 566204, upload-time = "2026-05-19T07:44:51.225Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/5f/af955feae69cce7fd2121ca3f790ff4b85ad2e17b2149546f50753e1a047/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c8083284488b84ad178e74add64cfd1e74e8be5e30821e5acbc5019281c658b0", size = 529986, upload-time = "2026-05-19T07:45:57.85Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cf/3fec757e51bef10eb41ae8075f5442c60e85ff456b42d16a3063f5dc6c80/uuid_utils-0.16.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:27a071a899ba46a551d6524dbbc5a98b88be176d0f55ddf72cf71c005326ac10", size = 98683, upload-time = "2026-05-19T07:44:16.369Z" },
+    { url = "https://files.pythonhosted.org/packages/40/a7/cd1adbea7ef882a70db064c00cd93b12e11027b4cdd7ffd79e95c35fc3e3/uuid_utils-0.16.0-cp313-cp313-win32.whl", hash = "sha256:924a8de04460e4cf65998ad0b6568084f7c51740ebd3254d07a0bcde35a84af6", size = 168822, upload-time = "2026-05-19T07:44:24.09Z" },
+    { url = "https://files.pythonhosted.org/packages/74/99/617ceb9e3a95b23837012740979baf71afad723b70daf34862da3f7c17a1/uuid_utils-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:5279bc7ab3c6683f1c67314695bee14d869015acbbc677bdb0015190fe753d16", size = 174967, upload-time = "2026-05-19T07:44:56.022Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/d8/148ae707bfc36d482e39db679c86b81bdce264d4feb9df5d40a03b7687e3/uuid_utils-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:61a9c4c26ad12ac66fa4bfd0fdb8494724fe7a5b98a9fcd43e78e2b388663dbb", size = 173142, upload-time = "2026-05-19T07:43:50.171Z" },
+    { url = "https://files.pythonhosted.org/packages/21/05/ca6d60705e71fdeaa3431dad94e279a8213c5573cb2925e1aabf3dc0330a/uuid_utils-0.16.0-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73486b6aa3f755a6c97000f5ea67e7ac78d6df89bf22980789a1e943e24b74f0", size = 564408, upload-time = "2026-05-19T07:44:38.351Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/8c/b9a0462c38535c1662acb1025768e2d626bee5ce9e1790bad6b5381162ea/uuid_utils-0.16.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f1614572fd9345cdc3dde3f40c237345719fabca1aa87d2d87b321d523cfa34d", size = 289923, upload-time = "2026-05-19T07:45:19.611Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/33/a53afeef1a56051551a0f5a801e4bce411dd73c6a8c99bad16902651256d/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9346ce6eb1fbd8b03a6b331d66016afcb4edcdff6eac708e21391600529a016a", size = 325762, upload-time = "2026-05-19T07:45:18.261Z" },
+    { url = "https://files.pythonhosted.org/packages/72/ca/4462a4f36365d7ee72d41e05e6bcfe127e861b073ab37c25b2c8a518317c/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a0fc6eb3fd821466fbab69cf356c6ec2b7327266bbbc740a2eb57c77c4bef965", size = 332359, upload-time = "2026-05-19T07:45:34.886Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/67/9d3373fa7c5a746fdecc64e30caf915c29eb632203508d87676f9243ed03/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:13a797e5e8f0dadc18351a5aa013815ddac25dce6864072a539d510910c95f71", size = 445483, upload-time = "2026-05-19T07:44:49.598Z" },
+    { url = "https://files.pythonhosted.org/packages/57/08/ce01aa6d897fc7f875844fe58cad0a542c8ebf089d9242b654b56260ecb8/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57c3583b1f1c00a94f59726a5e2b988fa209221143919a1af5c2fc24e318fc98", size = 326281, upload-time = "2026-05-19T07:44:59.677Z" },
+    { url = "https://files.pythonhosted.org/packages/76/ef/2c719b2c26bb5b5e5061a1435c11ad2bd33ac3cd6d4cd0c7c3ac1d3396ed/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:caac9c8b1d50e8fbddc76e93bfefbef472978eb45adbfdb6289d578816992953", size = 350809, upload-time = "2026-05-19T07:45:28.076Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/9b/c1ed447328b32229cca38ac4c62d309eab006e5e9c4020e2056a175bc607/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:91db59bad97ed2b9d2c6ed25082fe9762b2c422e694fe06786b28cf4e776ac4c", size = 502088, upload-time = "2026-05-19T07:44:09.208Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/e0/8442f4efe7bde72f0b4ae5f675d0c7fbe209ad0b54718b8ddf43c46c6fae/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:41985e342a30e76366a8becc60bbdb07d72cd1b86ec657b1f31654e9fb1baada", size = 607631, upload-time = "2026-05-19T07:44:19.384Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/1e/9a9fa261edf4c972f28ae83421377e3ab8dbd0bd7db58fd316e782d09a3b/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1b0dcedf9266bf34a54d5cbe78648eaa627e02352f2a6923ed647530aea2f661", size = 567618, upload-time = "2026-05-19T07:43:58.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f7/1bcfdb9d539bd42736dd6076470a42fbb5db23f79712c0a06aa0a3752f7b/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:26fe23ab60f05de4ad70aaa5b6a4c2a7bbd43055e3dd6f6b31efba0532ac9c71", size = 530971, upload-time = "2026-05-19T07:45:06.348Z" },
+    { url = "https://files.pythonhosted.org/packages/24/0c/18945f417d6bb4d0dd2b7652fe36c58c4e83bcf593b9b326b83aa40b853a/uuid_utils-0.16.0-cp313-cp313t-win32.whl", hash = "sha256:7f8cf49c05d58523a0f977cb7f11afc05791a0fa164d7303b8365a34750638e7", size = 169369, upload-time = "2026-05-19T07:44:32.581Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/cc/c0eb0c3fab2ed80d706369b750029143b53126809b77b36bcbb77da66bab/uuid_utils-0.16.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e99f9a8b2420b228faba23a637e96efaf5c6a678b2e225870f24431c82707f50", size = 175384, upload-time = "2026-05-19T07:45:56.623Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/77/50ac87b6e18b1c686f700aa38c9471a990683c6a955f71ac1a6677ed8145/uuid_utils-0.16.0-cp314-cp314-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:6853b627983aa1b4fd95aa52d9e87136eb94a7b3b7de0fbb1db8a498d457eeec", size = 564108, upload-time = "2026-05-19T07:43:55.609Z" },
+    { url = "https://files.pythonhosted.org/packages/83/16/65046676de246bb5334d9f58aa96d2feb9fc347fda3556aaff7da1c2fc7a/uuid_utils-0.16.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:f44b65ae0c329843817d9c90e36a7a3c677b413bf407c99e67db874dac49dad3", size = 289967, upload-time = "2026-05-19T07:45:38.886Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/54fa988606a15dfd2028e925d8eb9c3ee6edbf1eb7692a67b37282880b56/uuid_utils-0.16.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:de8a365795a76f347f5622621c2bee543cffa0c70949f3ee093bdefc9d926dcc", size = 325835, upload-time = "2026-05-19T07:44:42.02Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/1b/50622f967ceacea1f89fd065d9bfd395b51acb02cfb0a4ddc8fa9ff0c983/uuid_utils-0.16.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:426a8c9af90242d879706ccf29da56f0b0712e7739fb0bbe16baacabc75596e2", size = 332607, upload-time = "2026-05-19T07:43:42.42Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f5/4059706be6617e2787e375ea52994ce3c3fa3920b7d4a9c8ebf7895681a5/uuid_utils-0.16.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:833bc4b3c3fc24be541f67b01b4a75b6b9942a9b7137395b4eb35435948bd6da", size = 444287, upload-time = "2026-05-19T07:43:37.106Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d5/f44b2710563da687a368f0ce4dcbd462dfb6708bcd46439d831991d595c7/uuid_utils-0.16.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:efb5252d7c00d586077f10e169d6e6d0b0d0f806d8a085073f0d19b4737aef4e", size = 324949, upload-time = "2026-05-19T07:45:33.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/a7/a69e859e37d26c5603f0bc0ae481860f691224f140e5a832f325b804770d/uuid_utils-0.16.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0b3377ce388fd7bf8d231ec9d1d4f58c8e87888ddea93581f60ed6f878a4f722", size = 349651, upload-time = "2026-05-19T07:43:59.998Z" },
+    { url = "https://files.pythonhosted.org/packages/db/73/4139cd3ca7b81ea283c1c8769373e9b2008241c0744a8ffb25f0a1b31325/uuid_utils-0.16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:12b6310beb38adc173ec5dc89e98812fd7e3d98f87f3ef01d2ea6ecb5d87994f", size = 502326, upload-time = "2026-05-19T07:45:40.292Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/8c/858101583fbad1b3fa04da88b1f7170836aa0f00b4cb712063325c44466d/uuid_utils-0.16.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a49b5a75497643479c919e2e537a4a36224ac3aaa0fada61b75d87024021ac3e", size = 607689, upload-time = "2026-05-19T07:44:48.355Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bd/8f3d54a4763dd91ebd0f3d7b0c2ec434e4e0b1fc667b03a44d611a465ec6/uuid_utils-0.16.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:63bfdf00be51b6b3b79275d6767d034ea5c7a0caa067a35d72861284100cb60a", size = 566214, upload-time = "2026-05-19T07:44:53.519Z" },
+    { url = "https://files.pythonhosted.org/packages/54/76/4c9a8d9baaa243c7902d84dbba4d51b1ab51c379c66d3fd6368ff6933ecf/uuid_utils-0.16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7525bc59ac4579c32317d2493dd42cf134b9bb50cd0bc6a41dd9f77e4740dde6", size = 529989, upload-time = "2026-05-19T07:44:43.141Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/13/d32cea997f880cedde415730ce0e872ebfd7a040155ae0bbda70eccd208e/uuid_utils-0.16.0-cp314-cp314-win32.whl", hash = "sha256:fbcac6e6710aa2e4bfbb81762758e01470dc56d5048ba4253acc77c9833568ff", size = 169146, upload-time = "2026-05-19T07:45:46.655Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/19/9fc55172d8fe59e1f27a14d598b427fa508a7ebb35fa7b7b99c24fa0ef13/uuid_utils-0.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:d23fcaf37368a1647319187ef6f8b741bf079f033065899bc2d00a44b0a1214a", size = 175364, upload-time = "2026-05-19T07:45:55.335Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5d/fcd9226b715c5aa0638fcdd6deaf0de6c6c3c451c692cd76bfca810c6512/uuid_utils-0.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:ea3265f8e2b452a4870f3298cb1d183dc4e36a3682cbb264dbe46af31267e706", size = 173268, upload-time = "2026-05-19T07:44:31.19Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/97ec9af95e58b8187f2934008ffab26e1604d149e34fe01c388b0543a24f/uuid_utils-0.16.0-cp314-cp314t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:99f8420c3ed59f89a086782ac197e257f4b1debb4545dffa90cf5db23f96c892", size = 564464, upload-time = "2026-05-19T07:44:40.856Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/6d/e4082f407484ac28923c0bf8e861e71d277118d8b7542d0a350340e45350/uuid_utils-0.16.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:259bab73c241743d684dcc3507feb76f484d720545e4e4805582aeff8e19700b", size = 290087, upload-time = "2026-05-19T07:44:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/43/c5c5f273c0ff889f20f10344784f9197dd00eb81ccc294330d4b949fea7e/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:897e8ef0dc5e4ac0b17cf9cae84bb41e560d806280ec5b93db7475b504022105", size = 325532, upload-time = "2026-05-19T07:43:47.508Z" },
+    { url = "https://files.pythonhosted.org/packages/13/7f/669aa899ab5378374d28a28231e6978f739921a1af394c7ebd6cc86e2639/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c5af79cde16a7600dfccb7d431aec0afd3088ff170b6a09887bf3f7ab3cc7c81", size = 332209, upload-time = "2026-05-19T07:43:51.528Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/57/a2a32406d79a222794ef98a19254fd9a81a029a0f32d7740fba9873bff1f/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:bece1a6f677ca36047442c465d8166643eed9818b9e43e0bf42d3cf73e92dcff", size = 445507, upload-time = "2026-05-19T07:44:20.541Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6b/85459a35bfa7d73e79acbc4eab1cf6aa6e4d9d022c3260ed9dea539c7f0b/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2bb3444498e7b099499c8a607d7771377020fa55f7274e46f54106af19f752d7", size = 326154, upload-time = "2026-05-19T07:45:23.587Z" },
+    { url = "https://files.pythonhosted.org/packages/84/9e/e965efdbb503ed14d6e57aec1a22b98326ed24cc2fb48e750c4d192267a0/uuid_utils-0.16.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:542098f6cb6874aebeff98715f3ab7646fbe0f2ffb24509ca372828c68c4ed0e", size = 350905, upload-time = "2026-05-19T07:44:36.957Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ae/4321867888a783d03b7c053c0b68ca45d03974d86fcebf44d4ec268db397/uuid_utils-0.16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7207b25fe534bcf4d57e0110f90670e61c1c38b6f4598ba855af69ab428fc118", size = 502098, upload-time = "2026-05-19T07:44:17.696Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/9a/914a47bf42479bff0ce3e1fa1cbe3585354708edc928e27687cf91de9c26/uuid_utils-0.16.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:16dc5c6e439f75b0456114e955983e2156c1f38887733e54d54205d3005223e4", size = 607032, upload-time = "2026-05-19T07:44:22.151Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4c/2abacd6badba61a047eaa39c8347656229d12843bd9bbe4906daa6dc752c/uuid_utils-0.16.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:a6d3ee32c57898d8415242b08d5dd086bc4f7bcbbb3fc102ef257f3d793eb294", size = 567664, upload-time = "2026-05-19T07:45:21.043Z" },
+    { url = "https://files.pythonhosted.org/packages/53/1f/9d1a09521276424da19dc0d74456aed3311170fec181b28fa6acba45d963/uuid_utils-0.16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7555f120a2282d1901c9a632c2398a614101af4fe3f7c8114aa0f1d8c1978855", size = 530996, upload-time = "2026-05-19T07:45:44.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/22/14dbedb6b61f492d5524077fd10bbfb137583b0f0aafa6cd870ccb43f39a/uuid_utils-0.16.0-cp314-cp314t-win32.whl", hash = "sha256:756575d082ea4cb7d2f923d5b640c0efe7c82573aab49220c4e09b62d13737ff", size = 169358, upload-time = "2026-05-19T07:45:05.146Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f4/a636806c98401a1108f2456e9cc3fa39a618145bfb1d0860c57203159cfe/uuid_utils-0.16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:aa50261a83991dbb570a00573741455bd8f3249444f7329e5bdcd494799d1504", size = 174813, upload-time = "2026-05-19T07:45:59.579Z" },
+    { url = "https://files.pythonhosted.org/packages/75/12/3823742459d87a100deb24bb6b41692aa961b267abd130fa7739cdf7d409/uuid_utils-0.16.0-cp314-cp314t-win_arm64.whl", hash = "sha256:22a17e93a371d850ffce8fcdbacc2239f890efe73aa3262b6170c1febc08afe1", size = 171733, upload-time = "2026-05-19T07:45:29.283Z" },
+]
+
+[[package]]
+name = "wcmatch"
+version = "10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "bracex" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/3e/c0bdc27cf06f4e47680bd5803a07cb3dfd17de84cde92dd217dcb9e05253/wcmatch-10.1.tar.gz", hash = "sha256:f11f94208c8c8484a16f4f48638a85d771d9513f4ab3f37595978801cb9465af", size = 117421, upload-time = "2025-06-22T19:14:02.49Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/d8/0d1d2e9d3fabcf5d6840362adcf05f8cf3cd06a73358140c3a97189238ae/wcmatch-10.1-py3-none-any.whl", hash = "sha256:5848ace7dbb0476e5e55ab63c6bbd529745089343427caa5537f230cc01beb8a", size = 39854, upload-time = "2025-06-22T19:14:00.978Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+]
+
+[[package]]
+name = "xxhash"
+version = "3.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/2f/e183a1b407002f5af81822bee18b61cdb94b8670208ef34734d8d2b8ebe9/xxhash-3.7.0.tar.gz", hash = "sha256:6cc4eefbb542a5d6ffd6d70ea9c502957c925e800f998c5630ecc809d6702bae", size = 82022, upload-time = "2026-04-25T11:10:32.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/8a/51a14cdef4728c6c2337db8a7d8704422cc65676d9199d77215464c880af/xxhash-3.7.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:082c87bfdd2b9f457606c7a4a53457f4c4b48b0cdc48de0277f4349d79bb3d7a", size = 33357, upload-time = "2026-04-25T11:06:20.44Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/1b/0c2c933809421ffd9bf42b59315552c143c755db5d9a816b2f1ae273e884/xxhash-3.7.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5e7ce913b61f35b0c1c839a49ac9c8e75dd8d860150688aed353b0ce1bf409d8", size = 30869, upload-time = "2026-04-25T11:06:21.989Z" },
+    { url = "https://files.pythonhosted.org/packages/03/a8/89d5fdd6ee12d70ba99451de46dd0e8010167468dcd913ec855653f4dd50/xxhash-3.7.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3beb1de3b1e9694fcdd853e570ee64c631c7062435d2f8c69c1adf809bc086f0", size = 194100, upload-time = "2026-04-25T11:06:23.586Z" },
+    { url = "https://files.pythonhosted.org/packages/87/ee/2f9f2ed993e77206d1e66991290a1ebe22e843351ca3ebec8e49e01ba186/xxhash-3.7.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f3e7b689c3bce16699efcf736066f5c6cc4472c3840fe4b22bd8279daf4abdac", size = 212977, upload-time = "2026-04-25T11:06:25.019Z" },
+    { url = "https://files.pythonhosted.org/packages/de/60/5a91644615a9e9d4e42c2e9925f1908e3a24e4e691d9de7340d565bea024/xxhash-3.7.0-cp312-cp312-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:a6545e6b409e3d5cbafc850fb84c55a1ca26ed15a6b11e3bf07a0e0cd84517c8", size = 236373, upload-time = "2026-04-25T11:06:26.482Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c0/f3a9384eaaed9d14d4d062a5d953aa0da489bfe9747877aa994caa87cd0b/xxhash-3.7.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:31ab1461c77a11461d703c88eb949e132a1c6515933cf675d97ec680f4bd18de", size = 212229, upload-time = "2026-04-25T11:06:28.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/67/02f07a9fd79726804190f2172c4894c3ed9a4ebccaca05653c84beb58025/xxhash-3.7.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:7c4d596b7676f811172687ec567cbafb9e4dea2f9be1bbb4f622410cb7f40f40", size = 445462, upload-time = "2026-04-25T11:06:30.048Z" },
+    { url = "https://files.pythonhosted.org/packages/40/37/558f5a90c0672fc9b4402dc25d87ac5b7406616e8969430c9ca4e52ee74d/xxhash-3.7.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:13805f0461cba0a857924e70ff91ae6d52d2598f79a884e788db80532614a4a1", size = 193932, upload-time = "2026-04-25T11:06:31.857Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/90/aaa09cd58661d32044dbbad7df55bbe22a623032b810e7ed3b8c569a2a6f/xxhash-3.7.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d398f372496152f1c6933a33566373f8d1b37b98b8c9d608fa6edc0976f23b2", size = 284807, upload-time = "2026-04-25T11:06:33.697Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f3/53df3719ab127a02c174f0c1c74924fcd110866e89c966bc7909cfa8fa84/xxhash-3.7.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d610aa62cdb7d4d497740741772a24a794903bf3e79eaa51d2e800082abe11e5", size = 210445, upload-time = "2026-04-25T11:06:35.488Z" },
+    { url = "https://files.pythonhosted.org/packages/72/33/d219975c0e8b6fa2eb9ccd486fe47e21bf1847985b878dd2fbc3126e0d5c/xxhash-3.7.0-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:073c23900a9fbf3d26616c17c830db28af9803677cd5b33aea3224d824111514", size = 241273, upload-time = "2026-04-25T11:06:37.24Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/50/49b1afe610eb3964cedcb90a4d4c3d46a261ee8669cbd4f060652619ae3c/xxhash-3.7.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:418a463c3e6a590c0cdc890f8be19adb44a8c8acd175ca5b2a6de77e61d0b386", size = 197950, upload-time = "2026-04-25T11:06:39.148Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/75/5f42a1a4c78717d906a4b6a140c6dbf837ab1f547a54d23c4e2903310936/xxhash-3.7.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:03f8ff4474ee61c845758ce00711d7087a770d77efb36f7e74a6e867301000b8", size = 210709, upload-time = "2026-04-25T11:06:40.958Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/85/237e446c25abced71e9c53d269f2cef5bab8a82b3f88a12e00c5368e7368/xxhash-3.7.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:44fba4a5f1d179b7ddc7b3dc40f56f9209046421679b57025d4d8821b376fd8d", size = 275345, upload-time = "2026-04-25T11:06:42.525Z" },
+    { url = "https://files.pythonhosted.org/packages/62/34/c2c26c0a6a9cc739bc2a5f0ae03ba8b87deb12b8bce35f7ac495e790dc6d/xxhash-3.7.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:31e3516a0f829d06ded4a2c0f3c7c5561993256bfa1c493975fb9dc7bfa828a1", size = 414056, upload-time = "2026-04-25T11:06:44.343Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/aa/5c58e9bc8071b8afd8dcf297ff362f723c4892168faba149f19904132bf4/xxhash-3.7.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:b59ee2ac81de57771a09ecad09191e840a1d2fae1ef684208320591055768f83", size = 191485, upload-time = "2026-04-25T11:06:46.262Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/69/a929cf9d1e2e65a48b818cdce72cb6b69eab2e6877f21436d0a1942aff43/xxhash-3.7.0-cp312-cp312-win32.whl", hash = "sha256:74bbd92f8c7fcc397ba0a11bfdc106bc72ad7f11e3a60277753f87e7532b4d81", size = 30671, upload-time = "2026-04-25T11:06:48.039Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/1b/104b41a8947f4e1d4a66ce1e628eea752f37d1890bfd7453559ca7a3d950/xxhash-3.7.0-cp312-cp312-win_amd64.whl", hash = "sha256:7bd7bc82dd4f185f28f35193c2e968ef46131628e3cac62f639dadf321cba4d1", size = 31514, upload-time = "2026-04-25T11:06:49.279Z" },
+    { url = "https://files.pythonhosted.org/packages/98/a0/1fd0ea1f1b886d9e7c73f0397571e22333a7d79e31da6d7127c2a4a71d75/xxhash-3.7.0-cp312-cp312-win_arm64.whl", hash = "sha256:7d7148180ec99ba36585b42c8c5de25e9b40191613bc4be68909b4d25a77a852", size = 27761, upload-time = "2026-04-25T11:06:50.448Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ca/d5174b4c36d10f64d4ca7050563138c5a599efb01a765858ddefc9c1202a/xxhash-3.7.0-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:4b6d6b33f141158692bd4eafbb96edbc5aa0dabdb593a962db01a91983d4f8fa", size = 36813, upload-time = "2026-04-25T11:06:51.73Z" },
+    { url = "https://files.pythonhosted.org/packages/41/d0/abc6c9d347ba1f1e1e1d98125d0881a0452c7f9a76a9dd03a7b5d2197f23/xxhash-3.7.0-cp313-cp313-android_21_x86_64.whl", hash = "sha256:845d347df254d6c619f616afa921331bada8614b8d373d58725c663ba97c3605", size = 35121, upload-time = "2026-04-25T11:06:53.048Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/11/4cc834eb3d79f2f2b3a6ef7324195208bcdfbdcf7534d2b17267aa5f3a8f/xxhash-3.7.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:fddbbb69a6fff4f421e7a0d1fa28f894b20112e9e3fab306af451e2dfd0e459b", size = 29624, upload-time = "2026-04-25T11:06:54.311Z" },
+    { url = "https://files.pythonhosted.org/packages/23/83/e97d3e7b635fe73a1dfb1e91f805324dd6d930bb42041cbf18f183bc0b6d/xxhash-3.7.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:54876a4e45101cec2bf8f31a973cda073a23e2e108538dad224ba07f85f22487", size = 30638, upload-time = "2026-04-25T11:06:55.864Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/40/d84951d80c35db1f4c40a29a64a8520eea5d56e764c603906b4fe763580f/xxhash-3.7.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:0c72fe9c7e3d6dfd7f1e21e224a877917fa09c465694ba4e06464b9511b65544", size = 33323, upload-time = "2026-04-25T11:06:57.336Z" },
+    { url = "https://files.pythonhosted.org/packages/89/cc/c7dc6558d97e9ab023f663d69ab28b340ed9bf4d2d94f2c259cf896bb354/xxhash-3.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a6d73a830b17ef49bc04e00182bd839164c1b3c59c127cd7c54fcb10c7ed8ee8", size = 33362, upload-time = "2026-04-25T11:06:58.656Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6e/46b84017b1301d54091430353d4ad5901654a3e0871649877a416f7f1644/xxhash-3.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:91c3b07cf3362086d8f126c6aecd8e5e9396ad8b2f2219ea7e49a8250c318acd", size = 30874, upload-time = "2026-04-25T11:06:59.834Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5e/8f9158e3ab906ad3fec51e09b5ea0093e769f12207bfa42a368ca204e7ab/xxhash-3.7.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:50e879ebbac351c81565ca108db766d7832f5b8b6a5b14b8c0151f7190028e3d", size = 194185, upload-time = "2026-04-25T11:07:01.658Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/29/a804ded9f5d3d3758292678d23e7528b08fda7b7e750688d08b052322475/xxhash-3.7.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:921c14e93817842dd0dd9f372890a0f0c72e534650b6ab13c5be5cd0db11d47e", size = 213033, upload-time = "2026-04-25T11:07:03.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/91/1ce5a7d2fdc975267320e2c78fc1cecfe7ab735ccbcf6993ec5dd541cb2c/xxhash-3.7.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e64a7c9d7dfca3e0fafcbc5e455519090706a3e36e95d655cec3e04e79f95aaa", size = 236140, upload-time = "2026-04-25T11:07:05.396Z" },
+    { url = "https://files.pythonhosted.org/packages/34/04/fd595a4fd8617b05fa27bd9b684ecb4985bfed27917848eea85d54036d06/xxhash-3.7.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2220af08163baf5fa36c2b8af079dc2cbe6e66ae061385267f9472362dfd53c6", size = 212291, upload-time = "2026-04-25T11:07:06.966Z" },
+    { url = "https://files.pythonhosted.org/packages/03/fb/f1a379cbc372ae5b9f4ab36154c48a849ca6ebe3ac477067a57865bf3bc6/xxhash-3.7.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f14bb8b22a4a91325813e3d553b8963c10cf8c756cff65ee50c194431296c655", size = 445532, upload-time = "2026-04-25T11:07:08.525Z" },
+    { url = "https://files.pythonhosted.org/packages/65/59/172424b79f8cfd4b6d8a122b2193e6b8ad4b11f7159bb3b6f9b3191329bb/xxhash-3.7.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:496736f86a9bedaf64b0dc70e3539d0766df01c71ea22032698e88f3f04a1ce9", size = 193990, upload-time = "2026-04-25T11:07:10.315Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/19/aeac22161d953f139f07ba5586cb4a17c5b7b6dff985122803bb12933500/xxhash-3.7.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0ff71596bd79816975b3de7130ab1ff4541410285a3c084584eeb1c8239996fd", size = 284876, upload-time = "2026-04-25T11:07:12.15Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d5/4fd0b59e7a02242953da05ff679fbb961b0a4368eac97a217e11dae110c1/xxhash-3.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1ad86695c19b1d46fe106925db3c7a37f16be37669dcf58dcc70a9dd6e324676", size = 210495, upload-time = "2026-04-25T11:07:13.952Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/fb/976a3165c728c7faf74aa1b5ab3cf6a85e6d731612894741840524c7d28c/xxhash-3.7.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:970f9f8c50961d639cbd0d988c96f80ddf66006de93641719282c4fe7a87c5e6", size = 241331, upload-time = "2026-04-25T11:07:15.557Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/2c/6763d5901d53ac9e6ba296e5717ae599025c9d268396e8faa8b4b0a8e0ac/xxhash-3.7.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5886ad85e9e347911783760a1d16cb6b393e8f9e3b52c982568226cb56927bdc", size = 198037, upload-time = "2026-04-25T11:07:17.563Z" },
+    { url = "https://files.pythonhosted.org/packages/61/2b/876e722d533833f5f9a83473e6ba993e48745701096944e77bbecf29b2c3/xxhash-3.7.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6e934bbae1e0ec74e27d5f0d7f37ef547ce5ff9f0a7e63fb39e559fc99526734", size = 210744, upload-time = "2026-04-25T11:07:19.055Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e6/d7e7baef7ce24166b4668d3c48557bb35a23b92ecadcac7e7718d099ab69/xxhash-3.7.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:3b6b3d28228af044ebcded71c4a3dd86e1dbd7e2f4645bf40f7b5da65bb5fb5a", size = 275406, upload-time = "2026-04-25T11:07:20.908Z" },
+    { url = "https://files.pythonhosted.org/packages/92/fe/198b3763b2e01ca908f2154969a2352ec99bda892b574a11a9a151c5ede4/xxhash-3.7.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:6be4d70d9ab76c9f324ead9c01af6ff52c324745ea0c3731682a0cf99720f1fe", size = 414125, upload-time = "2026-04-25T11:07:23.037Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/6d/019a11affd5a5499137cacca53808659964785439855b5aa40dfd3412916/xxhash-3.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:151d7520838d4465461a0b7f4ae488b3b00de16183dd3214c1a6b14bf89d7fb6", size = 191555, upload-time = "2026-04-25T11:07:24.991Z" },
+    { url = "https://files.pythonhosted.org/packages/76/21/b96d58568df2d01533244c3e0e5cbdd0c8b2b25c4bec4d72f19259a292d7/xxhash-3.7.0-cp313-cp313-win32.whl", hash = "sha256:d798c1e291bffb8e37b5bbe0dda77fc767cd19e89cadaf66e6ed5d0ff88c9fe6", size = 30668, upload-time = "2026-04-25T11:07:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/99/57/d849a8d3afa1f8f4bc6a831cd89f49f9706fbbad94d2975d6140a171988c/xxhash-3.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:875811ba23c543b1a1c3143c926e43996eb27ebb8f52d3500744aa608c275aed", size = 31524, upload-time = "2026-04-25T11:07:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/81/52/bacc753e92dee78b058af8dcef0a50815f5f860986c664a92d75f965b6a5/xxhash-3.7.0-cp313-cp313-win_arm64.whl", hash = "sha256:54a675cb300dda83d71daae2a599389d22db8021a0f8db0dd659e14626eb3ecc", size = 27768, upload-time = "2026-04-25T11:07:29.113Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/47/ddbd683b7fc7e592c1a8d9d65f73ce9ab513f082b3967eee2baf549b8fc6/xxhash-3.7.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a3b19a42111c4057c1547a4a1396a53961dca576a0f6b82bfa88a2d1561764b2", size = 33576, upload-time = "2026-04-25T11:07:30.469Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f2/36d3310161db7f72efb4562aadde0ed429f1d0531782dd6345b12d2da527/xxhash-3.7.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8f4608a06e4d61b7a3425665a46d00e0579122e1a2fae97a0c52953a3aad9aa3", size = 31123, upload-time = "2026-04-25T11:07:31.989Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/3f/75937a5c69556ed213021e43cbedd84c8e0279d0d74e7d41a255d84ba4b1/xxhash-3.7.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ad37c7792479e49cf96c1ab25517d7003fe0d93687a772ba19a097d235bbe41e", size = 196491, upload-time = "2026-04-25T11:07:33.358Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/f10d7ff8c7a733d4403a43b9de18c8fabc005f98cec054644f04418659ee/xxhash-3.7.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc026e3b89d98e30a8288c95cb696e77d150b3f0fb7a51f73dcd49ee6b5577fa", size = 215793, upload-time = "2026-04-25T11:07:34.919Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/fd/778f60aa295f58907938f030a8b514611f391405614a525cccd2ffc00eb5/xxhash-3.7.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c9b31ab1f28b078a6a1ac1a54eb35e7d5390deddd56870d0be3a0a733d1c321c", size = 237993, upload-time = "2026-04-25T11:07:36.638Z" },
+    { url = "https://files.pythonhosted.org/packages/70/f5/736db5de387b4a540e37a05b84b40dc58a1ce974bfd2b4e5754ce29b68c3/xxhash-3.7.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3bb5fd680c038fd5229e44e9c493782f90df9bef632fd0499d442374688ff70b", size = 214887, upload-time = "2026-04-25T11:07:38.564Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/aa/09a095f22fdb9a27fbb716841fbff52119721f9ca4261952d07a912f7839/xxhash-3.7.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:030c0fd688fce3569fbb49a2feefd4110cbb0b650186fb4610759ecfac677548", size = 448407, upload-time = "2026-04-25T11:07:40.552Z" },
+    { url = "https://files.pythonhosted.org/packages/74/8a/b745efeeca9e34a91c26fdc97ad8514c43d5a81ac78565cba80a1353870a/xxhash-3.7.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5b1bde10324f4c31812ae0d0502e92d916ae8917cad7209353f122b8b8f610c3", size = 196119, upload-time = "2026-04-25T11:07:42.101Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/5c/0cfceb024af90c191f665c7933b1f318ee234f4797858383bebd1881d52f/xxhash-3.7.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:503722d52a615f2604f5e7611de7d43878df010dc0053094ef91cb9a9ac3d987", size = 286751, upload-time = "2026-04-25T11:07:43.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/0a/0793e405dc3cf8f4ebe2c1acec1e4e4608cd9e7e50ea691dabbc2a95ccbb/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c72500a3b6d6c30ebfc135035bcace9eb5884f2dc220804efcaaba43e9f611dd", size = 212961, upload-time = "2026-04-25T11:07:45.388Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/7e/721118ffc63bfff94aa565bcf2555a820f9f4bdb0f001e0d609bdfad70de/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:43475925a766d01ca8cd9a857fd87f3d50406983c8506a4c07c4df12adcc867f", size = 243703, upload-time = "2026-04-25T11:07:47.053Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/18/16f6267160488b8276fd3d449d425712512add292ba545c1b6946bfdb7dd/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8d09dfd2ab135b985daf868b594315ebe11ad86cd9fea46e6c69f19b28f7d25a", size = 200894, upload-time = "2026-04-25T11:07:48.657Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/94/80ba841287fd97e3e9cac1d228788c8ef623746f570404961eec748ecb5c/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c50269d0055ac1faecfd559886d2cbe4b730de236585aba0e873f9d9dadbe585", size = 213357, upload-time = "2026-04-25T11:07:50.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/7e/106d4067130c59f1e18a55ffadcd876d8c68534883a1e02685b29d3d8153/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:1910df4756a5ab58cfad8744fc2d0f23926e3efcc346ee76e87b974abab922f4", size = 277600, upload-time = "2026-04-25T11:07:51.745Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/86/a081dd30da71d720b2612a792bfd55e45fa9a07ac76a0507f60487473c25/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d006faf3b491957efcb433489be3c149efe4787b7063d5cddb8ddaefdc60e0c1", size = 416980, upload-time = "2026-04-25T11:07:53.504Z" },
+    { url = "https://files.pythonhosted.org/packages/35/29/1a95221a029a3c1293773869e1ab47b07cbbdd82444a42809e8c60156626/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:abb65b4e947e958f7b3b0d71db3ce447d1bc5f37f5eab871ce7223bda8768a04", size = 193840, upload-time = "2026-04-25T11:07:55.103Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/e0/db909dd0823285de2286f67e10ee4d81e96ad35d7d8e964ecb07fccd8af9/xxhash-3.7.0-cp313-cp313t-win32.whl", hash = "sha256:178959906cb1716a1ce08e0d69c82886c70a15a6f2790fc084fdd146ca30cd49", size = 30966, upload-time = "2026-04-25T11:07:56.524Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/ff/d705b15b22f21ee106adce239cb65d35067a158c630b240270f09b17c2e6/xxhash-3.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2524a1e20d4c231d13b50f7cf39e44265b055669a64a7a4b9a2a44faa03f19b6", size = 31784, upload-time = "2026-04-25T11:07:57.758Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/1f/b2cf83c3638fd0588e0b17f22e5a9400bdfb1a3e3755324ac0aee2250b88/xxhash-3.7.0-cp313-cp313t-win_arm64.whl", hash = "sha256:37d994d0ffe81ef087bb330d392caa809bb5853c77e22ea3f71db024a0543dba", size = 27932, upload-time = "2026-04-25T11:07:59.109Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/cc/431db584f6fbb9312e40a173af027644e5580d39df1f73603cbb9dca4d6b/xxhash-3.7.0-cp314-cp314-android_24_arm64_v8a.whl", hash = "sha256:8c5fcfd806c335bfa2adf1cd0b3110a44fc7b6995c3a648c27489bae85801465", size = 36644, upload-time = "2026-04-25T11:08:00.658Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/01/255ec513e0a705d1f9a61413e78dfce4e3235203f0ed525a24c2b4b56345/xxhash-3.7.0-cp314-cp314-android_24_x86_64.whl", hash = "sha256:506a0b488f190f0a06769575e30caf71615c898ed93ab18b0dbcb6dec5c3713c", size = 35003, upload-time = "2026-04-25T11:08:02.338Z" },
+    { url = "https://files.pythonhosted.org/packages/68/70/c55fc33c93445b44d8fc5a17b41ed99e3cebe92bcf8396809e63fc9a1165/xxhash-3.7.0-cp314-cp314-ios_13_0_arm64_iphoneos.whl", hash = "sha256:ec68dbba21532c0173a9872298e65c89749f7c9d21538c3a78b5bb6105871568", size = 29655, upload-time = "2026-04-25T11:08:03.701Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/72/ff8de73df000d74467d12a59ce6d6e2b2a368b978d41ab7b1fba5ed442be/xxhash-3.7.0-cp314-cp314-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:fa77e7ec1450d415d20129961814787c9abd9a07f98872f070b1fe96c5084611", size = 30664, upload-time = "2026-04-25T11:08:05.011Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/91/08416d9bd9bc3bf39d831abe8a5631ac2db5141dfd6fe81c3fe59a1f9264/xxhash-3.7.0-cp314-cp314-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:fe32736295ea38e43e7d9424053c8c47c9f64fecfc7c895fb3da9b30b131c9ee", size = 33317, upload-time = "2026-04-25T11:08:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/3b/86b1caa4dee10a99f4bf9521e623359341c5e50d05158fa10c275b2bd079/xxhash-3.7.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ab9dd2c83c4bbd63e422181a76f13502d049d3ddcac9a1bdc29196263d692bb8", size = 33457, upload-time = "2026-04-25T11:08:08.099Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/38/98ea14ad1517e1461292a65906951458d520689782bfbae111050145bdba/xxhash-3.7.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3afec3a336a2286601a437cb07562ab0227685e6fbb9ec17e8c18457ff348ecf", size = 30894, upload-time = "2026-04-25T11:08:09.429Z" },
+    { url = "https://files.pythonhosted.org/packages/61/a2/074654d0b893606541199993c7db70067d9fc63b748e0d60020a52a1bd36/xxhash-3.7.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:565df64437a9390f84465dcca33e7377114c7ede8d05cd2cf20081f831ea788e", size = 194409, upload-time = "2026-04-25T11:08:10.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/26/6d2a1afc468189f77ca28c32e1c83e1b9da1178231e05641dbc1b350e332/xxhash-3.7.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12eca820a5d558633d423bf8bb78ce72a55394823f64089247f788a7e0ae691e", size = 213135, upload-time = "2026-04-25T11:08:12.575Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/0e/d8aecf95e09c42547453137be74d2f7b8b14e08f5177fa2fab6144a19061/xxhash-3.7.0-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f262b8f7599516567e070abf607b9af649052b2c4bd6f9be02b0cb41b7024805", size = 236379, upload-time = "2026-04-25T11:08:14.206Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/74/8140e8210536b3dd0cc816c4faaeb5ba6e63e8125ab25af4bcddd6a037b3/xxhash-3.7.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f1598916cb197681e03e601901e4ab96a9a963de398c59d0964f8a6f44a2b361", size = 212447, upload-time = "2026-04-25T11:08:15.79Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/462001d2903b4bee5a5689598a0a55e5e7cd1ac7f4247a5545cff10d3ebb/xxhash-3.7.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:322b2f0622230f526aeb1738149948a7ae357a9e2ceb1383c6fd1fdaecdafa16", size = 445660, upload-time = "2026-04-25T11:08:17.441Z" },
+    { url = "https://files.pythonhosted.org/packages/23/09/2bd1ed7f8689b20e51727952cac8329d50c694dc32b2eba06ba5bc742b37/xxhash-3.7.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:24cc22070880cc57b830a65cde4e65fa884c6d9b28ae4803b5ee05911e7bafba", size = 194076, upload-time = "2026-04-25T11:08:19.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/6e/692302cd0a5f4ac4e6289f37fa888dc2e1e07750b68fe3e4bfe939b8cea3/xxhash-3.7.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cb5a888a968b2434abf9ecda357b5d43f10d7b5a6da6fdbbe036208473aff0e2", size = 284990, upload-time = "2026-04-25T11:08:20.618Z" },
+    { url = "https://files.pythonhosted.org/packages/05/d9/e54b159b3d9df7999d2a7c676ce7b323d1b5588a64f8f51ed8172567bd87/xxhash-3.7.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a999771ff97bec27d18341be4f3a36b163bb1ac41ec17bef6d2dabd84acd33c7", size = 210590, upload-time = "2026-04-25T11:08:22.24Z" },
+    { url = "https://files.pythonhosted.org/packages/50/93/0e0df1a3a196ced4ca71de76d65ead25d8e87bbfb87b64306ea47a40c00d/xxhash-3.7.0-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:ed4a6efe2dee1655adb73e7ad40c6aa955a6892422b1e3b95de6a34de56e3cbb", size = 241442, upload-time = "2026-04-25T11:08:23.844Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a9/d917a7a814e90b218f8a0d37967105eea91bf752c3303683c99a1f7bfc1f/xxhash-3.7.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:9fd17f14ac0faa12126c2f9ca774a8cf342957265ec3c8669c144e5e6cdb478c", size = 198356, upload-time = "2026-04-25T11:08:25.99Z" },
+    { url = "https://files.pythonhosted.org/packages/89/5e/f2ba1877c39469abbefc72991d6ebdcbd4c0880db01ae8cb1f553b0c537d/xxhash-3.7.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:05fd1254268c59b5cb2a029dfc204275e9fc52de2913f1e53aa8d01442c96b4d", size = 210898, upload-time = "2026-04-25T11:08:27.608Z" },
+    { url = "https://files.pythonhosted.org/packages/90/c6/be56b58e73de531f39a10de1355bb77ceb663900dc4bf2d6d3002a9c3f9e/xxhash-3.7.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:a2eae53197c6276d5b317f75a1be226bbf440c20b58bf525f36b5d0e1f657ca6", size = 275519, upload-time = "2026-04-25T11:08:29.301Z" },
+    { url = "https://files.pythonhosted.org/packages/92/e2/17ddc85d5765b9c709f192009ed8f5a1fc876f4eb35bba7c307b5b1169f9/xxhash-3.7.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:bfe6f92e3522dcbe8c4281efd74fa7542a336cb00b0e3272c4ec0edabeaeaf67", size = 414191, upload-time = "2026-04-25T11:08:31.16Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/42/85f5b79f4bf1ec7ba052491164adfd4f4e9519f5dc7246de4fbd64a1bd56/xxhash-3.7.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7ab9a49c410d8c6c786ab99e79c529938d894c01433130353dd0fe999111077a", size = 191604, upload-time = "2026-04-25T11:08:32.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/d0/6127b623aa4cca18d8b7743592b048d689fd6c6e37ff26a22cddf6cd9d7f/xxhash-3.7.0-cp314-cp314-win32.whl", hash = "sha256:040ea63668f9185b92bc74942df09c7e65703deed71431333678fc6e739a9955", size = 31271, upload-time = "2026-04-25T11:08:34.651Z" },
+    { url = "https://files.pythonhosted.org/packages/64/4f/44fc4788568004c43921701cbc127f48218a1eede2c9aea231115323564d/xxhash-3.7.0-cp314-cp314-win_amd64.whl", hash = "sha256:2a61e2a3fb23c892496d587b470dee7fa1b58b248a187719c65ea8e94ec13257", size = 32284, upload-time = "2026-04-25T11:08:35.987Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/77/18bb895eb60a49453d16e17d67990e5caff557c78eafc90ad4e2eabf4570/xxhash-3.7.0-cp314-cp314-win_arm64.whl", hash = "sha256:c7741c7524961d8c0cb4d4c21b28957ff731a3fd5b5cd8b856dc80a40e9e5acc", size = 28701, upload-time = "2026-04-25T11:08:37.767Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a0/46f72244570c550fbbb7db1ef554183dd5ebe9136385f30e032b781ae8f6/xxhash-3.7.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:fc84bf7aa7592f31ec63a3e7b11d624f468a3f19f5238cec7282a42e838ab1d7", size = 33646, upload-time = "2026-04-25T11:08:39.109Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3a/453846a7eceea11e75def361eed01ec6a0205b9822c19927ed364ccae7cc/xxhash-3.7.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:9f1563fdc8abfc389748e6932c7e4e99c89a53e4ec37d4563c24fc06f5e5644b", size = 31125, upload-time = "2026-04-25T11:08:40.467Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/3e/49434aba738885d512f9e486db1bdd19db28dfa40372b56da26ef7a4e738/xxhash-3.7.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:2d415f18becf6f153046ab6adc97da77e3643a0ee205dae61c4012604113a020", size = 196633, upload-time = "2026-04-25T11:08:41.943Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/e9/006cb6127baeb9f8abe6d15e62faa01349f09b34e2bfd65175b2422d026b/xxhash-3.7.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bb16aa13ed175bc9be5c2491ba031b85a9b51c4ed90e0b3d4ebe63cf3fb54f8e", size = 215899, upload-time = "2026-04-25T11:08:43.645Z" },
+    { url = "https://files.pythonhosted.org/packages/27/e4/cc57d72e66df0ae29b914335f1c6dcf61e8f3746ddf0ae3c471aa4f15e00/xxhash-3.7.0-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:f9fd595f1e5941b3d7863e4774e4b30caa6731fc34b9277da032295aa5656ee5", size = 238116, upload-time = "2026-04-25T11:08:45.698Z" },
+    { url = "https://files.pythonhosted.org/packages/af/78/3531d4a3fd8a0038cc6be1f265a69c1b3587f557a10b677dd736de2202c1/xxhash-3.7.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:1295325c5a98d552333fa53dc2b026b0ef0ec9c8e73ca3a952990b4c7d65d459", size = 215012, upload-time = "2026-04-25T11:08:47.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/f6/259fb1eaaec921f59b17203b0daee69829761226d3b980d5191d7723dd83/xxhash-3.7.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3573a651d146912da9daa9e29e5fbc45994420daaa9ef1e2fa5823e1dc485513", size = 448534, upload-time = "2026-04-25T11:08:49.149Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/16/a66d0eaf6a7e68532c07714361ddc904c663ec940f3b028c1ae4a21a7b9d/xxhash-3.7.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5ec1e080a3d02d94ea9335bfab0e3374b877e25411422c18f51a943fa4b46381", size = 196217, upload-time = "2026-04-25T11:08:50.805Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/ef/d2efc7fc51756dc52509109d1a25cefc859d74bc4b19a167b12dbd8c2786/xxhash-3.7.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:84415265192072d8638a3afc3c1bc5995e310570cd9acb54dc46d3939e364fe0", size = 286906, upload-time = "2026-04-25T11:08:52.418Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/67/25decd1d4a4018582ec4db2a868a2b7e40640f4adb20dfeb19ac923aa825/xxhash-3.7.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d4dea659b57443989ef32f4295104fd6912c73d0bf26d1d148bb88a9f159b02", size = 213057, upload-time = "2026-04-25T11:08:54.105Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5d/17651eb29d06786cdc40c60ae3d27d645aa5d61d2eca6237a7ba0b94789b/xxhash-3.7.0-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:05ece0fe4d9c9c2728912d1981ae1566cfc83a011571b24732cbf76e1fb70dca", size = 243886, upload-time = "2026-04-25T11:08:56.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d4/174d9cf7502243d586e6a9ae842b1ae23026620995114f85f1380e588bc9/xxhash-3.7.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:fd880353cf1ffaf321bc18dd663e111976dbd0d3bbd8a66d58d2b470dfa7f396", size = 201015, upload-time = "2026-04-25T11:08:57.777Z" },
+    { url = "https://files.pythonhosted.org/packages/91/8c/2254e2d06c3ac5e6fe22eaf3da791b87ea823ae9f2c17b4af66755c5752d/xxhash-3.7.0-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:4e15cc9e2817f6481160f930c62842b3ff419e20e13072bcbab12230943092bc", size = 213457, upload-time = "2026-04-25T11:08:59.826Z" },
+    { url = "https://files.pythonhosted.org/packages/79/a2/e3daa762545921173e3360f3b4ff7fc63c2d27359f7230ec1a7a74e117f6/xxhash-3.7.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:90b9d1a8bd37d768ffc92a1f651ec69afc532a96fa1ac2ea7abbed5d630b3237", size = 277738, upload-time = "2026-04-25T11:09:01.423Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/4c/e186da2c46b87f5204640e008d42730bf3c1ee9f0efb71ae1ebcdfeac681/xxhash-3.7.0-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:157c49475b34ecea8809e51123d9769a534e139d1247942f7a4bc67710bb2533", size = 417127, upload-time = "2026-04-25T11:09:03.592Z" },
+    { url = "https://files.pythonhosted.org/packages/17/28/3798e15007a3712d0da3d3fe70f8e11916569858b5cc371053bc26270832/xxhash-3.7.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5a6ddec83325685e729ca119d1f5c518ec39294212ecd770e60693cdc5f7eb79", size = 193962, upload-time = "2026-04-25T11:09:06.228Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/95/a26baa93b5241fd7630998816a4ec47a5a0bad193b3f8fc8f3593e1a4a67/xxhash-3.7.0-cp314-cp314t-win32.whl", hash = "sha256:a04a6cab47e2166435aaf5b9e5ee41d1532cc8300efdef87f2a4d0acb7db19ed", size = 31643, upload-time = "2026-04-25T11:09:08.153Z" },
+    { url = "https://files.pythonhosted.org/packages/44/36/5454f13c447e395f9b06a3e91274c59f503d31fad84e1836efe3bdb71f6a/xxhash-3.7.0-cp314-cp314t-win_amd64.whl", hash = "sha256:8653dd7c2eda020545bb2c71c7f7039b53fe7434d0fc1a0a9deb79ab3f1a4fc1", size = 32522, upload-time = "2026-04-25T11:09:09.534Z" },
+    { url = "https://files.pythonhosted.org/packages/74/35/698e7e3ff38e22992ea24870a511d8762474fb6783627a2910ff22a185c2/xxhash-3.7.0-cp314-cp314t-win_arm64.whl", hash = "sha256:468f0fc114faaa4b36699f8e328bbc3bb11dc418ba94ac52c26dd736d4b6c637", size = 28807, upload-time = "2026-04-25T11:09:11.234Z" },
+]
+
+[[package]]
+name = "zstandard"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/fc/f26eb6ef91ae723a03e16eddb198abcfce2bc5a42e224d44cc8b6765e57e/zstandard-0.25.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7b3c3a3ab9daa3eed242d6ecceead93aebbb8f5f84318d82cee643e019c4b73b", size = 795738, upload-time = "2025-09-14T22:16:56.237Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1c/d920d64b22f8dd028a8b90e2d756e431a5d86194caa78e3819c7bf53b4b3/zstandard-0.25.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:913cbd31a400febff93b564a23e17c3ed2d56c064006f54efec210d586171c00", size = 640436, upload-time = "2025-09-14T22:16:57.774Z" },
+    { url = "https://files.pythonhosted.org/packages/53/6c/288c3f0bd9fcfe9ca41e2c2fbfd17b2097f6af57b62a81161941f09afa76/zstandard-0.25.0-cp312-cp312-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:011d388c76b11a0c165374ce660ce2c8efa8e5d87f34996aa80f9c0816698b64", size = 5343019, upload-time = "2025-09-14T22:16:59.302Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/15/efef5a2f204a64bdb5571e6161d49f7ef0fffdbca953a615efbec045f60f/zstandard-0.25.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dffecc361d079bb48d7caef5d673c88c8988d3d33fb74ab95b7ee6da42652ea", size = 5063012, upload-time = "2025-09-14T22:17:01.156Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/37/a6ce629ffdb43959e92e87ebdaeebb5ac81c944b6a75c9c47e300f85abdf/zstandard-0.25.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:7149623bba7fdf7e7f24312953bcf73cae103db8cae49f8154dd1eadc8a29ecb", size = 5394148, upload-time = "2025-09-14T22:17:03.091Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/79/2bf870b3abeb5c070fe2d670a5a8d1057a8270f125ef7676d29ea900f496/zstandard-0.25.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:6a573a35693e03cf1d67799fd01b50ff578515a8aeadd4595d2a7fa9f3ec002a", size = 5451652, upload-time = "2025-09-14T22:17:04.979Z" },
+    { url = "https://files.pythonhosted.org/packages/53/60/7be26e610767316c028a2cbedb9a3beabdbe33e2182c373f71a1c0b88f36/zstandard-0.25.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5a56ba0db2d244117ed744dfa8f6f5b366e14148e00de44723413b2f3938a902", size = 5546993, upload-time = "2025-09-14T22:17:06.781Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c7/3483ad9ff0662623f3648479b0380d2de5510abf00990468c286c6b04017/zstandard-0.25.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:10ef2a79ab8e2974e2075fb984e5b9806c64134810fac21576f0668e7ea19f8f", size = 5046806, upload-time = "2025-09-14T22:17:08.415Z" },
+    { url = "https://files.pythonhosted.org/packages/08/b3/206883dd25b8d1591a1caa44b54c2aad84badccf2f1de9e2d60a446f9a25/zstandard-0.25.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:aaf21ba8fb76d102b696781bddaa0954b782536446083ae3fdaa6f16b25a1c4b", size = 5576659, upload-time = "2025-09-14T22:17:10.164Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/31/76c0779101453e6c117b0ff22565865c54f48f8bd807df2b00c2c404b8e0/zstandard-0.25.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:1869da9571d5e94a85a5e8d57e4e8807b175c9e4a6294e3b66fa4efb074d90f6", size = 4953933, upload-time = "2025-09-14T22:17:11.857Z" },
+    { url = "https://files.pythonhosted.org/packages/18/e1/97680c664a1bf9a247a280a053d98e251424af51f1b196c6d52f117c9720/zstandard-0.25.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:809c5bcb2c67cd0ed81e9229d227d4ca28f82d0f778fc5fea624a9def3963f91", size = 5268008, upload-time = "2025-09-14T22:17:13.627Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/73/316e4010de585ac798e154e88fd81bb16afc5c5cb1a72eeb16dd37e8024a/zstandard-0.25.0-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:f27662e4f7dbf9f9c12391cb37b4c4c3cb90ffbd3b1fb9284dadbbb8935fa708", size = 5433517, upload-time = "2025-09-14T22:17:16.103Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/60/dd0f8cfa8129c5a0ce3ea6b7f70be5b33d2618013a161e1ff26c2b39787c/zstandard-0.25.0-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:99c0c846e6e61718715a3c9437ccc625de26593fea60189567f0118dc9db7512", size = 5814292, upload-time = "2025-09-14T22:17:17.827Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/5f/75aafd4b9d11b5407b641b8e41a57864097663699f23e9ad4dbb91dc6bfe/zstandard-0.25.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:474d2596a2dbc241a556e965fb76002c1ce655445e4e3bf38e5477d413165ffa", size = 5360237, upload-time = "2025-09-14T22:17:19.954Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/8d/0309daffea4fcac7981021dbf21cdb2e3427a9e76bafbcdbdf5392ff99a4/zstandard-0.25.0-cp312-cp312-win32.whl", hash = "sha256:23ebc8f17a03133b4426bcc04aabd68f8236eb78c3760f12783385171b0fd8bd", size = 436922, upload-time = "2025-09-14T22:17:24.398Z" },
+    { url = "https://files.pythonhosted.org/packages/79/3b/fa54d9015f945330510cb5d0b0501e8253c127cca7ebe8ba46a965df18c5/zstandard-0.25.0-cp312-cp312-win_amd64.whl", hash = "sha256:ffef5a74088f1e09947aecf91011136665152e0b4b359c42be3373897fb39b01", size = 506276, upload-time = "2025-09-14T22:17:21.429Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/6b/8b51697e5319b1f9ac71087b0af9a40d8a6288ff8025c36486e0c12abcc4/zstandard-0.25.0-cp312-cp312-win_arm64.whl", hash = "sha256:181eb40e0b6a29b3cd2849f825e0fa34397f649170673d385f3598ae17cca2e9", size = 462679, upload-time = "2025-09-14T22:17:23.147Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
+    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
+    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/5c/f8923b595b55fe49e30612987ad8bf053aef555c14f05bb659dd5dbe3e8a/zstandard-0.25.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e29f0cf06974c899b2c188ef7f783607dbef36da4c242eb6c82dcd8b512855e3", size = 795887, upload-time = "2025-09-14T22:17:54.198Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/09/d0a2a14fc3439c5f874042dca72a79c70a532090b7ba0003be73fee37ae2/zstandard-0.25.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:05df5136bc5a011f33cd25bc9f506e7426c0c9b3f9954f056831ce68f3b6689f", size = 640658, upload-time = "2025-09-14T22:17:55.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/7c/8b6b71b1ddd517f68ffb55e10834388d4f793c49c6b83effaaa05785b0b4/zstandard-0.25.0-cp314-cp314-manylinux2010_i686.manylinux_2_12_i686.manylinux_2_28_i686.whl", hash = "sha256:f604efd28f239cc21b3adb53eb061e2a205dc164be408e553b41ba2ffe0ca15c", size = 5379849, upload-time = "2025-09-14T22:17:57.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/86/a48e56320d0a17189ab7a42645387334fba2200e904ee47fc5a26c1fd8ca/zstandard-0.25.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223415140608d0f0da010499eaa8ccdb9af210a543fac54bce15babbcfc78439", size = 5058095, upload-time = "2025-09-14T22:17:59.498Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ad/eb659984ee2c0a779f9d06dbfe45e2dc39d99ff40a319895df2d3d9a48e5/zstandard-0.25.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2e54296a283f3ab5a26fc9b8b5d4978ea0532f37b231644f367aa588930aa043", size = 5551751, upload-time = "2025-09-14T22:18:01.618Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b3/b637faea43677eb7bd42ab204dfb7053bd5c4582bfe6b1baefa80ac0c47b/zstandard-0.25.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ca54090275939dc8ec5dea2d2afb400e0f83444b2fc24e07df7fdef677110859", size = 6364818, upload-time = "2025-09-14T22:18:03.769Z" },
+    { url = "https://files.pythonhosted.org/packages/31/dc/cc50210e11e465c975462439a492516a73300ab8caa8f5e0902544fd748b/zstandard-0.25.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e09bb6252b6476d8d56100e8147b803befa9a12cea144bbe629dd508800d1ad0", size = 5560402, upload-time = "2025-09-14T22:18:05.954Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/ae/56523ae9c142f0c08efd5e868a6da613ae76614eca1305259c3bf6a0ed43/zstandard-0.25.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a9ec8c642d1ec73287ae3e726792dd86c96f5681eb8df274a757bf62b750eae7", size = 4955108, upload-time = "2025-09-14T22:18:07.68Z" },
+    { url = "https://files.pythonhosted.org/packages/98/cf/c899f2d6df0840d5e384cf4c4121458c72802e8bda19691f3b16619f51e9/zstandard-0.25.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a4089a10e598eae6393756b036e0f419e8c1d60f44a831520f9af41c14216cf2", size = 5269248, upload-time = "2025-09-14T22:18:09.753Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/c0/59e912a531d91e1c192d3085fc0f6fb2852753c301a812d856d857ea03c6/zstandard-0.25.0-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:f67e8f1a324a900e75b5e28ffb152bcac9fbed1cc7b43f99cd90f395c4375344", size = 5430330, upload-time = "2025-09-14T22:18:11.966Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/7e31db1240de2df22a58e2ea9a93fc6e38cc29353e660c0272b6735d6669/zstandard-0.25.0-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:9654dbc012d8b06fc3d19cc825af3f7bf8ae242226df5f83936cb39f5fdc846c", size = 5811123, upload-time = "2025-09-14T22:18:13.907Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/49/fac46df5ad353d50535e118d6983069df68ca5908d4d65b8c466150a4ff1/zstandard-0.25.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4203ce3b31aec23012d3a4cf4a2ed64d12fea5269c49aed5e4c3611b938e4088", size = 5359591, upload-time = "2025-09-14T22:18:16.465Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/38/f249a2050ad1eea0bb364046153942e34abba95dd5520af199aed86fbb49/zstandard-0.25.0-cp314-cp314-win32.whl", hash = "sha256:da469dc041701583e34de852d8634703550348d5822e66a0c827d39b05365b12", size = 444513, upload-time = "2025-09-14T22:18:20.61Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/43/241f9615bcf8ba8903b3f0432da069e857fc4fd1783bd26183db53c4804b/zstandard-0.25.0-cp314-cp314-win_amd64.whl", hash = "sha256:c19bcdd826e95671065f8692b5a4aa95c52dc7a02a4c5a0cac46deb879a017a2", size = 516118, upload-time = "2025-09-14T22:18:17.849Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ef/da163ce2450ed4febf6467d77ccb4cd52c4c30ab45624bad26ca0a27260c/zstandard-0.25.0-cp314-cp314-win_arm64.whl", hash = "sha256:d7541afd73985c630bafcd6338d2518ae96060075f9463d7dc14cfb33514383d", size = 476940, upload-time = "2025-09-14T22:18:19.088Z" },
+]


### PR DESCRIPTION
## Summary

- Add a Linux/Windows CI baseline that runs Ruff, pytest, gold verifier checks, package build, and package-content validation.
- Add GitHub Actions annotations for gold verifier failures so Windows/Linux failures are easier to inspect.
- Add a manual `workflow_dispatch` Windows benchmark smoke workflow with `run`, `run-pure`, `run-openrouter`, and `run-cli` runners, preflight secret checks, kept workspace artifacts, and UTF-8 environment settings.
- Add `--allow-task-failures` so mechanics-only smoke runs can report task-level failures without failing the harness job when the runner completed and produced a report.
- Classify LangGraph recursion-limit exceptions as normal task failures instead of uncaught harness crashes.
- Let `gigachat-sdk` use its default endpoint unless `GIGACHAT_BASE_URL` is explicitly set, and add `tzdata` for Windows `zoneinfo` checks.
- Replace the Unicode progress arrow with an ASCII `[START]` marker so benchmark runs do not crash in Windows `cmd.exe` CP1251 consoles.

## Test plan

- `uv sync --dev`
- `uv run ruff check .`
- `uv run pytest`
- `uv run python -m harness_bench version --check`
- `uv run python .github/scripts/verify_gold_with_annotations.py`
- `uv build`
- `uv run python .github/scripts/check_package_contents.py`

Local results: Ruff passed, pytest passed (`9 passed` after the CP1251 regression test addition), task-set metadata check passed, gold verification passed (`231/231 OK`), package build and package-content check passed.

Fork CI also passed on the latest commit:

https://github.com/trashchenkov/harness-bench-fast/actions/runs/26332550460

## Manual Windows smoke

After this workflow file is present on the fork/default branch, run:

- Actions → Windows benchmark smoke → Run workflow
- Default runner: `run-cli`
- Required secret for the default OpenRouter-backed CLI command: `OPENROUTER_API_KEY`

The smoke workflow intentionally passes `--allow-task-failures`: individual benchmark task failures remain visible as task `FAIL`s in the report, but the job stays green when the harness mechanics complete successfully.

Note: the workflow has been exposed on the fork default branch for manual testing, and it checks out `hermes-windows-bench-smoke` for the benchmark code under test.