### PR TITLE
feat: add --json-output machine-readable report to run commands

### DIFF
--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -23,7 +23,7 @@ import sys
 from pathlib import Path
 
 from harness_bench.harbor_export import export_harbor_dataset
-from harness_bench.runner import run_all, summarize, verify_gold
+from harness_bench.runner import run_all, summarize, verify_gold, write_results_json
 from harness_bench.runner_cli import DEFAULT_CLI_COMMAND, DEFAULT_TIMEOUT_SECONDS, run_all_cli
 from harness_bench.runner_openrouter import DEFAULT_OPENROUTER_MODEL
 from harness_bench.runner_openrouter import run_all as run_all_openrouter
@@ -86,6 +86,13 @@ def _cmd_version(args: argparse.Namespace) -> int:
     return 1 if args.check and errors else 0
 
 
+def _maybe_write_json(args: argparse.Namespace, results: list) -> None:
+    json_output = getattr(args, "json_output", None)
+    if json_output:
+        write_results_json(results, json_output)
+        print(f"\nWrote results JSON to {json_output}")
+
+
 def _cmd_run(args: argparse.Namespace) -> int:
     results = run_all(
         task_ids=args.task,
@@ -94,6 +101,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
+    _maybe_write_json(args, results)
     return 0 if all(r.passed for r in results) else 1
 
 
@@ -107,6 +115,7 @@ def _cmd_run_openrouter(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
+    _maybe_write_json(args, results)
     return 0 if all(r.passed for r in results) else 1
 
 
@@ -118,6 +127,7 @@ def _cmd_run_pure(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
+    _maybe_write_json(args, results)
     return 0 if all(r.passed for r in results) else 1
 
 
@@ -130,6 +140,7 @@ def _cmd_run_cli(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
     )
     summarize(results)
+    _maybe_write_json(args, results)
     return 0 if all(r.passed for r in results) else 1
 
 
@@ -193,6 +204,18 @@ def _cmd_export_harbor(args: argparse.Namespace) -> int:
     return 0
 
 
+def _add_json_output(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--json-output",
+        dest="json_output",
+        default=None,
+        help=(
+            "Write a machine-readable JSON report (aggregate pass_rate plus a "
+            "per-task breakdown with tags) to this path."
+        ),
+    )
+
+
 def build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="python -m harness_bench")
     sub = parser.add_subparsers(dest="cmd", required=True)
@@ -233,6 +256,7 @@ def build_parser() -> argparse.ArgumentParser:
         help="Run up to N tasks in parallel (default: 1; uses a thread pool, "
         "each task still has its own isolated TemporaryDirectory).",
     )
+    _add_json_output(p_run)
     p_run.set_defaults(func=_cmd_run)
 
     p_or = sub.add_parser(
@@ -260,6 +284,7 @@ def build_parser() -> argparse.ArgumentParser:
         ),
     )
     p_or.add_argument("--concurrency", type=int, default=1)
+    _add_json_output(p_or)
     p_or.set_defaults(func=_cmd_run_openrouter)
 
     p_pure = sub.add_parser(
@@ -273,6 +298,7 @@ def build_parser() -> argparse.ArgumentParser:
     p_pure.add_argument("--keep", action="store_true", help="Keep temp workspaces")
     p_pure.add_argument("--recursion-limit", type=int, default=80)
     p_pure.add_argument("--concurrency", type=int, default=1)
+    _add_json_output(p_pure)
     p_pure.set_defaults(func=_cmd_run_pure)
 
     p_gold = sub.add_parser(
@@ -372,6 +398,7 @@ def build_parser() -> argparse.ArgumentParser:
         default=1,
         help="Run up to N tasks in parallel (default: 1).",
     )
+    _add_json_output(p_cli)
     p_cli.set_defaults(func=_cmd_run_cli)
 
     return parser

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -259,6 +259,56 @@ def summarize(results: list[TaskRun]) -> None:
             print(f"  - {r.task_id}: {_one_line_detail(r)}")
 
 
+def results_to_payload(results: list[TaskRun]) -> dict[str, Any]:
+    """Build a JSON-serializable payload describing a benchmark run.
+
+    The payload carries an aggregate (``passed``/``total``/``pass_rate``) plus a
+    per-task breakdown including each task's free-form ``tags`` and numeric id,
+    so downstream tooling can compute per-category metrics without re-importing
+    the task registry.
+    """
+    from harness_bench.versioning import TASK_SET_VERSION, task_number
+
+    total = len(results)
+    passed = sum(1 for r in results if r.passed)
+    tasks_payload: list[dict[str, Any]] = []
+    for r in results:
+        try:
+            tags = list(get_task(r.task_id).tags)
+        except Exception:  # noqa: BLE001 — tags are best-effort metadata
+            tags = []
+        tasks_payload.append(
+            {
+                "task_id": r.task_id,
+                "number": task_number(r.task_id),
+                "passed": r.passed,
+                "message": r.message,
+                "elapsed_seconds": r.elapsed_seconds,
+                "error": r.error,
+                "tags": tags,
+            }
+        )
+    return {
+        "task_set_version": TASK_SET_VERSION,
+        "total": total,
+        "passed": passed,
+        "pass_rate": (passed / total) if total else 0.0,
+        "tasks": tasks_payload,
+    }
+
+
+def write_results_json(results: list[TaskRun], path: str | Path) -> None:
+    """Serialize a run's results to ``path`` as JSON (parents are created)."""
+    import json
+
+    out = Path(path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(
+        json.dumps(results_to_payload(results), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+
 # ---------------------------------------------------------------------------
 # Gold sanity check (no LLM): exercises the verifiers themselves.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add a `--json-output PATH` flag to the `run`, `run-openrouter`, `run-pure`, and `run-cli` subcommands. After a run it serializes an aggregate (passed/total/pass_rate) plus a per-task breakdown (task_id, number, passed, message, elapsed_seconds, error, tags) to JSON, enabling downstream tooling to consume results without scraping stdout.

Logic lives in `runner.results_to_payload()` / `runner.write_results_json()`.