### PR TITLE
Add repeated benchmark attempts and pass@/pass^ metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ uv run python -m harness_bench run-cli \
     --concurrency 5
 
 # Run repeated attempts and report pass@ / pass^ metrics. With
-# --attempts N, summaries print pass@1, pass@N, and pass^N by default;
+# --attempts N, summaries print pass@1..N and pass^1..N by default;
 # --pass-at/--pass@ and --pass-hat/--pass^ can request specific K values.
 uv run python -m harness_bench run-cli \
     --cli-command 'free-code -p --model haiku --dangerously-skip-permissions' \

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ uv run python -m harness_bench run-cli \
     --cli-command 'free-code -p --model haiku --dangerously-skip-permissions' \
     --concurrency 5
 
+# Run repeated attempts and report pass@ / pass^ metrics. With
+# --attempts N, summaries print pass@1, pass@N, and pass^N by default;
+# --pass-at/--pass@ and --pass-hat/--pass^ can request specific K values.
+uv run python -m harness_bench run-cli \
+    --cli-command 'free-code -p --model haiku --dangerously-skip-permissions' \
+    --attempts 5 --pass@ 5 --pass^ 5 --concurrency 5
+
 # Verify the gold solutions without calling any model. Useful when
 # adding a new task — confirms the verifier accepts a hand-written
 # "perfect" solution.
@@ -104,6 +111,7 @@ changes do not need a task-set bump.
 | File | Purpose |
 | --- | --- |
 | `core.py` | `Task` (dataclass) and `VerifyResult`. Supports `setup_callback` / `gold_callback` hooks for binary fixtures (xlsx, sqlite, zip, tar). |
+| `metrics.py` | Computes `pass@K` (at least one of K attempts passes) and `pass^K` (all K attempts pass) from repeated task runs. |
 | `verifiers.py` | Helpers for building verifiers: `file_exists`, `file_contains`, `file_lines_equal`, `file_matches_regex`, `json_file_has`, `python_runs`, `python_callable_returns`, `pytest_passes`, `xlsx_cell_equals`, `sqlite_query_returns`, `all_of`, etc. |
 | `runner.py` | Runs a task in an isolated `tempfile.TemporaryDirectory` with `LocalShellBackend(virtual_mode=True)` rooted at that directory. Drives GigaChat through `langchain-gigachat`. Optional `--concurrency` via a thread pool. Auto-loads the `deepagents-gigachat` harness profile if installed. |
 | `runner_cli.py` | Alternative driver that shells out to an external CLI agent (`free-code`, `claude`, etc.). Default: `free-code -p --model haiku --dangerously-skip-permissions`. Detects Claude-Code-style CLIs and auto-injects workspace `AGENTS.md` via `--append-system-prompt`. |

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -167,6 +167,7 @@ def _positive_int(value: str) -> int:
 
 def _add_metric_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
+        "-k",
         "--attempts",
         type=_positive_int,
         default=1,

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -172,7 +172,7 @@ def _add_metric_args(parser: argparse.ArgumentParser) -> None:
         default=1,
         help=(
             "Run each selected task N independent times. Default: 1. "
-            "Use N > 1 to compute pass@N / pass^N."
+            "Use N > 1 to compute pass@K / pass^K for K=1..N."
         ),
     )
     parser.add_argument(
@@ -184,7 +184,7 @@ def _add_metric_args(parser: argparse.ArgumentParser) -> None:
         metavar="K",
         help=(
             "Print pass@K (at least one of K attempts passes). Repeatable. "
-            "Defaults to pass@1, plus pass@N when --attempts N > 1."
+            "Defaults to all K values from 1 to --attempts."
         ),
     )
     parser.add_argument(
@@ -197,7 +197,7 @@ def _add_metric_args(parser: argparse.ArgumentParser) -> None:
         metavar="K",
         help=(
             "Print pass^K (all K attempts pass). Repeatable. "
-            "Defaults to pass^N when --attempts N > 1."
+            "Defaults to all K values from 1 to --attempts."
         ),
     )
 

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -21,6 +21,7 @@ import argparse
 import json
 import sys
 
+from harness_bench.metrics import default_metric_ks
 from harness_bench.runner import run_all, summarize, verify_gold
 from harness_bench.runner_cli import DEFAULT_CLI_COMMAND, DEFAULT_TIMEOUT_SECONDS, run_all_cli
 from harness_bench.runner_openrouter import DEFAULT_OPENROUTER_MODEL
@@ -85,48 +86,56 @@ def _cmd_version(args: argparse.Namespace) -> int:
 
 
 def _cmd_run(args: argparse.Namespace) -> int:
+    pass_at_ks, pass_hat_ks = _resolve_metric_ks(args)
     results = run_all(
         task_ids=args.task,
         keep_workspace=args.keep,
         recursion_limit=args.recursion_limit,
         concurrency=args.concurrency,
+        attempts=args.attempts,
     )
-    summarize(results)
+    summarize(results, pass_at_ks=pass_at_ks, pass_hat_ks=pass_hat_ks)
     return 0 if all(r.passed for r in results) else 1
 
 
 def _cmd_run_openrouter(args: argparse.Namespace) -> int:
