### PR TITLE
Add fail-on-runtime-error for OpenRouter

### DIFF
--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -39,8 +39,19 @@ from harness_bench.versioning import (
 )
 
 
-def _exit_code(results: Sequence[object], *, allow_task_failures: bool) -> int:
+def _has_runtime_error(results: Sequence[object]) -> bool:
+    return any(bool(getattr(r, "error", None)) for r in results)
+
+
+def _exit_code(
+    results: Sequence[object],
+    *,
+    allow_task_failures: bool,
+    fail_on_runtime_error: bool = False,
+) -> int:
     """Return the process exit code for a completed benchmark run."""
+    if fail_on_runtime_error and _has_runtime_error(results):
+        return 1
     if allow_task_failures:
         return 0
     return 0 if all(getattr(r, "passed", False) for r in results) else 1
@@ -149,10 +160,15 @@ def _cmd_run_openrouter(args: argparse.Namespace) -> int:
         attempts=args.attempts,
         json_output=args.json_output,
         transient_attempts=args.transient_attempts,
+        fail_on_runtime_error=args.fail_on_runtime_error,
     )
     _summarize_run(results, metric_ks)
     _maybe_write_json(args, results)
-    return _exit_code(results, allow_task_failures=args.allow_task_failures)
+    return _exit_code(
+        results,
+        allow_task_failures=args.allow_task_failures,
+        fail_on_runtime_error=args.fail_on_runtime_error,
+    )
 
 
 def _cmd_run_pure(args: argparse.Namespace) -> int:
@@ -424,6 +440,14 @@ def build_parser() -> argparse.ArgumentParser:
         "--allow-task-failures",
         action="store_true",
         help="Exit 0 when the harness completes even if some benchmark tasks fail.",
+    )
+    p_or.add_argument(
+        "--fail-on-runtime-error",
+        action="store_true",
+        help=(
+            "Exit non-zero and stop scheduling more tasks when a task fails with "
+            "an agent/runtime exception recorded in the JSON error field."
+        ),
     )
     p_or.set_defaults(func=_cmd_run_openrouter)
 

--- a/harness_bench/runner_openrouter.py
+++ b/harness_bench/runner_openrouter.py
@@ -453,6 +453,7 @@ def run_all(
     attempts: int = 1,
     json_output: str | Path | None = None,
     transient_attempts: int = DEFAULT_TRANSIENT_ATTEMPTS,
+    fail_on_runtime_error: bool = False,
 ) -> list[TaskRun]:
     _load_env_from_dotenv()
     _ensure_openrouter_key()
@@ -484,6 +485,8 @@ def run_all(
                 print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
                 if keep_workspace and run.workspace:
                     print(f"  workspace: {run.workspace}")
+                if fail_on_runtime_error and run.error:
+                    return results
         return results
 
     print_lock = threading.Lock()
@@ -520,6 +523,12 @@ def run_all(
                 )
                 if keep_workspace and run.workspace:
                     print(f"           workspace: {run.workspace}")
+            if fail_on_runtime_error and run.error:
+                for pending_future in future_to_task:
+                    if pending_future is not future:
+                        pending_future.cancel()
+                results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
+                return results
     results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     _write_partial_results_json(results, json_output)
     return results

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -69,6 +69,82 @@ def test_allow_task_failures_returns_zero_when_harness_completed(monkeypatch) ->
     assert bench_main.main(["run", "--task", "task_fake", "--allow-task-failures"]) == 0
 
 
+def test_openrouter_fail_on_runtime_error_returns_nonzero_with_allowed_task_failures(
+    monkeypatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run_all_openrouter(**kwargs: object) -> list[TaskRun]:
+        captured.update(kwargs)
+        return [
+            TaskRun(
+                "task_fake",
+                False,
+                "",
+                0.01,
+                error="Traceback\nRuntimeError: endpoint down",
+            )
+        ]
+
+    monkeypatch.setattr(bench_main, "run_all_openrouter", _fake_run_all_openrouter)
+    monkeypatch.setattr(bench_main, "summarize", lambda _results: None)
+
+    assert (
+        bench_main.main(
+            [
+                "run-openrouter",
+                "--task",
+                "task_fake",
+                "--allow-task-failures",
+                "--fail-on-runtime-error",
+            ]
+        )
+        == 1
+    )
+    assert captured["fail_on_runtime_error"] is True
+
+
+def test_openrouter_run_all_stops_on_runtime_error(monkeypatch) -> None:
+    from harness_bench import runner_openrouter
+
+    fake_tasks = [
+        SimpleNamespace(id="task_01_fake", name="Fake one"),
+        SimpleNamespace(id="task_02_fake", name="Fake two"),
+    ]
+    calls: list[str] = []
+
+    def _fake_run_task(task: object, **_kwargs: object) -> TaskRun:
+        task_id = cast(str, getattr(task, "id"))
+        calls.append(task_id)
+        if task_id == "task_01_fake":
+            return TaskRun(
+                task_id,
+                False,
+                "",
+                0.01,
+                error="Traceback\nRuntimeError: endpoint down",
+            )
+        raise AssertionError("must not run the second task after runtime error")
+
+    monkeypatch.setattr(runner_openrouter, "_load_env_from_dotenv", lambda: None)
+    monkeypatch.setattr(runner_openrouter, "_ensure_openrouter_key", lambda: None)
+    monkeypatch.setattr(
+        runner_openrouter,
+        "get_task",
+        lambda task_id: next(task for task in fake_tasks if task.id == task_id),
+    )
+    monkeypatch.setattr(runner_openrouter, "run_task", _fake_run_task)
+
+    results = runner_openrouter.run_all(
+        task_ids=["task_01_fake", "task_02_fake"],
+        concurrency=1,
+        fail_on_runtime_error=True,
+    )
+
+    assert calls == ["task_01_fake"]
+    assert [result.task_id for result in results] == ["task_01_fake"]
+
+
 def test_cli_timeout_kills_windows_process_tree(monkeypatch, tmp_path: Path) -> None:
     from harness_bench import runner_cli
 


### PR DESCRIPTION
  ## Summary
  - add `--fail-on-runtime-error` to `run-openrouter`
  - stop scheduling more OpenRouter tasks after a runtime/agent error
  - keep default behavior unchanged unless the flag is passed

  ## Tests
  - `uv run pytest tests/test_runner_policy.py -q`