### PR TITLE
Add Qwen3.6-27B-FP8 results on 298-task set: opencode 291/298 (97.7%) + deepagents baseline 274/298 (91.9%)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,12 @@ Public landing page: <https://ai-forever.github.io/harness-bench-fast/>
 | --- | --- | ---: | ---: | ---: | ---: |
 | Claude Code CLI | Claude Opus 4.8 | 298/298 | 100.0% | — | — |
 | Codex CLI | GPT-5.5 | 298/298 | 100.0% | — | — |
+| opencode | Qwen3.6-27B-FP8 (vLLM) | 291/298 | 97.7% | — | — |
 | free-code | Claude Haiku 4.5 | 284/298 | 95.3% | — | — |
 | deepagents + Anthropic profile | Claude Haiku 4.5 | 280/298 | 94.0% | 3,016 | 41,405,850 |
 | deepagents + Anthropic profile | Claude Sonnet 4.6 | 279/298 | 93.6% | 2,894 | 39,695,400 |
 | deepagents | Qwen 3.6 Flash | 277/298 | 93.0% | 3,132 | 35,108,655 |
+| deepagents | Qwen3.6-27B-FP8 (vLLM) | 274/298 | 91.9% | 3,028 | 33,645,093 |
 | deepagents | DeepSeek V4 Flash | 266/298 | 89.3% | 3,489 | 40,392,075 |
 | deepagents | Qwen 3.6 Plus | 265/298 | 88.9% | 3,288 | 37,687,035 |
 | Hermes CLI | Claude Sonnet 4.6 | 262/298 | 87.9% | — | — |


### PR DESCRIPTION
## Summary

Two externally-contributed rows for **Qwen3.6-27B-FP8** (served by vLLM, OpenAI-compatible gateway) on the current 298-task set (`task-set v0.7.0`) — a tuned-harness run and a stock baseline, so the pair isolates the harness contribution on one model.

| Harness | Model | Result | % | Steps | Tokens |
| --- | --- | ---: | ---: | ---: | ---: |
| opencode | Qwen3.6-27B-FP8 (vLLM) | 291/298 | 97.7% | — | — |
| deepagents | Qwen3.6-27B-FP8 (vLLM) | 274/298 | 91.9% | 3,028 | 33,645,093 |

**Harness contribution: +17 tasks (274 → 291).** The deepagents baseline (274/298, 33.6M tokens, 3,028 steps) lands right between the existing `deepagents` Qwen 3.6 Flash (277) and DeepSeek V4 Flash (266) rows.

## Provenance

Both runs were done by an external contributor against a vLLM deployment of Qwen3.6-27B-FP8 reached through an OpenAI-compatible gateway — not verified by the maintainers. Reproducible with the documented runners; no bench code or task changes.

## How they were run

Both via the existing generic runners on `task-set v0.7.0`, `--concurrency 5`, `--json-output` (checkpointed/resumable).

**opencode (tuned):**
```
OPENCODE_CONFIG=/path/to/opencode-vllm.json \
uv run python -m harness_bench run-cli \
    --cli-command 'opencode run -m <provider>/<model>' \
    --timeout 900 --concurrency 5 --json-output opencode_qwen_298.json
```
- Custom OpenAI-compatible provider pointing at the vLLM endpoint.
- Thinking sampling per model card: `temperature=0.6 top_p=0.95 top_k=20`, `chat_template_kwargs={enable_thinking:true, preserve_thinking:true}`.
- **`formatter:false` and `lsp:false`** — otherwise opencode auto-runs a formatter (ruff) after edits and rewrites quotes/whitespace, failing exact-match verifiers.
- `permission:"allow"` for headless auto-approval; opencode reads workspace `AGENTS.md` natively. Steps/Tokens are `—` because the external CLI doesn't expose per-task usage to the runner.
- 7 misses: `task_02_write_data_json`, `task_41_count_todos`, `task_92_count_chars`, `task_114_jsonl_sum_amount`, `task_137_grep_count_defs`, `task_209_request_latency_reconstruction`, `task_239_memory_multi_hop_salary`.

**deepagents (no adapt / baseline):**
```
OPENROUTER_BASE_URL=<vllm>/v1 OPENROUTER_API_KEY=... \
uv run python -m harness_bench run-openrouter --model <served-name> \
    --concurrency 5 --json-output deepagents_qwen_298.json
```
- Stock `deepagents` + `ChatOpenAI` defaults, no profile, no model-specific sampling (so this is the model on bare defaults, consistent with the other no-profile rows).
- 24 misses skew toward the memory-discipline wave (232–253) and a few rename/move/missing-output-file tasks — on bare defaults the agent more often ends without writing the deliverable.

## Changes

- README: two rows in the Current Results table (ranked by result). The opencode Quick-start example documenting the provider/sampling/formatter-off setup is already in the repo.