+    pass_at_ks, pass_hat_ks = _resolve_metric_ks(args)
     results = run_all_openrouter(
         task_ids=args.task,
         model_name=args.model,
         keep_workspace=args.keep,
         recursion_limit=args.recursion_limit,
         concurrency=args.concurrency,
+        attempts=args.attempts,
     )
-    summarize(results)
+    summarize(results, pass_at_ks=pass_at_ks, pass_hat_ks=pass_hat_ks)
     return 0 if all(r.passed for r in results) else 1
 
 
 def _cmd_run_pure(args: argparse.Namespace) -> int:
+    pass_at_ks, pass_hat_ks = _resolve_metric_ks(args)
     results = run_all_pure(
         task_ids=args.task,
         keep_workspace=args.keep,
         recursion_limit=args.recursion_limit,
         concurrency=args.concurrency,
+        attempts=args.attempts,
     )
-    summarize(results)
+    summarize(results, pass_at_ks=pass_at_ks, pass_hat_ks=pass_hat_ks)
     return 0 if all(r.passed for r in results) else 1
 
 
 def _cmd_run_cli(args: argparse.Namespace) -> int:
+    pass_at_ks, pass_hat_ks = _resolve_metric_ks(args)
     results = run_all_cli(
         task_ids=args.task,
         cli_command=args.cli_command,
         timeout=args.timeout,
         keep_workspace=args.keep,
         concurrency=args.concurrency,
+        attempts=args.attempts,
     )
-    summarize(results)
+    summarize(results, pass_at_ks=pass_at_ks, pass_hat_ks=pass_hat_ks)
     return 0 if all(r.passed for r in results) else 1
 
 
@@ -144,6 +153,66 @@ def _cmd_verify_gold(args: argparse.Namespace) -> int:
             print(f"  - {r.task_id}: {head[0] if head else ''}")
         return 1
     return 0
+
+
+def _positive_int(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}") from exc
+    if parsed < 1:
+        raise argparse.ArgumentTypeError(f"expected a positive integer, got {value!r}")
+    return parsed
+
+
+def _add_metric_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--attempts",
+        type=_positive_int,
+        default=1,
+        help=(
+            "Run each selected task N independent times. Default: 1. "
+            "Use N > 1 to compute pass@N / pass^N."
+        ),
+    )
+    parser.add_argument(
+        "--pass-at",
+        "--pass@",
+        dest="pass_at",
+        action="append",
+        type=_positive_int,
+        metavar="K",
+        help=(
+            "Print pass@K (at least one of K attempts passes). Repeatable. "
+            "Defaults to pass@1, plus pass@N when --attempts N > 1."
+        ),
+    )
+    parser.add_argument(
+        "--pass-hat",
+        "--pass-caret",
+        "--pass^",
+        dest="pass_hat",
+        action="append",
+        type=_positive_int,
+        metavar="K",
+        help=(
+            "Print pass^K (all K attempts pass). Repeatable. "
+            "Defaults to pass^N when --attempts N > 1."
+        ),
+    )
+
+
+def _resolve_metric_ks(args: argparse.Namespace) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    default_pass_at, default_pass_hat = default_metric_ks(args.attempts)
+    pass_at_ks = tuple(args.pass_at) if args.pass_at else default_pass_at
+    pass_hat_ks = tuple(args.pass_hat) if args.pass_hat else default_pass_hat
+    too_large = [k for k in (*pass_at_ks, *pass_hat_ks) if k > args.attempts]
+    if too_large:
+        joined = ", ".join(str(k) for k in too_large)
+        raise SystemExit(
+            f"Metric k cannot exceed --attempts ({args.attempts}); got: {joined}"
+        )
+    return pass_at_ks, pass_hat_ks
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -186,6 +255,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run up to N tasks in parallel (default: 1; uses a thread pool, "
         "each task still has its own isolated TemporaryDirectory).",
     )
+    _add_metric_args(p_run)
     p_run.set_defaults(func=_cmd_run)
 
     p_or = sub.add_parser(
@@ -204,6 +274,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_or.add_argument("--keep", action="store_true", help="Keep temp workspaces")
     p_or.add_argument("--recursion-limit", type=int, default=80)
     p_or.add_argument("--concurrency", type=int, default=1)
+    _add_metric_args(p_or)
     p_or.set_defaults(func=_cmd_run_openrouter)
 
     p_pure = sub.add_parser(
@@ -217,6 +288,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_pure.add_argument("--keep", action="store_true", help="Keep temp workspaces")
     p_pure.add_argument("--recursion-limit", type=int, default=80)
     p_pure.add_argument("--concurrency", type=int, default=1)
+    _add_metric_args(p_pure)
     p_pure.set_defaults(func=_cmd_run_pure)
 
     p_gold = sub.add_parser(
@@ -264,6 +336,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=1,
         help="Run up to N tasks in parallel (default: 1).",
     )
+    _add_metric_args(p_cli)
     p_cli.set_defaults(func=_cmd_run_cli)
 
     return parser

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -102,15 +102,27 @@ def _maybe_write_json(args: argparse.Namespace, results: list) -> None:
         print(f"\nWrote results JSON to {json_output}")
 
 
-def _summarize_run(args: argparse.Namespace, results: list) -> None:
+def _metric_ks_for_args(
+    args: argparse.Namespace,
+) -> tuple[tuple[int, ...], tuple[int, ...]] | None:
     if args.attempts == 1 and not args.pass_at and not args.pass_hat:
+        return None
+    return _resolve_metric_ks(args)
+
+
+def _summarize_run(
+    results: list,
+    metric_ks: tuple[tuple[int, ...], tuple[int, ...]] | None,
+) -> None:
+    if metric_ks is None:
         summarize(results)
         return
-    pass_at_ks, pass_hat_ks = _resolve_metric_ks(args)
+    pass_at_ks, pass_hat_ks = metric_ks
     summarize(results, pass_at_ks=pass_at_ks, pass_hat_ks=pass_hat_ks)
 
 
 def _cmd_run(args: argparse.Namespace) -> int:
+    metric_ks = _metric_ks_for_args(args)
     results = run_all(
         task_ids=args.task,
         keep_workspace=args.keep,
@@ -118,12 +130,13 @@ def _cmd_run(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
         attempts=args.attempts,
     )
-    _summarize_run(args, results)
+    _summarize_run(results, metric_ks)
     _maybe_write_json(args, results)
     return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
 def _cmd_run_openrouter(args: argparse.Namespace) -> int:
+    metric_ks = _metric_ks_for_args(args)
     results = run_all_openrouter(
         task_ids=args.task,
         model_name=args.model,
@@ -134,12 +147,13 @@ def _cmd_run_openrouter(args: argparse.Namespace) -> int:
         harness_profile=args.harness_profile,
         attempts=args.attempts,
     )
-    _summarize_run(args, results)
+    _summarize_run(results, metric_ks)
     _maybe_write_json(args, results)
     return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
 def _cmd_run_pure(args: argparse.Namespace) -> int:
+    metric_ks = _metric_ks_for_args(args)
     results = run_all_pure(
         task_ids=args.task,
         keep_workspace=args.keep,
@@ -147,12 +161,13 @@ def _cmd_run_pure(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
         attempts=args.attempts,
     )
-    _summarize_run(args, results)
+    _summarize_run(results, metric_ks)
     _maybe_write_json(args, results)
     return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
 def _cmd_run_cli(args: argparse.Namespace) -> int:
+    metric_ks = _metric_ks_for_args(args)
     results = run_all_cli(
         task_ids=args.task,
         cli_command=args.cli_command,
@@ -161,7 +176,7 @@ def _cmd_run_cli(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
         attempts=args.attempts,
     )
-    _summarize_run(args, results)
+    _summarize_run(results, metric_ks)
     _maybe_write_json(args, results)
     return _exit_code(results, allow_task_failures=args.allow_task_failures)
 

--- a/harness_bench/metrics.py
+++ b/harness_bench/metrics.py
@@ -1,0 +1,138 @@
+"""Pass@k and pass^k metric helpers for benchmark runs."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from collections.abc import Iterable, Sequence
+from dataclasses import dataclass
+from math import comb
+from typing import Literal, Protocol
+
+
+class RunLike(Protocol):
+    """Minimal shape needed from a task run."""
+
+    task_id: str
+    passed: bool
+
+
+MetricKind = Literal["pass@", "pass^"]
+
+
+@dataclass(frozen=True)
+class PassMetric:
+    """A benchmark-level pass metric averaged across tasks."""
+
+    kind: MetricKind
+    k: int
+    value: float
+    task_count: int
+
+    @property
+    def label(self) -> str:
+        return f"{self.kind}{self.k}"
+
+
+def pass_at_k(num_samples: int, num_correct: int, k: int) -> float:
+    """Estimate probability that at least one of `k` samples passes."""
+    _validate_counts(num_samples, num_correct, k)
+    if num_correct == 0:
+        return 0.0
+    if num_samples - num_correct < k:
+        return 1.0
+    return 1.0 - (comb(num_samples - num_correct, k) / comb(num_samples, k))
+
+
+def pass_hat_k(num_samples: int, num_correct: int, k: int) -> float:
+    """Estimate probability that all `k` samples pass (`pass^k`)."""
+    _validate_counts(num_samples, num_correct, k)
+    if num_correct < k:
+        return 0.0
+    return comb(num_correct, k) / comb(num_samples, k)
+
+
+def compute_pass_metrics(
+    results: Iterable[RunLike],
+    *,
+    pass_at_ks: Sequence[int] = (),
+    pass_hat_ks: Sequence[int] = (),
+) -> list[PassMetric]:
+    """Compute requested pass metrics from one or more attempts per task.
+
+    `pass@k` is the probability that at least one of `k` independent attempts
+    solves a task. `pass^k` is the stricter probability that all `k` attempts
+    solve it. Both are averaged over tasks.
+    """
+    grouped = _group_passes(results)
+    metrics: list[PassMetric] = []
+    for k in _dedupe_positive(pass_at_ks):
+        metrics.append(_compute_group_metric(grouped, "pass@", k))
+    for k in _dedupe_positive(pass_hat_ks):
+        metrics.append(_compute_group_metric(grouped, "pass^", k))
+    return metrics
+
+
+def default_metric_ks(num_attempts: int) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    """Default metrics for CLI summaries."""
+    if num_attempts < 1:
+        raise ValueError("num_attempts must be positive")
+    if num_attempts == 1:
+        return (1,), ()
+    return (1, num_attempts), (num_attempts,)
+
+
+def format_metric(metric: PassMetric) -> str:
+    """Format a pass metric as a concise percentage line."""
+    return f"{metric.label}: {metric.value * 100:.1f}%"
+
+
+def _compute_group_metric(
+    grouped: OrderedDict[str, list[bool]],
+    kind: MetricKind,
+    k: int,
+) -> PassMetric:
+    values: list[float] = []
+    for task_id, passes in grouped.items():
+        num_samples = len(passes)
+        num_correct = sum(passes)
+        if k > num_samples:
+            raise ValueError(
+                f"{kind}{k} requires at least {k} attempts for {task_id}; "
+                f"got {num_samples}"
+            )
+        if kind == "pass@":
+            values.append(pass_at_k(num_samples, num_correct, k))
+        else:
+            values.append(pass_hat_k(num_samples, num_correct, k))
+    value = sum(values) / len(values) if values else 0.0
+    return PassMetric(kind=kind, k=k, value=value, task_count=len(values))
+
+
+def _group_passes(results: Iterable[RunLike]) -> OrderedDict[str, list[bool]]:
+    grouped: OrderedDict[str, list[bool]] = OrderedDict()
+    for result in results:
+        grouped.setdefault(result.task_id, []).append(result.passed)
+    return grouped
+
+
+def _dedupe_positive(values: Sequence[int]) -> tuple[int, ...]:
+    seen: set[int] = set()
+    deduped: list[int] = []
+    for value in values:
+        if value < 1:
+            raise ValueError("metric k must be positive")
+        if value not in seen:
+            deduped.append(value)
+            seen.add(value)
+    return tuple(deduped)
+
+
+def _validate_counts(num_samples: int, num_correct: int, k: int) -> None:
+    if num_samples < 1:
+        raise ValueError("num_samples must be positive")
+    if k < 1:
+        raise ValueError("k must be positive")
+    if k > num_samples:
+        raise ValueError("k cannot exceed num_samples")
+    if num_correct < 0 or num_correct > num_samples:
+        raise ValueError("num_correct must be between 0 and num_samples")

--- a/harness_bench/metrics.py
+++ b/harness_bench/metrics.py
@@ -76,9 +76,8 @@ def default_metric_ks(num_attempts: int) -> tuple[tuple[int, ...], tuple[int, ..
     """Default metrics for CLI summaries."""
     if num_attempts < 1:
         raise ValueError("num_attempts must be positive")
-    if num_attempts == 1:
-        return (1,), ()
-    return (1, num_attempts), (num_attempts,)
+    ks = tuple(range(1, num_attempts + 1))
+    return ks, ks
 
 
 def format_metric(metric: PassMetric) -> str:

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -7,12 +7,13 @@ import threading
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
 
 from harness_bench.core import Task, VerifyResult
+from harness_bench.metrics import compute_pass_metrics, format_metric
 from harness_bench.tasks import ALL_TASKS, get_task
 
 
@@ -26,6 +27,8 @@ class TaskRun:
     elapsed_seconds: float
     error: str | None = None
     workspace: Path | None = None
+    attempt: int = 1
+    attempts: int = 1
 
 
 def _load_env_from_dotenv() -> None:
@@ -155,6 +158,7 @@ def run_all(
     keep_workspace: bool = False,
     recursion_limit: int = 80,
     concurrency: int = 1,
+    attempts: int = 1,
 ) -> list[TaskRun]:
     """Run a subset (or all) of the benchmark tasks.
 
@@ -169,23 +173,32 @@ def run_all(
     _load_env_from_dotenv()
     _ensure_credentials()
 
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
+
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
 
     if concurrency <= 1:
         results: list[TaskRun] = []
         for task in targets:
-            print(f"→ {task.id}: {task.name}")
-            run = run_task(task, keep_workspace=keep_workspace, recursion_limit=recursion_limit)
-            results.append(run)
-            status = "PASS" if run.passed else "FAIL"
-            print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-            if keep_workspace and run.workspace:
-                print(f"  workspace: {run.workspace}")
+            for attempt in range(1, attempts + 1):
+                print(f"→ {task.id}: {task.name}{_attempt_suffix(attempt, attempts)}")
+                run = run_task(
+                    task,
+                    keep_workspace=keep_workspace,
+                    recursion_limit=recursion_limit,
+                )
+                run = _mark_attempt(run, attempt, attempts)
+                results.append(run)
+                status = "PASS" if run.passed else "FAIL"
+                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                if keep_workspace and run.workspace:
+                    print(f"  workspace: {run.workspace}")
         return results
 
     print_lock = threading.Lock()
     completed = 0
-    total = len(targets)
+    total = len(targets) * attempts
     results = []
     with ThreadPoolExecutor(max_workers=concurrency) as executor:
         future_to_task = {
@@ -194,22 +207,25 @@ def run_all(
                 task,
                 keep_workspace=keep_workspace,
                 recursion_limit=recursion_limit,
-            ): task
+            ): (task, attempt)
             for task in targets
+            for attempt in range(1, attempts + 1)
         }
         for future in as_completed(future_to_task):
-            run = future.result()
+            _task, attempt = future_to_task[future]
+            run = _mark_attempt(future.result(), attempt, attempts)
             results.append(run)
             with print_lock:
                 completed += 1
                 status = "PASS" if run.passed else "FAIL"
                 print(
-                    f"[{completed:3d}/{total}] [{status}] {run.task_id:32s} "
+                    f"[{completed:3d}/{total}] [{status}] "
+                    f"{_task_attempt_label(run):40s} "
                     f"{run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}"
                 )
                 if keep_workspace and run.workspace:
                     print(f"           workspace: {run.workspace}")
-    results.sort(key=lambda r: _task_sort_key(r.task_id))
+    results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     return results
 
 
@@ -243,20 +259,48 @@ def _one_line_detail(run: TaskRun) -> str:
     return "(no detail)"
 
 
-def summarize(results: list[TaskRun]) -> None:
+def _mark_attempt(run: TaskRun, attempt: int, attempts: int) -> TaskRun:
+    return replace(run, attempt=attempt, attempts=attempts)
+
+
+def _attempt_suffix(attempt: int, attempts: int) -> str:
+    if attempts == 1:
+        return ""
+    return f" (attempt {attempt}/{attempts})"
+
+
+def _task_attempt_label(run: TaskRun) -> str:
+    if run.attempts == 1:
+        return run.task_id
+    return f"{run.task_id} #{run.attempt}/{run.attempts}"
+
+
+def summarize(
+    results: list[TaskRun],
+    *,
+    pass_at_ks: tuple[int, ...] = (1,),
+    pass_hat_ks: tuple[int, ...] = (),
+) -> None:
     """Print a pass/fail summary block at the end of a run."""
     total = len(results)
     passed = sum(1 for r in results if r.passed)
     print()
     print("=" * 64)
-    print(f"Passed: {passed}/{total}")
+    label = "Passed" if all(r.attempts == 1 for r in results) else "Passed attempts"
+    print(f"{label}: {passed}/{total}")
+    metrics = compute_pass_metrics(results, pass_at_ks=pass_at_ks, pass_hat_ks=pass_hat_ks)
+    if metrics:
+        print()
+        print("Metrics:")
+        for metric in metrics:
+            print(f"  {format_metric(metric)}")
     if passed < total:
         print()
         print("Failures:")
         for r in results:
             if r.passed:
                 continue
-            print(f"  - {r.task_id}: {_one_line_detail(r)}")
+            print(f"  - {_task_attempt_label(r)}: {_one_line_detail(r)}")
 
 
 # ---------------------------------------------------------------------------

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -13,7 +13,7 @@ from tempfile import TemporaryDirectory
 from typing import Any
 
 from harness_bench.core import Task, VerifyResult
-from harness_bench.metrics import compute_pass_metrics, format_metric
+from harness_bench.metrics import PassMetric, compute_pass_metrics
 from harness_bench.tasks import ALL_TASKS, get_task
 
 
@@ -292,8 +292,8 @@ def summarize(
     if metrics:
         print()
         print("Metrics:")
-        for metric in metrics:
-            print(f"  {format_metric(metric)}")
+        for line in _format_metrics_table(metrics):
+            print(f"  {line}")
     if passed < total:
         print()
         print("Failures:")
@@ -301,6 +301,44 @@ def summarize(
             if r.passed:
                 continue
             print(f"  - {_task_attempt_label(r)}: {_one_line_detail(r)}")
+
+
+def _format_metrics_table(metrics: list[PassMetric]) -> list[str]:
+    metric_by_key = {(metric.kind, metric.k): metric for metric in metrics}
+    ks = sorted({metric.k for metric in metrics})
+    kinds = [kind for kind in ("pass@", "pass^") if any(m.kind == kind for m in metrics)]
+    headers = ["K", *(f"{kind}K" for kind in kinds)]
+    rows = [
+        [
+            str(k),
+            *[
+                _format_metric_value(metric_by_key.get((kind, k)))
+                for kind in kinds
+            ],
+        ]
+        for k in ks
+    ]
+    widths = [
+        max(len(row[i]) for row in [headers, *rows])
+        for i in range(len(headers))
+    ]
+    lines = [
+        _format_table_row(headers, widths),
+        _format_table_row(["-" * width for width in widths], widths),
+    ]
+    lines.extend(_format_table_row(row, widths) for row in rows)
+    return lines
+
+
+def _format_metric_value(metric: PassMetric | None) -> str:
+    if metric is None:
+        return "-"
+    return f"{metric.value * 100:.1f}%"
+
+
+def _format_table_row(values: list[str], widths: list[int]) -> str:
+    cells = [value.rjust(width) for value, width in zip(values, widths, strict=True)]
+    return "  ".join(cells)
 
 
 # ---------------------------------------------------------------------------

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -333,7 +333,10 @@ def _format_metrics_table(metrics: list[PassMetric]) -> list[str]:
 def _format_metric_value(metric: PassMetric | None) -> str:
     if metric is None:
         return "-"
-    return f"{metric.value * 100:.1f}%"
+    task_equivalent = metric.value * metric.task_count
+    rounded = round(task_equivalent)
+    count = str(rounded) if abs(task_equivalent - rounded) < 1e-9 else f"{task_equivalent:.1f}"
+    return f"{count}/{metric.task_count}"
 
 
 def _format_table_row(values: list[str], widths: list[int]) -> str:

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -32,8 +32,11 @@ from tempfile import TemporaryDirectory, mkdtemp
 from harness_bench.core import Task
 from harness_bench.runner import (
     TaskRun,
+    _attempt_suffix,
     _load_env_from_dotenv,
+    _mark_attempt,
     _one_line_detail,
+    _task_attempt_label,
     _task_sort_key,
     summarize,
 )
@@ -454,31 +457,37 @@ def run_all_cli(
     timeout: int = DEFAULT_TIMEOUT_SECONDS,
     keep_workspace: bool = False,
     concurrency: int = 1,
+    attempts: int = 1,
 ) -> list[TaskRun]:
     """Run a subset (or all) of the benchmark via the CLI agent."""
     _load_env_from_dotenv()
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
+
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
 
     if concurrency <= 1:
         results: list[TaskRun] = []
         for task in targets:
-            print(f"→ {task.id}: {task.name}")
-            run = run_task_cli(
-                task,
-                cli_command=cli_command,
-                timeout=timeout,
-                keep_workspace=keep_workspace,
-            )
-            results.append(run)
-            status = "PASS" if run.passed else "FAIL"
-            print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-            if keep_workspace and run.workspace:
-                print(f"  workspace: {run.workspace}")
+            for attempt in range(1, attempts + 1):
+                print(f"→ {task.id}: {task.name}{_attempt_suffix(attempt, attempts)}")
+                run = run_task_cli(
+                    task,
+                    cli_command=cli_command,
+                    timeout=timeout,
+                    keep_workspace=keep_workspace,
+                )
+                run = _mark_attempt(run, attempt, attempts)
+                results.append(run)
+                status = "PASS" if run.passed else "FAIL"
+                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                if keep_workspace and run.workspace:
+                    print(f"  workspace: {run.workspace}")
         return results
 
     print_lock = threading.Lock()
     completed = 0
-    total = len(targets)
+    total = len(targets) * attempts
     results = []
     with ThreadPoolExecutor(max_workers=concurrency) as executor:
         future_to_task = {
@@ -488,22 +497,25 @@ def run_all_cli(
                 cli_command=cli_command,
                 timeout=timeout,
                 keep_workspace=keep_workspace,
-            ): task
+            ): (task, attempt)
             for task in targets
+            for attempt in range(1, attempts + 1)
         }
         for future in as_completed(future_to_task):
-            run = future.result()
+            _task, attempt = future_to_task[future]
+            run = _mark_attempt(future.result(), attempt, attempts)
             results.append(run)
             with print_lock:
                 completed += 1
                 status = "PASS" if run.passed else "FAIL"
                 print(
-                    f"[{completed:3d}/{total}] [{status}] {run.task_id:36s} "
+                    f"[{completed:3d}/{total}] [{status}] "
+                    f"{_task_attempt_label(run):40s} "
                     f"{run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}"
                 )
                 if keep_workspace and run.workspace:
                     print(f"           workspace: {run.workspace}")
-    results.sort(key=lambda r: _task_sort_key(r.task_id))
+    results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     return results
 
 

--- a/harness_bench/runner_openrouter.py
+++ b/harness_bench/runner_openrouter.py
@@ -20,8 +20,11 @@ from typing import Any
 from harness_bench.core import Task
 from harness_bench.runner import (
     TaskRun,
+    _attempt_suffix,
     _load_env_from_dotenv,
+    _mark_attempt,
     _one_line_detail,
+    _task_attempt_label,
     _task_sort_key,
 )
 from harness_bench.tasks import ALL_TASKS, get_task
@@ -125,32 +128,38 @@ def run_all(
     keep_workspace: bool = False,
     recursion_limit: int = 80,
     concurrency: int = 1,
+    attempts: int = 1,
 ) -> list[TaskRun]:
     _load_env_from_dotenv()
     _ensure_openrouter_key()
+
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
 
     if concurrency <= 1:
         results: list[TaskRun] = []
         for task in targets:
-            print(f"→ {task.id}: {task.name}")
-            run = run_task(
-                task,
-                model_name=model_name,
-                keep_workspace=keep_workspace,
-                recursion_limit=recursion_limit,
-            )
-            results.append(run)
-            status = "PASS" if run.passed else "FAIL"
-            print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-            if keep_workspace and run.workspace:
-                print(f"  workspace: {run.workspace}")
+            for attempt in range(1, attempts + 1):
+                print(f"→ {task.id}: {task.name}{_attempt_suffix(attempt, attempts)}")
+                run = run_task(
+                    task,
+                    model_name=model_name,
+                    keep_workspace=keep_workspace,
+                    recursion_limit=recursion_limit,
+                )
+                run = _mark_attempt(run, attempt, attempts)
+                results.append(run)
+                status = "PASS" if run.passed else "FAIL"
+                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                if keep_workspace and run.workspace:
+                    print(f"  workspace: {run.workspace}")
         return results
 
     print_lock = threading.Lock()
     completed = 0
-    total = len(targets)
+    total = len(targets) * attempts
     results = []
     with ThreadPoolExecutor(max_workers=concurrency) as executor:
         future_to_task = {
@@ -160,20 +169,23 @@ def run_all(
                 model_name=model_name,
                 keep_workspace=keep_workspace,
                 recursion_limit=recursion_limit,
-            ): task
+            ): (task, attempt)
             for task in targets
+            for attempt in range(1, attempts + 1)
         }
         for future in as_completed(future_to_task):
-            run = future.result()
+            _task, attempt = future_to_task[future]
+            run = _mark_attempt(future.result(), attempt, attempts)
             results.append(run)
             with print_lock:
                 completed += 1
                 status = "PASS" if run.passed else "FAIL"
                 print(
-                    f"[{completed:3d}/{total}] [{status}] {run.task_id:32s} "
+                    f"[{completed:3d}/{total}] [{status}] "
+                    f"{_task_attempt_label(run):40s} "
                     f"{run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}"
                 )
                 if keep_workspace and run.workspace:
                     print(f"           workspace: {run.workspace}")
-    results.sort(key=lambda r: _task_sort_key(r.task_id))
+    results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     return results

--- a/harness_bench/runner_pure.py
+++ b/harness_bench/runner_pure.py
@@ -14,8 +14,11 @@ from typing import Any
 from harness_bench.core import Task
 from harness_bench.runner import (
     TaskRun,
+    _attempt_suffix,
     _load_env_from_dotenv,
+    _mark_attempt,
     _one_line_detail,
+    _task_attempt_label,
     _task_sort_key,
 )
 from harness_bench.tasks import ALL_TASKS, get_task
@@ -116,27 +119,37 @@ def run_all(
     keep_workspace: bool = False,
     recursion_limit: int = 80,
     concurrency: int = 1,
+    attempts: int = 1,
 ) -> list[TaskRun]:
     _load_env_from_dotenv()
     _ensure_credentials()
+
+    if attempts < 1:
+        raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
 
     if concurrency <= 1:
         results: list[TaskRun] = []
         for task in targets:
-            print(f"→ {task.id}: {task.name}")
-            run = run_task(task, keep_workspace=keep_workspace, recursion_limit=recursion_limit)
-            results.append(run)
-            status = "PASS" if run.passed else "FAIL"
-            print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-            if keep_workspace and run.workspace:
-                print(f"  workspace: {run.workspace}")
+            for attempt in range(1, attempts + 1):
+                print(f"→ {task.id}: {task.name}{_attempt_suffix(attempt, attempts)}")
+                run = run_task(
+                    task,
+                    keep_workspace=keep_workspace,
+                    recursion_limit=recursion_limit,
+                )
+                run = _mark_attempt(run, attempt, attempts)
+                results.append(run)
+                status = "PASS" if run.passed else "FAIL"
+                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                if keep_workspace and run.workspace:
+                    print(f"  workspace: {run.workspace}")
         return results
 
     print_lock = threading.Lock()
     completed = 0
-    total = len(targets)
+    total = len(targets) * attempts
     results = []
     with ThreadPoolExecutor(max_workers=concurrency) as executor:
         future_to_task = {
@@ -145,20 +158,23 @@ def run_all(
                 task,
                 keep_workspace=keep_workspace,
                 recursion_limit=recursion_limit,
-            ): task
+            ): (task, attempt)
             for task in targets
+            for attempt in range(1, attempts + 1)
         }
         for future in as_completed(future_to_task):
-            run = future.result()
+            _task, attempt = future_to_task[future]
+            run = _mark_attempt(future.result(), attempt, attempts)
             results.append(run)
             with print_lock:
                 completed += 1
                 status = "PASS" if run.passed else "FAIL"
                 print(
-                    f"[{completed:3d}/{total}] [{status}] {run.task_id:32s} "
+                    f"[{completed:3d}/{total}] [{status}] "
+                    f"{_task_attempt_label(run):40s} "
                     f"{run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}"
                 )
                 if keep_workspace and run.workspace:
                     print(f"           workspace: {run.workspace}")
-    results.sort(key=lambda r: _task_sort_key(r.task_id))
+    results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     return results

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -59,7 +59,8 @@ def test_summary_prints_pass_metrics_for_attempts(capsys: pytest.CaptureFixture[
 
     out = capsys.readouterr().out
     assert "Passed attempts: 3/4" in out
-    assert "pass@1: 75.0%" in out
-    assert "pass@2: 100.0%" in out
-    assert "pass^2: 50.0%" in out
+    assert "K  pass@K  pass^K" in out
+    assert "-  ------  ------" in out
+    assert "1   75.0%       -" in out
+    assert "2  100.0%   50.0%" in out
     assert "task_1 #2/2: bad" in out

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -35,7 +35,7 @@ def test_cli_metric_defaults_for_repeated_attempts() -> None:
     parser = build_parser()
     args = parser.parse_args(["run-cli", "--attempts", "5"])
 
-    assert _resolve_metric_ks(args) == ((1, 5), (5,))
+    assert _resolve_metric_ks(args) == ((1, 2, 3, 4, 5), (1, 2, 3, 4, 5))
 
 
 def test_cli_accepts_symbolic_metric_aliases() -> None:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from harness_bench.__main__ import _resolve_metric_ks, build_parser
+from harness_bench.metrics import compute_pass_metrics, pass_at_k, pass_hat_k
+from harness_bench.runner import TaskRun, summarize
+
+
+def test_pass_at_k_and_pass_hat_k_formulas() -> None:
+    assert pass_at_k(num_samples=10, num_correct=3, k=1) == pytest.approx(0.3)
+    assert pass_at_k(num_samples=10, num_correct=3, k=2) == pytest.approx(24 / 45)
+    assert pass_hat_k(num_samples=10, num_correct=3, k=2) == pytest.approx(3 / 45)
+
+
+def test_compute_pass_metrics_groups_attempts_by_task() -> None:
+    results = [
+        SimpleNamespace(task_id="task_1", passed=True),
+        SimpleNamespace(task_id="task_1", passed=False),
+        SimpleNamespace(task_id="task_1", passed=False),
+        SimpleNamespace(task_id="task_2", passed=True),
+        SimpleNamespace(task_id="task_2", passed=True),
+        SimpleNamespace(task_id="task_2", passed=False),
+    ]
+
+    metrics = compute_pass_metrics(results, pass_at_ks=(2,), pass_hat_ks=(2,))
+
+    assert [m.label for m in metrics] == ["pass@2", "pass^2"]
+    assert [m.value for m in metrics] == pytest.approx([5 / 6, 1 / 6])
+
+
+def test_cli_metric_defaults_for_repeated_attempts() -> None:
+    parser = build_parser()
+    args = parser.parse_args(["run-cli", "--attempts", "5"])
+
+    assert _resolve_metric_ks(args) == ((1, 5), (5,))
+
+
+def test_cli_accepts_symbolic_metric_aliases() -> None:
+    parser = build_parser()
+    args = parser.parse_args(
+        ["run-cli", "--attempts", "5", "--pass@", "2", "--pass^", "3"]
+    )
+
+    assert _resolve_metric_ks(args) == ((2,), (3,))
+
+
+def test_summary_prints_pass_metrics_for_attempts(capsys: pytest.CaptureFixture[str]) -> None:
+    results = [
+        TaskRun("task_1", True, "ok", 0.1, attempt=1, attempts=2),
+        TaskRun("task_1", False, "bad", 0.1, attempt=2, attempts=2),
+        TaskRun("task_2", True, "ok", 0.1, attempt=1, attempts=2),
+        TaskRun("task_2", True, "ok", 0.1, attempt=2, attempts=2),
+    ]
+
+    summarize(results, pass_at_ks=(1, 2), pass_hat_ks=(2,))
+
+    out = capsys.readouterr().out
+    assert "Passed attempts: 3/4" in out
+    assert "pass@1: 75.0%" in out
+    assert "pass@2: 100.0%" in out
+    assert "pass^2: 50.0%" in out
+    assert "task_1 #2/2: bad" in out

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -33,7 +33,7 @@ def test_compute_pass_metrics_groups_attempts_by_task() -> None:
 
 def test_cli_metric_defaults_for_repeated_attempts() -> None:
     parser = build_parser()
-    args = parser.parse_args(["run-cli", "--attempts", "5"])
+    args = parser.parse_args(["run-cli", "-k", "5"])
 
     assert _resolve_metric_ks(args) == ((1, 2, 3, 4, 5), (1, 2, 3, 4, 5))
 
@@ -61,6 +61,6 @@ def test_summary_prints_pass_metrics_for_attempts(capsys: pytest.CaptureFixture[
     assert "Passed attempts: 3/4" in out
     assert "K  pass@K  pass^K" in out
     assert "-  ------  ------" in out
-    assert "1   75.0%       -" in out
-    assert "2  100.0%   50.0%" in out
+    assert "1   1.5/2       -" in out
+    assert "2     2/2     1/2" in out
     assert "task_1 #2/2: bad" in out


### PR DESCRIPTION
## Summary
- Add pass@K and pass^K metric helpers for repeated benchmark runs.
- Add `--attempts` / `-k`, `--pass-at` / `--pass@`, and `--pass-hat` / `--pass^` CLI options.
- Wire repeated attempts through the GigaChat, OpenRouter, pure, and CLI runners.
- Track attempt metadata in `TaskRun`, label repeated failures clearly, and render metric summaries as task-count tables.
- Document repeated-attempt benchmark usage in the README.

## Testing
- `uv run pytest` (`9 passed`)