### PR TITLE
Make benchmark runs interrupt-safe and resumable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.idea/
 build/
 develop-eggs/
 dist/

--- a/README.md
+++ b/README.md
@@ -130,8 +130,14 @@ uv run python -m harness_bench run-cli \
 # plus agent_llm_calls / agent_input_tokens / agent_output_tokens /
 # agent_total_tokens when the backend exposes usage metadata. Codex CLI runs
 # auto-enable `codex exec --json` so those metrics can be read from JSONL.
-# `--json-output` is checkpointed after each completed task, so completed
-# results survive a later hang or interrupted run.
+# `--json-output` is checkpointed after each completed task. If the JSON file
+# already exists, completed task attempts are loaded from it and skipped so the
+# run continues from the checkpoint. Bare filenames such as `results.json` are
+# written under the ignored `jobs/` directory. If `--json-output` is provided
+# without a path, or with a directory path, the filename is generated from the
+# current timestamp. JSON reports also include the command that launched the
+# run. Ctrl-C writes `run_status: "interrupted"` plus `interrupted_attempts`;
+# those attempts are rerun from clean workspaces on the next continue.
 uv run python -m harness_bench run-cli \
     --cli-command 'codex exec -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox' \
     --concurrency 5 --json-output results.json

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ uv run python -m harness_bench run-cli \
 # continues from the checkpoint. JSON reports also include the command that
 # launched the run. Ctrl-C writes `run_status: "interrupted"` plus
 # `interrupted_attempts`; those attempts are rerun from clean workspaces on the
-# next continue when you rerun with the same JSON path.
+# next continue when you rerun with the same JSON path. CLI per-task timeouts
+# are also marked `rerun_on_continue` and rerun from clean workspaces on the
+# next launch with the same `--json-output` file.
 uv run python -m harness_bench run-cli \
     --cli-command 'codex exec -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox' \
     --concurrency 5

--- a/README.md
+++ b/README.md
@@ -130,17 +130,17 @@ uv run python -m harness_bench run-cli \
 # plus agent_llm_calls / agent_input_tokens / agent_output_tokens /
 # agent_total_tokens when the backend exposes usage metadata. Codex CLI runs
 # auto-enable `codex exec --json` so those metrics can be read from JSONL.
-# `--json-output` is checkpointed after each completed task. If the JSON file
-# already exists, completed task attempts are loaded from it and skipped so the
-# run continues from the checkpoint. Bare filenames such as `results.json` are
-# written under the ignored `jobs/` directory. If `--json-output` is provided
-# without a path, or with a directory path, the filename is generated from the
-# current timestamp. JSON reports also include the command that launched the
-# run. Ctrl-C writes `run_status: "interrupted"` plus `interrupted_attempts`;
-# those attempts are rerun from clean workspaces on the next continue.
+# JSON checkpointing is enabled by default for run commands. A fresh run writes
+# to `jobs/<timestamp>.json`; pass `--json-output results.json` to use
+# `jobs/results.json`, or pass an explicit path. If the JSON file already
+# exists, completed task attempts are loaded from it and skipped so the run
+# continues from the checkpoint. JSON reports also include the command that
+# launched the run. Ctrl-C writes `run_status: "interrupted"` plus
+# `interrupted_attempts`; those attempts are rerun from clean workspaces on the
+# next continue when you rerun with the same JSON path.
 uv run python -m harness_bench run-cli \
     --cli-command 'codex exec -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox' \
-    --concurrency 5 --json-output results.json
+    --concurrency 5
 
 # Repeat every selected task 5 times and print pass@K / pass^K
 # task-count metrics for K=1..5. Works for run, run-openrouter,

--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ uv run python -m harness_bench run-cli \
 # plus agent_llm_calls / agent_input_tokens / agent_output_tokens /
 # agent_total_tokens when the backend exposes usage metadata. Codex, Claude
 # Code, and Gemini CLI runs auto-enable JSON/stream-json output so those metrics
-# can be read from machine-readable events.
+# can be read from machine-readable events. The top-level JSON summary also
+# includes `steps` and `tokens` totals for README-style result tables.
 # JSON checkpointing is enabled by default for run commands. A fresh run writes
 # to `jobs/<timestamp>.json`; pass `--json-output results.json` to use
 # `jobs/results.json`, or pass an explicit path. If the JSON file already

--- a/README.md
+++ b/README.md
@@ -142,6 +142,26 @@ uv run python -m harness_bench run-cli \
     --cli-command 'codex exec -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox' \
     --concurrency 5
 
+# Drive mini-SWE-agent through any OpenAI-compatible gateway, including local
+# gpt2giga. Install `mini-swe-agent` once for faster startup; the wrapper can
+# also fall back to `uvx` when `mini` is not installed. Keep the wrapper path
+# absolute because `run-cli` launches the agent from each per-task temp
+# workspace. The wrapper runs mini-SWE-agent's non-interactive DefaultAgent
+# directly and writes `mini-swe-agent.traj.json`; `run-cli` parses that
+# trajectory for agent_steps / agent_llm_calls / token metrics.
+uv tool install mini-swe-agent
+HB_MINI_SWE_AGENT="$(pwd -P)/scripts/hb-mini-swe-agent"
+OPENAI_API_KEY=0 \
+OPENAI_API_BASE=http://127.0.0.1:8090/v1 \
+MSWEA_MODEL_NAME='openai/GigaChat-3-Ultra' \
+MSWEA_COST_TRACKING=ignore_errors \
+uv run python -m harness_bench run-cli \
+    --cli-command "$HB_MINI_SWE_AGENT" \
+    --timeout 900 --concurrency 5 \
+    --json-output mini_swe_agent_gigachat_3_ultra.json
+# Smoke-test one task first by adding:
+#     --task task_01_create_hello --keep
+
 # Repeat every selected task 5 times and print pass@K / pass^K
 # percentage metrics for K=1..5. Works for run, run-openrouter,
 # run-pure, and run-cli.

--- a/README.md
+++ b/README.md
@@ -156,6 +156,11 @@ uv run python -m harness_bench run-cli \
     --attempts 5 --pass@ 1 --pass@ 5 --pass^ 5 \
     --json-output results.json
 
+# Summarize an existing completed JSON run without rerunning tasks. For a
+# 313-task run with --attempts 5, this prints Passed attempts, pass@K/pass^K
+# for K=1..5, and the per-wave breakdown.
+uv run python -m harness_bench summarize-json jobs/results.json
+
 # Drive `opencode` against any OpenAI-compatible deployment (example:
 # Qwen3.6-27B-FP8 served by vLLM). Point OPENCODE_CONFIG at a config
 # that registers a custom openai-compatible provider, sets the thinking

--- a/README.md
+++ b/README.md
@@ -128,8 +128,9 @@ uv run python -m harness_bench run-cli \
 # Runner JSON writes best-effort per-task effort metrics:
 # agent_steps / agent_tool_calls / agent_shell_commands / agent_events,
 # plus agent_llm_calls / agent_input_tokens / agent_output_tokens /
-# agent_total_tokens when the backend exposes usage metadata. Codex CLI runs
-# auto-enable `codex exec --json` so those metrics can be read from JSONL.
+# agent_total_tokens when the backend exposes usage metadata. Codex, Claude
+# Code, and Gemini CLI runs auto-enable JSON/stream-json output so those metrics
+# can be read from machine-readable events.
 # JSON checkpointing is enabled by default for run commands. A fresh run writes
 # to `jobs/<timestamp>.json`; pass `--json-output results.json` to use
 # `jobs/results.json`, or pass an explicit path. If the JSON file already

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ uv run python -m harness_bench run-cli \
     --concurrency 5
 
 # Repeat every selected task 5 times and print pass@K / pass^K
-# task-count metrics for K=1..5. Works for run, run-openrouter,
+# percentage metrics for K=1..5. Works for run, run-openrouter,
 # run-pure, and run-cli.
 uv run python -m harness_bench run-cli \
     --cli-command 'free-code -p --model haiku --dangerously-skip-permissions' \

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -19,13 +19,21 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sys
 from collections.abc import Sequence
 from pathlib import Path
 
 from harness_bench.harbor_export import export_harbor_dataset
 from harness_bench.metrics import default_metric_ks
-from harness_bench.runner import run_all, summarize, verify_gold, write_results_json
+from harness_bench.runner import (
+    normalize_json_output_path,
+    run_all,
+    set_results_json_command,
+    summarize,
+    verify_gold,
+    write_results_json,
+)
 from harness_bench.runner_cli import DEFAULT_CLI_COMMAND, DEFAULT_TIMEOUT_SECONDS, run_all_cli
 from harness_bench.runner_openrouter import DEFAULT_OPENROUTER_MODEL
 from harness_bench.runner_openrouter import run_all as run_all_openrouter
@@ -266,10 +274,17 @@ def _add_json_output(p: argparse.ArgumentParser) -> None:
     p.add_argument(
         "--json-output",
         dest="json_output",
+        nargs="?",
+        const="",
         default=None,
+        type=normalize_json_output_path,
+        metavar="PATH",
         help=(
             "Write a machine-readable JSON report (aggregate pass_rate plus a "
-            "per-task breakdown with tags) to this path."
+            "per-task breakdown with tags) to this path. Bare filenames are "
+            "stored under jobs/. If PATH is omitted, a timestamped JSON file "
+            "is created under jobs/. If the file exists, completed task "
+            "attempts are loaded from it and skipped."
         ),
     )
 
@@ -580,14 +595,22 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _command_for_argv(argv: list[str] | None) -> str:
+    args = sys.argv[1:] if argv is None else argv
+    return shlex.join(["python", "-m", "harness_bench", *args])
+
+
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
+    set_results_json_command(_command_for_argv(argv))
     try:
         return int(args.func(args))
     except KeyboardInterrupt:
         print("\nInterrupted by user; shutdown complete.", file=sys.stderr)
         return 130
+    finally:
+        set_results_json_command(None)
 
 
 if __name__ == "__main__":

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -326,12 +326,13 @@ def _add_json_output(p: argparse.ArgumentParser) -> None:
         type=normalize_json_output_path,
         metavar="PATH",
         help=(
-            "Write a machine-readable JSON report (aggregate pass_rate plus a "
-            "per-task breakdown with tags) to this path. Bare filenames are "
-            "stored under jobs/. Enabled by default with a timestamped JSON "
-            "file under jobs/; if PATH is omitted or is a directory path, the "
-            "filename is generated from the current timestamp. If the file "
-            "exists, completed task attempts are loaded from it and skipped."
+            "Write a machine-readable JSON report (aggregate pass_rate, steps, "
+            "tokens, plus a per-task breakdown with tags) to this path. Bare "
+            "filenames are stored under jobs/. Enabled by default with a "
+            "timestamped JSON file under jobs/; if PATH is omitted or is a "
+            "directory path, the filename is generated from the current "
+            "timestamp. If the file exists, completed task attempts are loaded "
+            "from it and skipped."
         ),
     )
 

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -32,7 +32,6 @@ from harness_bench.runner import (
     set_results_json_command,
     summarize,
     verify_gold,
-    write_results_json,
 )
 from harness_bench.runner_cli import DEFAULT_CLI_COMMAND, DEFAULT_TIMEOUT_SECONDS, run_all_cli
 from harness_bench.runner_openrouter import DEFAULT_OPENROUTER_MODEL
@@ -114,11 +113,16 @@ def _cmd_version(args: argparse.Namespace) -> int:
     return 1 if args.check and errors else 0
 
 
-def _maybe_write_json(args: argparse.Namespace, results: list) -> None:
+def _maybe_report_json(args: argparse.Namespace, _results: list) -> None:
     json_output = getattr(args, "json_output", None)
     if json_output:
-        write_results_json(results, json_output)
         print(f"\nWrote results JSON to {json_output}")
+
+
+def _announce_json_output(args: argparse.Namespace) -> None:
+    json_output = getattr(args, "json_output", None)
+    if json_output:
+        print(f"Writing results JSON to {json_output}")
 
 
 def _metric_ks_for_args(
@@ -142,6 +146,7 @@ def _summarize_run(
 
 def _cmd_run(args: argparse.Namespace) -> int:
     metric_ks = _metric_ks_for_args(args)
+    _announce_json_output(args)
     results = run_all(
         task_ids=args.task,
         keep_workspace=args.keep,
@@ -151,12 +156,13 @@ def _cmd_run(args: argparse.Namespace) -> int:
         json_output=args.json_output,
     )
     _summarize_run(results, metric_ks)
-    _maybe_write_json(args, results)
+    _maybe_report_json(args, results)
     return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
 def _cmd_run_openrouter(args: argparse.Namespace) -> int:
     metric_ks = _metric_ks_for_args(args)
+    _announce_json_output(args)
     results = run_all_openrouter(
         task_ids=args.task,
         model_name=args.model,
@@ -171,7 +177,7 @@ def _cmd_run_openrouter(args: argparse.Namespace) -> int:
         fail_on_runtime_error=args.fail_on_runtime_error,
     )
     _summarize_run(results, metric_ks)
-    _maybe_write_json(args, results)
+    _maybe_report_json(args, results)
     return _exit_code(
         results,
         allow_task_failures=args.allow_task_failures,
@@ -181,6 +187,7 @@ def _cmd_run_openrouter(args: argparse.Namespace) -> int:
 
 def _cmd_run_pure(args: argparse.Namespace) -> int:
     metric_ks = _metric_ks_for_args(args)
+    _announce_json_output(args)
     results = run_all_pure(
         task_ids=args.task,
         keep_workspace=args.keep,
@@ -190,12 +197,13 @@ def _cmd_run_pure(args: argparse.Namespace) -> int:
         json_output=args.json_output,
     )
     _summarize_run(results, metric_ks)
-    _maybe_write_json(args, results)
+    _maybe_report_json(args, results)
     return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
 def _cmd_run_cli(args: argparse.Namespace) -> int:
     metric_ks = _metric_ks_for_args(args)
+    _announce_json_output(args)
     results = run_all_cli(
         task_ids=args.task,
         cli_command=args.cli_command,
@@ -206,7 +214,7 @@ def _cmd_run_cli(args: argparse.Namespace) -> int:
         json_output=args.json_output,
     )
     _summarize_run(results, metric_ks)
-    _maybe_write_json(args, results)
+    _maybe_report_json(args, results)
     return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
@@ -276,15 +284,16 @@ def _add_json_output(p: argparse.ArgumentParser) -> None:
         dest="json_output",
         nargs="?",
         const="",
-        default=None,
+        default="",
         type=normalize_json_output_path,
         metavar="PATH",
         help=(
             "Write a machine-readable JSON report (aggregate pass_rate plus a "
             "per-task breakdown with tags) to this path. Bare filenames are "
-            "stored under jobs/. If PATH is omitted, a timestamped JSON file "
-            "is created under jobs/. If the file exists, completed task "
-            "attempts are loaded from it and skipped."
+            "stored under jobs/. Enabled by default with a timestamped JSON "
+            "file under jobs/; if PATH is omitted or is a directory path, the "
+            "filename is generated from the current timestamp. If the file "
+            "exists, completed task attempts are loaded from it and skipped."
         ),
     )
 

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -583,7 +583,11 @@ def build_parser() -> argparse.ArgumentParser:
 def main(argv: list[str] | None = None) -> int:
     parser = build_parser()
     args = parser.parse_args(argv)
-    return int(args.func(args))
+    try:
+        return int(args.func(args))
+    except KeyboardInterrupt:
+        print("\nInterrupted by user; shutdown complete.", file=sys.stderr)
+        return 130
 
 
 if __name__ == "__main__":

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -27,6 +27,8 @@ from pathlib import Path
 from harness_bench.harbor_export import export_harbor_dataset
 from harness_bench.metrics import default_metric_ks
 from harness_bench.runner import (
+    TaskRun,
+    load_results_json,
     normalize_json_output_path,
     run_all,
     set_results_json_command,
@@ -218,6 +220,42 @@ def _cmd_run_cli(args: argparse.Namespace) -> int:
     return _exit_code(results, allow_task_failures=args.allow_task_failures)
 
 
+def _infer_attempts_from_results(results: Sequence[TaskRun]) -> int:
+    if not results:
+        return 1
+    attempts_by_task: dict[str, int] = {}
+    for result in results:
+        attempts_by_task[result.task_id] = attempts_by_task.get(result.task_id, 0) + 1
+    observed_attempts = max(attempts_by_task.values(), default=1)
+    declared_attempts = max(
+        (getattr(result, "attempts", 1) or 1 for result in results),
+        default=1,
+    )
+    return max(observed_attempts, declared_attempts)
+
+
+def _metric_ks_for_results(
+    args: argparse.Namespace,
+    results: Sequence[TaskRun],
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    attempts = _infer_attempts_from_results(results)
+    if attempts == 1 and not args.pass_at and not args.pass_hat:
+        return (1,), ()
+    return _resolve_metric_ks_for_attempts(attempts, args.pass_at, args.pass_hat)
+
+
+def _cmd_summarize_json(args: argparse.Namespace) -> int:
+    results = load_results_json(args.json_path)
+    pass_at_ks, pass_hat_ks = _metric_ks_for_results(args, results)
+    summarize(
+        results,
+        pass_at_ks=pass_at_ks,
+        pass_hat_ks=pass_hat_ks,
+        include_failures=False,
+    )
+    return 0
+
+
 def _cmd_verify_gold(args: argparse.Namespace) -> int:
     results = verify_gold(task_ids=args.task)
     failed = [r for r in results if not r.passed]
@@ -321,6 +359,10 @@ def _add_metric_args(parser: argparse.ArgumentParser) -> None:
             "Use N > 1 to compute pass@K / pass^K for K=1..N."
         ),
     )
+    _add_pass_metric_args(parser)
+
+
+def _add_pass_metric_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--pass-at",
         "--pass@",
@@ -348,17 +390,30 @@ def _add_metric_args(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _resolve_metric_ks(args: argparse.Namespace) -> tuple[tuple[int, ...], tuple[int, ...]]:
-    default_pass_at, default_pass_hat = default_metric_ks(args.attempts)
-    pass_at_ks = tuple(args.pass_at) if args.pass_at else default_pass_at
-    pass_hat_ks = tuple(args.pass_hat) if args.pass_hat else default_pass_hat
-    too_large = [k for k in (*pass_at_ks, *pass_hat_ks) if k > args.attempts]
+def _resolve_metric_ks_for_attempts(
+    attempts: int,
+    pass_at: Sequence[int] | None,
+    pass_hat: Sequence[int] | None,
+    *,
+    attempts_label: str = "attempts",
+) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    default_pass_at, default_pass_hat = default_metric_ks(attempts)
+    pass_at_ks = tuple(pass_at) if pass_at else default_pass_at
+    pass_hat_ks = tuple(pass_hat) if pass_hat else default_pass_hat
+    too_large = [k for k in (*pass_at_ks, *pass_hat_ks) if k > attempts]
     if too_large:
         joined = ", ".join(str(k) for k in too_large)
-        raise SystemExit(
-            f"Metric k cannot exceed --attempts ({args.attempts}); got: {joined}"
-        )
+        raise SystemExit(f"Metric k cannot exceed {attempts_label} ({attempts}); got: {joined}")
     return pass_at_ks, pass_hat_ks
+
+
+def _resolve_metric_ks(args: argparse.Namespace) -> tuple[tuple[int, ...], tuple[int, ...]]:
+    return _resolve_metric_ks_for_attempts(
+        args.attempts,
+        args.pass_at,
+        args.pass_hat,
+        attempts_label="--attempts",
+    )
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -376,6 +431,14 @@ def build_parser() -> argparse.ArgumentParser:
         help="Exit non-zero if task registry and version metadata disagree",
     )
     p_version.set_defaults(func=_cmd_version)
+
+    p_summarize_json = sub.add_parser(
+        "summarize-json",
+        help="Summarize an existing benchmark results JSON",
+    )
+    p_summarize_json.add_argument("json_path", type=Path, help="Path to a results JSON")
+    _add_pass_metric_args(p_summarize_json)
+    p_summarize_json.set_defaults(func=_cmd_summarize_json)
 
     p_run = sub.add_parser("run", help="Run benchmark with the GigaChat agent")
     p_run.add_argument(

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -432,29 +432,36 @@ def run_all(
 
     if concurrency <= 1:
         results: list[TaskRun] = []
-        for task in targets:
-            for attempt in range(1, attempts + 1):
-                label = _task_attempt_label_for(task.id, attempt, attempts)
-                print(f"[START] {label}: {task.name}")
-                run = run_task(
-                    task,
-                    keep_workspace=keep_workspace,
-                    recursion_limit=recursion_limit,
-                )
-                run = _mark_attempt(run, attempt, attempts)
-                results.append(run)
-                _write_partial_results_json(results, json_output)
-                status = "PASS" if run.passed else "FAIL"
-                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-                if keep_workspace and run.workspace:
-                    print(f"  workspace: {run.workspace}")
+        try:
+            for task in targets:
+                for attempt in range(1, attempts + 1):
+                    label = _task_attempt_label_for(task.id, attempt, attempts)
+                    print(f"[START] {label}: {task.name}")
+                    run = run_task(
+                        task,
+                        keep_workspace=keep_workspace,
+                        recursion_limit=recursion_limit,
+                    )
+                    run = _mark_attempt(run, attempt, attempts)
+                    results.append(run)
+                    _write_partial_results_json(results, json_output)
+                    status = "PASS" if run.passed else "FAIL"
+                    print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                    if keep_workspace and run.workspace:
+                        print(f"  workspace: {run.workspace}")
+        except KeyboardInterrupt:
+            _write_partial_results_json(results, json_output)
+            raise
         return results
 
     print_lock = threading.Lock()
     completed = 0
     total = len(targets) * attempts
     results = []
-    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+    executor = ThreadPoolExecutor(max_workers=concurrency)
+    interrupted = False
+    future_to_task = {}
+    try:
         future_to_task = {
             executor.submit(
                 run_task,
@@ -480,6 +487,14 @@ def run_all(
                 )
                 if keep_workspace and run.workspace:
                     print(f"           workspace: {run.workspace}")
+    except KeyboardInterrupt:
+        interrupted = True
+        for future in future_to_task:
+            future.cancel()
+        _write_partial_results_json(results, json_output)
+        raise
+    finally:
+        executor.shutdown(wait=not interrupted, cancel_futures=interrupted)
     results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     _write_partial_results_json(results, json_output)
     return results

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -125,6 +125,22 @@ def _coerce_float(value: Any) -> float:
     return 0.0
 
 
+def _is_cli_timeout_error(error: Any) -> bool:
+    return isinstance(error, str) and error.startswith("CLI timed out after ")
+
+
+def _payload_reruns_on_continue(item: dict[str, Any]) -> bool:
+    if item.get("rerun_on_continue") is True:
+        return True
+    if item.get("failure_kind") == "timeout":
+        return True
+    return _is_cli_timeout_error(item.get("error"))
+
+
+def _task_run_reruns_on_continue(run: TaskRun) -> bool:
+    return _is_cli_timeout_error(run.error)
+
+
 def set_results_json_command(command: str | None) -> None:
     """Set the command recorded in subsequently written benchmark JSON files."""
     global _RESULTS_JSON_COMMAND
@@ -179,7 +195,12 @@ def task_run_from_payload(item: dict[str, Any], *, attempts: int | None = None) 
     )
 
 
-def load_results_json(path: str | Path, *, attempts: int | None = None) -> list[TaskRun]:
+def load_results_json(
+    path: str | Path,
+    *,
+    attempts: int | None = None,
+    include_rerun_on_continue: bool = True,
+) -> list[TaskRun]:
     """Load a previously written benchmark JSON report back into ``TaskRun`` rows."""
     result_path = Path(path)
     try:
@@ -192,6 +213,8 @@ def load_results_json(path: str | Path, *, attempts: int | None = None) -> list[
     for item in payload["tasks"]:
         if not isinstance(item, dict):
             raise ValueError(f"{result_path} contains a non-object task entry")
+        if not include_rerun_on_continue and _payload_reruns_on_continue(item):
+            continue
         runs.append(task_run_from_payload(item, attempts=attempts))
     return runs
 
@@ -206,7 +229,11 @@ def _resume_results(
         return []
 
     target_ids = {task.id for task in targets}
-    loaded = load_results_json(json_output_path, attempts=attempts)
+    loaded = load_results_json(
+        json_output_path,
+        attempts=attempts,
+        include_rerun_on_continue=False,
+    )
     by_key: dict[tuple[str, int], TaskRun] = {}
     for run in loaded:
         if run.task_id not in target_ids:
@@ -894,28 +921,30 @@ def results_to_payload(
             tags = list(get_task(r.task_id).tags)
         except Exception:  # noqa: BLE001 — tags are best-effort metadata
             tags = []
-        tasks_payload.append(
-            {
-                "task_id": r.task_id,
-                "number": task_number(r.task_id),
-                "passed": r.passed,
-                "message": r.message,
-                "elapsed_seconds": r.elapsed_seconds,
-                "error": r.error,
-                "tags": tags,
-                "attempt": r.attempt,
-                "attempts": r.attempts,
-                "agent_steps": r.agent_steps,
-                "agent_tool_calls": r.agent_tool_calls,
-                "agent_shell_commands": r.agent_shell_commands,
-                "agent_events": r.agent_events,
-                "agent_llm_calls": r.agent_llm_calls,
-                "agent_input_tokens": r.agent_input_tokens,
-                "agent_output_tokens": r.agent_output_tokens,
-                "agent_total_tokens": r.agent_total_tokens,
-            }
-        )
-    payload = {"task_set_version": TASK_SET_VERSION}
+        task_payload: dict[str, Any] = {
+            "task_id": r.task_id,
+            "number": task_number(r.task_id),
+            "passed": r.passed,
+            "message": r.message,
+            "elapsed_seconds": r.elapsed_seconds,
+            "error": r.error,
+            "tags": tags,
+            "attempt": r.attempt,
+            "attempts": r.attempts,
+            "agent_steps": r.agent_steps,
+            "agent_tool_calls": r.agent_tool_calls,
+            "agent_shell_commands": r.agent_shell_commands,
+            "agent_events": r.agent_events,
+            "agent_llm_calls": r.agent_llm_calls,
+            "agent_input_tokens": r.agent_input_tokens,
+            "agent_output_tokens": r.agent_output_tokens,
+            "agent_total_tokens": r.agent_total_tokens,
+        }
+        if _task_run_reruns_on_continue(r):
+            task_payload["failure_kind"] = "timeout"
+            task_payload["rerun_on_continue"] = True
+        tasks_payload.append(task_payload)
+    payload: dict[str, Any] = {"task_set_version": TASK_SET_VERSION}
     result_command = command if command is not None else _RESULTS_JSON_COMMAND
     if result_command:
         payload["command"] = result_command

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import os
 import threading
 import time
 import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, replace
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import Any
@@ -15,6 +17,22 @@ from typing import Any
 from harness_bench.core import Task, VerifyResult
 from harness_bench.metrics import PassMetric, compute_pass_metrics
 from harness_bench.tasks import ALL_TASKS, get_task
+
+DEFAULT_JOBS_DIR = Path("jobs")
+"""Default directory for CLI-specified benchmark JSON/checkpoint files."""
+
+_AGENT_METRIC_FIELDS = (
+    "agent_steps",
+    "agent_tool_calls",
+    "agent_shell_commands",
+    "agent_events",
+    "agent_llm_calls",
+    "agent_input_tokens",
+    "agent_output_tokens",
+    "agent_total_tokens",
+)
+
+_RESULTS_JSON_COMMAND: str | None = None
 
 
 def _is_graph_recursion_error(exc: BaseException) -> bool:
@@ -96,6 +114,149 @@ def _coerce_int(value: Any) -> int | None:
     if isinstance(value, float) and value.is_integer():
         return int(value)
     return None
+
+
+def _coerce_float(value: Any) -> float:
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    return 0.0
+
+
+def set_results_json_command(command: str | None) -> None:
+    """Set the command recorded in subsequently written benchmark JSON files."""
+    global _RESULTS_JSON_COMMAND
+    _RESULTS_JSON_COMMAND = command
+
+
+def _timestamped_json_name() -> str:
+    return f"{datetime.now():%Y%m%d_%H%M%S_%f}.json"
+
+
+def _path_has_trailing_separator(path: str) -> bool:
+    return path.endswith(("/", "\\"))
+
+
+def normalize_json_output_path(path: str | Path | None) -> Path | None:
+    """Resolve result JSON paths while keeping bare filenames under ``jobs/``."""
+    if path is None:
+        return None
+    raw_path = os.fspath(path)
+    if raw_path == "":
+        return DEFAULT_JOBS_DIR / _timestamped_json_name()
+    out = Path(path)
+    if _path_has_trailing_separator(raw_path) or (out.exists() and out.is_dir()):
+        return out / _timestamped_json_name()
+    if not out.is_absolute() and out.parent == Path("."):
+        return DEFAULT_JOBS_DIR / out
+    return out
+
+
+def task_run_from_payload(item: dict[str, Any], *, attempts: int | None = None) -> TaskRun:
+    task_id = item.get("task_id")
+    if not isinstance(task_id, str) or not task_id:
+        raise ValueError("result task entry is missing task_id")
+
+    attempt = _coerce_int(item.get("attempt")) or 1
+    saved_attempts = _coerce_int(item.get("attempts")) or 1
+    metric_values = {
+        field: _coerce_int(item.get(field))
+        for field in _AGENT_METRIC_FIELDS
+    }
+    error = item.get("error")
+    message = item.get("message")
+    return TaskRun(
+        task_id=task_id,
+        passed=bool(item.get("passed")),
+        message=message if isinstance(message, str) else "",
+        elapsed_seconds=_coerce_float(item.get("elapsed_seconds")),
+        error=error if isinstance(error, str) else None,
+        attempt=attempt,
+        attempts=attempts or saved_attempts,
+        **metric_values,
+    )
+
+
+def load_results_json(path: str | Path, *, attempts: int | None = None) -> list[TaskRun]:
+    """Load a previously written benchmark JSON report back into ``TaskRun`` rows."""
+    result_path = Path(path)
+    try:
+        payload = json.loads(result_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{result_path} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("tasks"), list):
+        raise ValueError(f"{result_path} does not look like a harness-bench results JSON")
+    runs = []
+    for item in payload["tasks"]:
+        if not isinstance(item, dict):
+            raise ValueError(f"{result_path} contains a non-object task entry")
+        runs.append(task_run_from_payload(item, attempts=attempts))
+    return runs
+
+
+def _resume_results(
+    json_output: str | Path | None,
+    targets: list[Task],
+    attempts: int,
+) -> list[TaskRun]:
+    json_output_path = normalize_json_output_path(json_output)
+    if json_output_path is None or not json_output_path.exists():
+        return []
+
+    target_ids = {task.id for task in targets}
+    loaded = load_results_json(json_output_path, attempts=attempts)
+    by_key: dict[tuple[str, int], TaskRun] = {}
+    for run in loaded:
+        if run.task_id not in target_ids:
+            continue
+        if run.attempt < 1 or run.attempt > attempts:
+            continue
+        by_key[(run.task_id, run.attempt)] = replace(
+            run,
+            attempts=attempts,
+            workspace=None,
+        )
+    results = sorted(by_key.values(), key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
+    if results:
+        total = len(targets) * attempts
+        print(
+            f"[CONTINUE] loaded {len(results)}/{total} completed task attempt(s) "
+            f"from {json_output_path}"
+        )
+    return results
+
+
+def _pending_task_attempts(
+    targets: list[Task],
+    attempts: int,
+    results: list[TaskRun],
+) -> list[tuple[Task, int]]:
+    completed = {(run.task_id, run.attempt) for run in results}
+    return [
+        (task, attempt)
+        for task in targets
+        for attempt in range(1, attempts + 1)
+        if (task.id, attempt) not in completed
+    ]
+
+
+def _task_attempts_payload(
+    task_attempts: list[tuple[Task, int]],
+    attempts: int,
+    *,
+    reason: str,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "task_id": task.id,
+            "attempt": attempt,
+            "attempts": attempts,
+            "reason": reason,
+            "rerun_on_continue": True,
+        }
+        for task, attempt in task_attempts
+    ]
 
 
 def _usage_token_counts(usage: Any) -> tuple[int | None, int | None, int | None]:
@@ -424,40 +585,45 @@ def run_all(
     """
     _load_env_from_dotenv()
     _ensure_credentials()
+    json_output = normalize_json_output_path(json_output)
 
     if attempts < 1:
         raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
+    results = _resume_results(json_output, targets, attempts)
+    pending_attempts = _pending_task_attempts(targets, attempts, results)
+    if not pending_attempts:
+        _write_partial_results_json(results, json_output)
+        return results
 
     if concurrency <= 1:
-        results: list[TaskRun] = []
         try:
-            for task in targets:
-                for attempt in range(1, attempts + 1):
-                    label = _task_attempt_label_for(task.id, attempt, attempts)
-                    print(f"[START] {label}: {task.name}")
-                    run = run_task(
-                        task,
-                        keep_workspace=keep_workspace,
-                        recursion_limit=recursion_limit,
-                    )
-                    run = _mark_attempt(run, attempt, attempts)
-                    results.append(run)
-                    _write_partial_results_json(results, json_output)
-                    status = "PASS" if run.passed else "FAIL"
-                    print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-                    if keep_workspace and run.workspace:
-                        print(f"  workspace: {run.workspace}")
+            for task, attempt in pending_attempts:
+                label = _task_attempt_label_for(task.id, attempt, attempts)
+                print(f"[START] {label}: {task.name}")
+                run = run_task(
+                    task,
+                    keep_workspace=keep_workspace,
+                    recursion_limit=recursion_limit,
+                )
+                run = _mark_attempt(run, attempt, attempts)
+                results.append(run)
+                _write_partial_results_json(results, json_output)
+                status = "PASS" if run.passed else "FAIL"
+                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                if keep_workspace and run.workspace:
+                    print(f"  workspace: {run.workspace}")
         except KeyboardInterrupt:
-            _write_partial_results_json(results, json_output)
+            _write_interrupted_results_json(results, json_output, pending_attempts, attempts)
             raise
+        results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
+        _write_partial_results_json(results, json_output)
         return results
 
     print_lock = threading.Lock()
-    completed = 0
+    completed = len(results)
     total = len(targets) * attempts
-    results = []
     executor = ThreadPoolExecutor(max_workers=concurrency)
     interrupted = False
     future_to_task = {}
@@ -469,8 +635,7 @@ def run_all(
                 keep_workspace=keep_workspace,
                 recursion_limit=recursion_limit,
             ): (task, attempt)
-            for task in targets
-            for attempt in range(1, attempts + 1)
+            for task, attempt in pending_attempts
         }
         for future in as_completed(future_to_task):
             _task, attempt = future_to_task[future]
@@ -491,7 +656,7 @@ def run_all(
         interrupted = True
         for future in future_to_task:
             future.cancel()
-        _write_partial_results_json(results, json_output)
+        _write_interrupted_results_json(results, json_output, pending_attempts, attempts)
         raise
     finally:
         executor.shutdown(wait=not interrupted, cancel_futures=interrupted)
@@ -622,7 +787,12 @@ def _format_table_row(values: list[str], widths: list[int]) -> str:
     return "  ".join(cells)
 
 
-def results_to_payload(results: list[TaskRun]) -> dict[str, Any]:
+def results_to_payload(
+    results: list[TaskRun],
+    *,
+    interrupted_attempts: list[dict[str, Any]] | None = None,
+    command: str | None = None,
+) -> dict[str, Any]:
     """Build a JSON-serializable payload describing a benchmark run.
 
     The payload carries an aggregate (``passed``/``total``/``pass_rate``) plus a
@@ -661,23 +831,45 @@ def results_to_payload(results: list[TaskRun]) -> dict[str, Any]:
                 "agent_total_tokens": r.agent_total_tokens,
             }
         )
-    return {
-        "task_set_version": TASK_SET_VERSION,
-        "total": total,
-        "passed": passed,
-        "pass_rate": (passed / total) if total else 0.0,
-        "tasks": tasks_payload,
-    }
+    payload = {"task_set_version": TASK_SET_VERSION}
+    result_command = command if command is not None else _RESULTS_JSON_COMMAND
+    if result_command:
+        payload["command"] = result_command
+    payload.update(
+        {
+            "total": total,
+            "passed": passed,
+            "pass_rate": (passed / total) if total else 0.0,
+            "tasks": tasks_payload,
+        }
+    )
+    if interrupted_attempts is not None:
+        payload["run_status"] = "interrupted"
+        payload["interrupted"] = True
+        payload["interrupted_attempts"] = interrupted_attempts
+    return payload
 
 
-def write_results_json(results: list[TaskRun], path: str | Path) -> None:
+def write_results_json(
+    results: list[TaskRun],
+    path: str | Path,
+    *,
+    interrupted_attempts: list[dict[str, Any]] | None = None,
+    command: str | None = None,
+) -> None:
     """Serialize a run's results to ``path`` as JSON (parents are created)."""
-    import json
-
     out = Path(path)
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_text(
-        json.dumps(results_to_payload(results), ensure_ascii=False, indent=2),
+        json.dumps(
+            results_to_payload(
+                results,
+                interrupted_attempts=interrupted_attempts,
+                command=command,
+            ),
+            ensure_ascii=False,
+            indent=2,
+        ),
         encoding="utf-8",
     )
 
@@ -687,6 +879,32 @@ def _write_partial_results_json(results: list[TaskRun], path: str | Path | None)
         return
     sorted_results = sorted(results, key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     write_results_json(sorted_results, path)
+
+
+def _write_interrupted_results_json(
+    results: list[TaskRun],
+    path: str | Path | None,
+    pending_attempts: list[tuple[Task, int]],
+    attempts: int,
+) -> None:
+    if path is None:
+        return
+    completed = {(run.task_id, run.attempt) for run in results}
+    interrupted_attempts = [
+        (task, attempt)
+        for task, attempt in pending_attempts
+        if (task.id, attempt) not in completed
+    ]
+    sorted_results = sorted(results, key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
+    write_results_json(
+        sorted_results,
+        path,
+        interrupted_attempts=_task_attempts_payload(
+            interrupted_attempts,
+            attempts,
+            reason="KeyboardInterrupt",
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -715,13 +715,16 @@ def summarize(
     *,
     pass_at_ks: tuple[int, ...] = (1,),
     pass_hat_ks: tuple[int, ...] = (),
+    include_failures: bool = True,
 ) -> None:
     """Print a pass/fail summary block at the end of a run."""
     total = len(results)
     passed = sum(1 for r in results if r.passed)
     print()
     print("=" * 64)
-    label = "Passed" if all(r.attempts == 1 for r in results) else "Passed attempts"
+    repeated_task_ids = len(_task_results_by_id(results)) < len(results)
+    repeated_attempts = repeated_task_ids or any(r.attempts != 1 for r in results)
+    label = "Passed attempts" if repeated_attempts else "Passed"
     print(f"{label}: {passed}/{total}")
     metrics = compute_pass_metrics(results, pass_at_ks=pass_at_ks, pass_hat_ks=pass_hat_ks)
     if metrics:
@@ -735,7 +738,7 @@ def summarize(
         print("Per-wave breakdown:")
         for line in wave_table:
             print(f"  {line}")
-    if passed < total:
+    if include_failures and passed < total:
         print()
         print("Failures:")
         show_tracebacks = os.getenv("HARNESS_BENCH_SHOW_TRACEBACK", "").lower() in (

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -900,6 +900,10 @@ def _format_table_row(values: list[str], widths: list[int]) -> str:
     return "  ".join(cells)
 
 
+def _sum_run_metric(results: list[TaskRun], field: str) -> int:
+    return sum(value for run in results if isinstance(value := getattr(run, field), int))
+
+
 def results_to_payload(
     results: list[TaskRun],
     *,
@@ -953,6 +957,8 @@ def results_to_payload(
             "total": total,
             "passed": passed,
             "pass_rate": (passed / total) if total else 0.0,
+            "steps": _sum_run_metric(results, "agent_steps"),
+            "tokens": _sum_run_metric(results, "agent_total_tokens"),
             "tasks": tasks_payload,
         }
     )

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -17,6 +17,7 @@ from typing import Any
 from harness_bench.core import Task, VerifyResult
 from harness_bench.metrics import PassMetric, compute_pass_metrics
 from harness_bench.tasks import ALL_TASKS, get_task
+from harness_bench.versioning import TASK_SET_VERSION, TASK_WAVES, TaskWave, task_number
 
 DEFAULT_JOBS_DIR = Path("jobs")
 """Default directory for CLI-specified benchmark JSON/checkpoint files."""
@@ -728,6 +729,12 @@ def summarize(
         print("Metrics:")
         for line in _format_metrics_table(metrics):
             print(f"  {line}")
+    wave_table = _format_wave_breakdown_table(results)
+    if wave_table:
+        print()
+        print("Per-wave breakdown:")
+        for line in wave_table:
+            print(f"  {line}")
     if passed < total:
         print()
         print("Failures:")
@@ -776,10 +783,86 @@ def _format_metrics_table(metrics: list[PassMetric]) -> list[str]:
 def _format_metric_value(metric: PassMetric | None) -> str:
     if metric is None:
         return "-"
-    task_equivalent = metric.value * metric.task_count
-    rounded = round(task_equivalent)
-    count = str(rounded) if abs(task_equivalent - rounded) < 1e-9 else f"{task_equivalent:.1f}"
-    return f"{count}/{metric.task_count}"
+    return f"{metric.value * 100:.1f}%"
+
+
+def _format_wave_breakdown_table(results: list[TaskRun]) -> list[str]:
+    task_results = _task_results_by_id(results)
+    if not task_results:
+        return []
+
+    rows = []
+    for wave in TASK_WAVES:
+        row = _wave_breakdown_row(wave, task_results)
+        if row[1] > 0:
+            rows.append(row)
+    unknown_task_results = {
+        task_id: runs
+        for task_id, runs in task_results.items()
+        if not _wave_for_task_id(task_id)
+    }
+    if unknown_task_results:
+        rows.append(_breakdown_row("unknown", unknown_task_results))
+    rows.append(_breakdown_row("Total", task_results))
+
+    table_rows = [
+        [label, str(tasks), str(passed), f"{passed / tasks * 100:.1f}%"]
+        for label, tasks, passed in rows
+    ]
+    headers = ["Wave", "Tasks", "Passed", "%"]
+    widths = [
+        max(len(row[i]) for row in [headers, *table_rows])
+        for i in range(len(headers))
+    ]
+    lines = [
+        _format_table_row_aligned(headers, widths),
+        _format_table_row_aligned(["-" * width for width in widths], widths),
+    ]
+    lines.extend(_format_table_row_aligned(row, widths) for row in table_rows)
+    return lines
+
+
+def _task_results_by_id(results: list[TaskRun]) -> dict[str, list[TaskRun]]:
+    grouped: dict[str, list[TaskRun]] = {}
+    for result in results:
+        grouped.setdefault(result.task_id, []).append(result)
+    return grouped
+
+
+def _wave_breakdown_row(
+    wave: TaskWave,
+    task_results: dict[str, list[TaskRun]],
+) -> tuple[str, int, int]:
+    matching_task_results = {
+        task_id: runs
+        for task_id, runs in task_results.items()
+        if (number := task_number(task_id)) is not None and wave.contains(number)
+    }
+    return _breakdown_row(wave.label, matching_task_results)
+
+
+def _breakdown_row(
+    label: str,
+    task_results: dict[str, list[TaskRun]],
+) -> tuple[str, int, int]:
+    tasks = len(task_results)
+    passed = sum(1 for runs in task_results.values() if any(run.passed for run in runs))
+    return label, tasks, passed
+
+
+def _wave_for_task_id(task_id: str) -> TaskWave | None:
+    number = task_number(task_id)
+    if number is None:
+        return None
+    return next((wave for wave in TASK_WAVES if wave.contains(number)), None)
+
+
+def _format_table_row_aligned(values: list[str], widths: list[int]) -> str:
+    cells = [
+        value.ljust(width) if index == 0 else value.rjust(width)
+        for index, (value, width) in enumerate(zip(values, widths, strict=True))
+    ]
+    return "  ".join(cells)
 
 
 def _format_table_row(values: list[str], widths: list[int]) -> str:
@@ -800,8 +883,6 @@ def results_to_payload(
     so downstream tooling can compute per-category metrics without re-importing
     the task registry.
     """
-    from harness_bench.versioning import TASK_SET_VERSION, task_number
-
     total = len(results)
     passed = sum(1 for r in results if r.passed)
     tasks_payload: list[dict[str, Any]] = []

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -23,6 +23,7 @@ import json
 import os
 import re
 import shlex
+import signal
 import subprocess
 import sys
 import threading
@@ -102,6 +103,31 @@ _CLEANUP_RETRY_DELAYS = (0.1, 0.25, 0.5, 1.0, 2.0)
 
 _PROCESS_TREE_SHUTDOWN_TIMEOUT = 10
 """Seconds to wait for pipes to close after killing a timed-out CLI tree."""
+
+_INTERRUPT_SHUTDOWN_GRACE_SECONDS = 2.0
+"""Seconds to wait after Ctrl-C TERM before force-killing active CLI trees."""
+
+_ACTIVE_PROCESS_LOCK = threading.Lock()
+_ACTIVE_PROCESSES: set[subprocess.Popen[str]] = set()
+"""CLI subprocesses currently owned by worker threads."""
+
+_STOP_REQUESTED = threading.Event()
+"""Set when the main runner is interrupted so worker retries/backoffs stop."""
+
+
+def _is_opencode_run_command(argv: list[str]) -> bool:
+    if len(argv) < 2:
+        return False
+    return Path(argv[0]).name == "opencode" and argv[1] == "run"
+
+
+def _argv_for_workspace(argv: list[str], workspace: Path) -> list[str]:
+    """Return argv with an explicit workspace argument when the CLI needs one."""
+    if not _is_opencode_run_command(argv):
+        return list(argv)
+    if any(arg == "--dir" or arg.startswith("--dir=") for arg in argv):
+        return list(argv)
+    return [*argv, "--dir", str(workspace)]
 
 
 def _is_codex_exec_command(argv: list[str]) -> bool:
@@ -228,11 +254,73 @@ def _terminate_process_tree(proc: subprocess.Popen[str]) -> None:
         return
 
     try:
-        os.killpg(proc.pid, 15)
+        os.killpg(proc.pid, signal.SIGTERM)
     except ProcessLookupError:
         return
     except OSError:
         proc.kill()
+
+
+def _kill_process_tree(proc: subprocess.Popen[str]) -> None:
+    if os.name == "nt":
+        subprocess.run(  # noqa: S603,S607 — Windows process-tree cleanup helper
+            ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        return
+
+    try:
+        os.killpg(proc.pid, signal.SIGKILL)
+    except ProcessLookupError:
+        return
+    except OSError:
+        proc.kill()
+
+
+def _process_is_running(proc: subprocess.Popen[str]) -> bool:
+    try:
+        return proc.poll() is None
+    except AttributeError:
+        return getattr(proc, "returncode", None) is None
+
+
+def _register_active_process(proc: subprocess.Popen[str]) -> None:
+    with _ACTIVE_PROCESS_LOCK:
+        _ACTIVE_PROCESSES.add(proc)
+
+
+def _unregister_active_process(proc: subprocess.Popen[str]) -> None:
+    with _ACTIVE_PROCESS_LOCK:
+        _ACTIVE_PROCESSES.discard(proc)
+
+
+def _terminate_all_active_processes() -> None:
+    with _ACTIVE_PROCESS_LOCK:
+        procs = list(_ACTIVE_PROCESSES)
+    for proc in procs:
+        try:
+            _terminate_process_tree(proc)
+        except Exception:  # noqa: BLE001 — best-effort interrupt cleanup.
+            continue
+    deadline = time.monotonic() + _INTERRUPT_SHUTDOWN_GRACE_SECONDS
+    while time.monotonic() < deadline:
+        if all(not _process_is_running(proc) for proc in procs):
+            return
+        time.sleep(0.05)
+    for proc in procs:
+        if not _process_is_running(proc):
+            continue
+        try:
+            _kill_process_tree(proc)
+        except Exception:  # noqa: BLE001 — best-effort interrupt cleanup.
+            continue
+
+
+def _sleep_interruptibly(seconds: float) -> None:
+    if _STOP_REQUESTED.wait(seconds):
+        raise KeyboardInterrupt
 
 
 def _run_cli_subprocess(
@@ -263,6 +351,7 @@ def _run_cli_subprocess(
         creationflags=creationflags,
         start_new_session=start_new_session,
     )
+    _register_active_process(proc)
     try:
         stdout, stderr = proc.communicate(timeout=timeout)
     except subprocess.TimeoutExpired:
@@ -270,9 +359,14 @@ def _run_cli_subprocess(
         try:
             proc.communicate(timeout=_PROCESS_TREE_SHUTDOWN_TIMEOUT)
         except subprocess.TimeoutExpired:
-            proc.kill()
+            _kill_process_tree(proc)
             proc.communicate()
         raise
+    except BaseException:
+        _terminate_process_tree(proc)
+        raise
+    finally:
+        _unregister_active_process(proc)
     return subprocess.CompletedProcess(argv, proc.returncode, stdout, stderr)
 
 
@@ -506,7 +600,10 @@ def run_task_cli(
 
             task.setup(workspace_path)
 
-            argv = list(base_argv)
+            if _STOP_REQUESTED.is_set():
+                raise KeyboardInterrupt
+
+            argv = _argv_for_workspace(base_argv, workspace_path)
             agents_md = workspace_path / "AGENTS.md"
             if inject_agents_md and agents_md.exists():
                 argv += [
@@ -577,7 +674,7 @@ def run_task_cli(
                     _cleanup_workspace_keepalive(workspace_keepalive, task_id=task.id)
                     workspace_keepalive = None
                 delay = _BACKOFF_SCHEDULE[min(attempt, len(_BACKOFF_SCHEDULE) - 1)]
-                time.sleep(delay)
+                _sleep_interruptibly(delay)
                 continue
 
             # Verifier failed and the error isn't transient (or budget exhausted).
@@ -604,9 +701,9 @@ def run_task_cli(
                 prom_env = _subprocess_env_with_prom_token()
                 if prom_env is not None:
                     prom_model = os.getenv("GIGACHAT_PROM_MODEL", "GigaChat-2-Max")
-                    prom_argv = shlex.split(
-                        _swap_model_in_cli_command(cli_command, prom_model)
-                    ) + [task.prompt]
+                    prom_base_argv = _ensure_codex_json_events(
+                        shlex.split(_swap_model_in_cli_command(cli_command, prom_model))
+                    )
                     # Clean prior workspace and re-set up for PROM attempt.
                     if workspace_keepalive is not None:
                         _cleanup_workspace_keepalive(workspace_keepalive, task_id=task.id)
@@ -619,6 +716,10 @@ def run_task_cli(
                         )
                         workspace_path = Path(workspace_keepalive.name)
                     task.setup(workspace_path)
+                    prom_argv = [
+                        *_argv_for_workspace(prom_base_argv, workspace_path),
+                        task.prompt,
+                    ]
                     try:
                         prom_result = _run_cli_subprocess(
                             prom_argv,
@@ -674,6 +775,7 @@ def run_all_cli(
 ) -> list[TaskRun]:
     """Run a subset (or all) of the benchmark via the CLI agent."""
     _load_env_from_dotenv()
+    _STOP_REQUESTED.clear()
     if attempts < 1:
         raise ValueError("attempts must be positive")
 
@@ -681,30 +783,39 @@ def run_all_cli(
 
     if concurrency <= 1:
         results: list[TaskRun] = []
-        for task in targets:
-            for attempt in range(1, attempts + 1):
-                label = _task_attempt_label_for(task.id, attempt, attempts)
-                print(f"[START] {label}: {task.name}")
-                run = run_task_cli(
-                    task,
-                    cli_command=cli_command,
-                    timeout=timeout,
-                    keep_workspace=keep_workspace,
-                )
-                run = _mark_attempt(run, attempt, attempts)
-                results.append(run)
-                _write_partial_results_json(results, json_output)
-                status = "PASS" if run.passed else "FAIL"
-                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-                if keep_workspace and run.workspace:
-                    print(f"  workspace: {run.workspace}")
+        try:
+            for task in targets:
+                for attempt in range(1, attempts + 1):
+                    label = _task_attempt_label_for(task.id, attempt, attempts)
+                    print(f"[START] {label}: {task.name}")
+                    run = run_task_cli(
+                        task,
+                        cli_command=cli_command,
+                        timeout=timeout,
+                        keep_workspace=keep_workspace,
+                    )
+                    run = _mark_attempt(run, attempt, attempts)
+                    results.append(run)
+                    _write_partial_results_json(results, json_output)
+                    status = "PASS" if run.passed else "FAIL"
+                    print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                    if keep_workspace and run.workspace:
+                        print(f"  workspace: {run.workspace}")
+        except KeyboardInterrupt:
+            _STOP_REQUESTED.set()
+            _terminate_all_active_processes()
+            _write_partial_results_json(results, json_output)
+            raise
         return results
 
     print_lock = threading.Lock()
     completed = 0
     total = len(targets) * attempts
     results = []
-    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+    executor = ThreadPoolExecutor(max_workers=concurrency)
+    interrupted = False
+    future_to_task = {}
+    try:
         future_to_task = {
             executor.submit(
                 run_task_cli,
@@ -731,6 +842,16 @@ def run_all_cli(
                 )
                 if keep_workspace and run.workspace:
                     print(f"           workspace: {run.workspace}")
+    except KeyboardInterrupt:
+        interrupted = True
+        _STOP_REQUESTED.set()
+        _terminate_all_active_processes()
+        for future in future_to_task:
+            future.cancel()
+        _write_partial_results_json(results, json_output)
+        raise
+    finally:
+        executor.shutdown(wait=not interrupted, cancel_futures=interrupted)
     results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     _write_partial_results_json(results, json_output)
     return results
@@ -739,6 +860,7 @@ def run_all_cli(
 __all__ = [
     "DEFAULT_CLI_COMMAND",
     "DEFAULT_TIMEOUT_SECONDS",
+    "_argv_for_workspace",
     "run_all_cli",
     "run_task_cli",
     "summarize",

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -40,10 +40,14 @@ from harness_bench.runner import (
     _load_env_from_dotenv,
     _mark_attempt,
     _one_line_detail,
+    _pending_task_attempts,
+    _resume_results,
     _task_attempt_label,
     _task_attempt_label_for,
     _task_sort_key,
+    _write_interrupted_results_json,
     _write_partial_results_json,
+    normalize_json_output_path,
     summarize,
 )
 from harness_bench.tasks import ALL_TASKS, get_task
@@ -776,42 +780,47 @@ def run_all_cli(
     """Run a subset (or all) of the benchmark via the CLI agent."""
     _load_env_from_dotenv()
     _STOP_REQUESTED.clear()
+    json_output = normalize_json_output_path(json_output)
     if attempts < 1:
         raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
+    results = _resume_results(json_output, targets, attempts)
+    pending_attempts = _pending_task_attempts(targets, attempts, results)
+    if not pending_attempts:
+        _write_partial_results_json(results, json_output)
+        return results
 
     if concurrency <= 1:
-        results: list[TaskRun] = []
         try:
-            for task in targets:
-                for attempt in range(1, attempts + 1):
-                    label = _task_attempt_label_for(task.id, attempt, attempts)
-                    print(f"[START] {label}: {task.name}")
-                    run = run_task_cli(
-                        task,
-                        cli_command=cli_command,
-                        timeout=timeout,
-                        keep_workspace=keep_workspace,
-                    )
-                    run = _mark_attempt(run, attempt, attempts)
-                    results.append(run)
-                    _write_partial_results_json(results, json_output)
-                    status = "PASS" if run.passed else "FAIL"
-                    print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-                    if keep_workspace and run.workspace:
-                        print(f"  workspace: {run.workspace}")
+            for task, attempt in pending_attempts:
+                label = _task_attempt_label_for(task.id, attempt, attempts)
+                print(f"[START] {label}: {task.name}")
+                run = run_task_cli(
+                    task,
+                    cli_command=cli_command,
+                    timeout=timeout,
+                    keep_workspace=keep_workspace,
+                )
+                run = _mark_attempt(run, attempt, attempts)
+                results.append(run)
+                _write_partial_results_json(results, json_output)
+                status = "PASS" if run.passed else "FAIL"
+                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                if keep_workspace and run.workspace:
+                    print(f"  workspace: {run.workspace}")
         except KeyboardInterrupt:
             _STOP_REQUESTED.set()
             _terminate_all_active_processes()
-            _write_partial_results_json(results, json_output)
+            _write_interrupted_results_json(results, json_output, pending_attempts, attempts)
             raise
+        results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
+        _write_partial_results_json(results, json_output)
         return results
 
     print_lock = threading.Lock()
-    completed = 0
+    completed = len(results)
     total = len(targets) * attempts
-    results = []
     executor = ThreadPoolExecutor(max_workers=concurrency)
     interrupted = False
     future_to_task = {}
@@ -824,8 +833,7 @@ def run_all_cli(
                 timeout=timeout,
                 keep_workspace=keep_workspace,
             ): (task, attempt)
-            for task in targets
-            for attempt in range(1, attempts + 1)
+            for task, attempt in pending_attempts
         }
         for future in as_completed(future_to_task):
             _task, attempt = future_to_task[future]
@@ -848,7 +856,7 @@ def run_all_cli(
         _terminate_all_active_processes()
         for future in future_to_task:
             future.cancel()
-        _write_partial_results_json(results, json_output)
+        _write_interrupted_results_json(results, json_output, pending_attempts, attempts)
         raise
     finally:
         executor.shutdown(wait=not interrupted, cancel_futures=interrupted)

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -118,6 +118,18 @@ _ACTIVE_PROCESSES: set[subprocess.Popen[str]] = set()
 _STOP_REQUESTED = threading.Event()
 """Set when the main runner is interrupted so worker retries/backoffs stop."""
 
+_AGENT_METRIC_KEYS = (
+    "agent_steps",
+    "agent_tool_calls",
+    "agent_shell_commands",
+    "agent_events",
+    "agent_llm_calls",
+    "agent_input_tokens",
+    "agent_output_tokens",
+    "agent_total_tokens",
+)
+"""Per-task effort metrics written to result JSON when a parser recognizes a run."""
+
 
 def _is_opencode_run_command(argv: list[str]) -> bool:
     if len(argv) < 2:
@@ -149,6 +161,370 @@ def _ensure_codex_json_events(argv: list[str]) -> list[str]:
     return [*argv[:2], "--json", *argv[2:]]
 
 
+def _is_claude_print_command(argv: list[str]) -> bool:
+    if not argv:
+        return False
+    executable = Path(argv[0]).name
+    return executable == "claude" and any(arg in ("-p", "--print") for arg in argv)
+
+
+def _is_gemini_prompt_command(argv: list[str]) -> bool:
+    if not argv:
+        return False
+    executable = Path(argv[0]).name
+    return executable == "gemini" and any(
+        arg in ("-p", "--prompt") or arg.startswith("--prompt=") for arg in argv
+    )
+
+
+def _argv_with_output_format(
+    argv: list[str],
+    output_format: str,
+    *,
+    insert_before: tuple[str, ...] = (),
+) -> list[str]:
+    """Return argv with --output-format set without mutating the caller's list."""
+    result = list(argv)
+    for i, arg in enumerate(result):
+        if arg in ("--output-format", "-o"):
+            if i + 1 < len(result):
+                result[i + 1] = output_format
+                return result
+            return [*result, output_format]
+        if arg.startswith("--output-format="):
+            result[i] = f"--output-format={output_format}"
+            return result
+        if arg.startswith("-o="):
+            result[i] = f"-o={output_format}"
+            return result
+
+    insert_at = len(result)
+    for i, arg in enumerate(result):
+        if arg in insert_before:
+            insert_at = i
+            break
+    return [*result[:insert_at], "--output-format", output_format, *result[insert_at:]]
+
+
+def _ensure_claude_verbose(argv: list[str]) -> list[str]:
+    result = [
+        "--verbose" if arg in ("—verbose", "–verbose") else arg
+        for arg in argv
+    ]
+    if "--verbose" in result:
+        return result
+    return [*result, "--verbose"]
+
+
+def _ensure_claude_json_events(argv: list[str]) -> list[str]:
+    """Ask Claude Code for stream-json events when it is used in print mode."""
+    if not _is_claude_print_command(argv):
+        return argv
+    argv = _argv_with_output_format(argv, "stream-json")
+    return _ensure_claude_verbose(argv)
+
+
+def _ensure_gemini_json_events(argv: list[str]) -> list[str]:
+    """Ask Gemini CLI for stream-json events when it is used in prompt mode."""
+    if not _is_gemini_prompt_command(argv):
+        return argv
+    return _argv_with_output_format(
+        argv,
+        "stream-json",
+        insert_before=("-p", "--prompt"),
+    )
+
+
+def _ensure_cli_json_events(argv: list[str]) -> list[str]:
+    """Enable machine-readable CLI output for CLIs that expose it."""
+    argv = _ensure_codex_json_events(argv)
+    argv = _ensure_claude_json_events(argv)
+    return _ensure_gemini_json_events(argv)
+
+
+def _iter_json_payloads(stdout: str) -> list[dict[str, object]]:
+    payloads: list[dict[str, object]] = []
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            payloads.append(payload)
+    if payloads:
+        return payloads
+
+    stripped = stdout.strip()
+    if not stripped:
+        return []
+    try:
+        payload = json.loads(stripped)
+    except json.JSONDecodeError:
+        return []
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    return []
+
+
+def _add_metric_count(stats: dict[str, int], key: str, value: object) -> None:
+    parsed = _int_or_none(value)
+    if parsed is not None:
+        stats[key] = stats.get(key, 0) + parsed
+
+
+def _set_metric_max(stats: dict[str, int], key: str, value: object) -> None:
+    parsed = _int_or_none(value)
+    if parsed is not None:
+        stats[key] = max(stats.get(key, 0), parsed)
+
+
+def _usage_stats_from_mapping(usage: object) -> dict[str, int]:
+    stats: dict[str, int] = {}
+    if not isinstance(usage, dict):
+        return stats
+
+    _add_usage_counts(stats, usage)
+
+    if "agent_input_tokens" not in stats:
+        for key in ("inputTokens", "promptTokenCount", "prompt_token_count"):
+            if key in usage:
+                _add_metric_count(stats, "agent_input_tokens", usage[key])
+                break
+    if "agent_output_tokens" not in stats:
+        for key in ("outputTokens", "candidatesTokenCount", "candidates_token_count"):
+            if key in usage:
+                _add_metric_count(stats, "agent_output_tokens", usage[key])
+                break
+
+    for key in ("totalTokens", "totalTokenCount", "total_token_count"):
+        if key in usage:
+            parsed = _int_or_none(usage[key])
+            if parsed is not None:
+                stats["agent_total_tokens"] = parsed
+                break
+
+    return stats
+
+
+def _merge_metric_counts(stats: dict[str, int], extra: dict[str, int]) -> None:
+    for key, value in extra.items():
+        stats[key] = stats.get(key, 0) + value
+
+
+def _with_default_agent_metrics(stats: dict[str, int]) -> dict[str, int]:
+    return {key: stats.get(key, 0) for key in _AGENT_METRIC_KEYS}
+
+
+def _tool_name_is_shell(name: object) -> bool:
+    if not isinstance(name, str):
+        return False
+    return name.lower() in {
+        "bash",
+        "shell",
+        "run_shell_command",
+        "execute_shell_command",
+    }
+
+
+def _claude_tool_use_names(content: object) -> list[str]:
+    if not isinstance(content, list):
+        return []
+    names: list[str] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") != "tool_use":
+            continue
+        name = part.get("name")
+        if isinstance(name, str):
+            names.append(name)
+    return names
+
+
+def _looks_like_claude_payload(payload: dict[str, object]) -> bool:
+    payload_type = payload.get("type")
+    if any(key in payload for key in ("totalToolUseCount", "totalTokens", "toolStats")):
+        return True
+    if payload_type == "assistant":
+        return isinstance(payload.get("message"), dict) or "message" in payload
+    if payload_type == "user":
+        return isinstance(payload.get("message"), dict)
+    if payload_type == "system":
+        return "subtype" in payload or "session_id" in payload
+    if payload_type == "result":
+        return "stats" not in payload and any(
+            key in payload
+            for key in (
+                "subtype",
+                "is_error",
+                "num_turns",
+                "duration_ms",
+                "duration_api_ms",
+                "total_cost_usd",
+                "usage",
+            )
+        )
+    return False
+
+
+def _claude_json_event_stats(stdout: str) -> dict[str, int] | None:
+    """Extract effort metrics from Claude Code JSON / stream-json output."""
+    payloads = _iter_json_payloads(stdout)
+    if not payloads:
+        return None
+
+    saw_claude_event = False
+    events = 0
+    tool_calls = 0
+    shell_commands = 0
+    llm_calls = 0
+    stream_usage_stats: dict[str, int] = {}
+    result_usage_stats: dict[str, int] = {}
+    result_tool_calls: int | None = None
+    result_shell_commands: int | None = None
+
+    for payload in payloads:
+        payload_type = payload.get("type")
+        if not _looks_like_claude_payload(payload):
+            continue
+
+        saw_claude_event = True
+        events += 1
+
+        if payload_type == "assistant":
+            llm_calls += 1
+            message = payload.get("message")
+            if isinstance(message, dict):
+                _merge_metric_counts(
+                    stream_usage_stats,
+                    _usage_stats_from_mapping(message.get("usage")),
+                )
+                names = _claude_tool_use_names(message.get("content"))
+            else:
+                names = _claude_tool_use_names(payload.get("content"))
+            tool_calls += len(names)
+            shell_commands += sum(1 for name in names if _tool_name_is_shell(name))
+        elif payload_type == "result":
+            _set_metric_max(result_usage_stats, "agent_total_tokens", payload.get("totalTokens"))
+            turns = _int_or_none(payload.get("num_turns"))
+            if turns is not None:
+                llm_calls = max(llm_calls, turns)
+
+        _merge_metric_counts(
+            result_usage_stats,
+            _usage_stats_from_mapping(payload.get("usage")),
+        )
+        _set_metric_max(result_usage_stats, "agent_total_tokens", payload.get("totalTokens"))
+
+        total_tool_use_count = _int_or_none(payload.get("totalToolUseCount"))
+        if total_tool_use_count is not None:
+            result_tool_calls = max(result_tool_calls or 0, total_tool_use_count)
+        tool_stats = payload.get("toolStats")
+        if isinstance(tool_stats, dict):
+            bash_count = _int_or_none(tool_stats.get("bashCount"))
+            if bash_count is not None:
+                result_shell_commands = max(result_shell_commands or 0, bash_count)
+
+    if not saw_claude_event:
+        return None
+
+    if result_tool_calls is not None:
+        tool_calls = max(tool_calls, result_tool_calls)
+    if result_shell_commands is not None:
+        shell_commands = max(shell_commands, result_shell_commands)
+
+    stats = {
+        "agent_steps": tool_calls,
+        "agent_tool_calls": tool_calls,
+        "agent_shell_commands": shell_commands,
+        "agent_events": events,
+    }
+    if llm_calls:
+        stats["agent_llm_calls"] = llm_calls
+
+    token_stats = stream_usage_stats or result_usage_stats
+    if result_usage_stats.get("agent_total_tokens", 0) > token_stats.get(
+        "agent_total_tokens",
+        0,
+    ):
+        token_stats = {
+            **token_stats,
+            "agent_total_tokens": result_usage_stats["agent_total_tokens"],
+        }
+    stats.update(token_stats)
+    return _with_default_agent_metrics(stats)
+
+
+def _gemini_json_event_stats(stdout: str) -> dict[str, int] | None:
+    """Extract effort metrics from Gemini CLI JSON / stream-json output."""
+    payloads = _iter_json_payloads(stdout)
+    if not payloads:
+        return None
+
+    saw_gemini_event = False
+    events = 0
+    tool_calls = 0
+    shell_commands = 0
+    llm_calls = 0
+    result_stats: dict[str, int] = {}
+
+    for payload in payloads:
+        payload_type = payload.get("type")
+        looks_gemini = payload_type in {
+            "init",
+            "message",
+            "tool_use",
+            "tool_result",
+            "error",
+            "result",
+        } or "stats" in payload
+        if not looks_gemini:
+            continue
+
+        saw_gemini_event = True
+        events += 1
+
+        if payload_type == "message" and payload.get("role") == "assistant":
+            llm_calls += 1
+        elif payload_type == "tool_use":
+            tool_calls += 1
+            if _tool_name_is_shell(payload.get("tool_name") or payload.get("name")):
+                shell_commands += 1
+
+        stats_payload = payload.get("stats")
+        if isinstance(stats_payload, dict):
+            _merge_metric_counts(
+                result_stats,
+                _usage_stats_from_mapping(stats_payload),
+            )
+            _set_metric_max(result_stats, "agent_steps", stats_payload.get("tool_calls"))
+            _set_metric_max(
+                result_stats,
+                "agent_tool_calls",
+                stats_payload.get("tool_calls"),
+            )
+
+    if not saw_gemini_event:
+        return None
+
+    tool_calls = max(tool_calls, result_stats.get("agent_tool_calls", 0))
+    stats = {
+        "agent_steps": max(tool_calls, result_stats.get("agent_steps", 0)),
+        "agent_tool_calls": tool_calls,
+        "agent_shell_commands": shell_commands,
+        "agent_events": events,
+    }
+    if llm_calls:
+        stats["agent_llm_calls"] = llm_calls
+    stats.update(result_stats)
+    return _with_default_agent_metrics(stats)
+
+
 def _codex_json_event_stats(stdout: str) -> dict[str, int] | None:
     """Count Codex JSONL action events emitted by `codex exec --json`.
 
@@ -174,6 +550,16 @@ def _codex_json_event_stats(stdout: str) -> dict[str, int] | None:
         except json.JSONDecodeError:
             continue
         if not isinstance(payload, dict) or not isinstance(payload.get("type"), str):
+            continue
+        if payload["type"] not in {
+            "thread.started",
+            "turn.started",
+            "turn.completed",
+            "turn.failed",
+            "item.started",
+            "item.completed",
+            "error",
+        }:
             continue
         saw_codex_event = True
         events += 1
@@ -212,7 +598,7 @@ def _codex_json_event_stats(stdout: str) -> dict[str, int] | None:
         result["agent_output_tokens"] = output_tokens
     if total_tokens:
         result["agent_total_tokens"] = total_tokens
-    return result
+    return _with_default_agent_metrics(result)
 
 
 def _int_or_none(value: object) -> int | None:
@@ -315,6 +701,10 @@ def _task_run_with_cli_stats(
     stats_workspace: Path | None = None,
 ) -> TaskRun:
     stats = _codex_json_event_stats(result.stdout or "") if result is not None else None
+    if stats is None and result is not None:
+        stats = _claude_json_event_stats(result.stdout or "")
+    if stats is None and result is not None:
+        stats = _gemini_json_event_stats(result.stdout or "")
     if stats is None:
         stats = _mini_swe_agent_traj_stats(stats_workspace or workspace)
     return TaskRun(
@@ -665,7 +1055,7 @@ def run_task_cli(
     """
     _load_env_from_dotenv()
     workspace_keepalive: TemporaryDirectory | None = None
-    base_argv = _ensure_codex_json_events(shlex.split(cli_command))
+    base_argv = _ensure_cli_json_events(shlex.split(cli_command))
     last_result: subprocess.CompletedProcess[str] | None = None
     last_transient_excerpt: str | None = None
     started = time.monotonic()

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -215,6 +215,94 @@ def _codex_json_event_stats(stdout: str) -> dict[str, int] | None:
     return result
 
 
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _mini_swe_agent_traj_candidates(workspace: Path) -> list[Path]:
+    """Return possible mini-SWE-agent trajectory paths for a task workspace."""
+    candidates = [workspace / "mini-swe-agent.traj.json"]
+    configured = os.getenv("MSWEA_OUTPUT_PATH")
+    if configured:
+        configured_path = Path(configured)
+        if not configured_path.is_absolute():
+            configured_path = workspace / configured_path
+        if configured_path not in candidates:
+            candidates.append(configured_path)
+    return candidates
+
+
+def _mini_swe_agent_traj_stats(workspace: Path | None) -> dict[str, int] | None:
+    """Extract effort metrics from a mini-SWE-agent trajectory JSON file."""
+    if workspace is None:
+        return None
+
+    payload = None
+    for path in _mini_swe_agent_traj_candidates(workspace):
+        if not path.exists():
+            continue
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        break
+    if not isinstance(payload, dict):
+        return None
+
+    messages = payload.get("messages")
+    if not isinstance(messages, list):
+        return None
+
+    stats: dict[str, int] = {"agent_events": len(messages)}
+    info = payload.get("info")
+    if isinstance(info, dict):
+        model_stats = info.get("model_stats")
+        if isinstance(model_stats, dict):
+            api_calls = _int_or_none(model_stats.get("api_calls"))
+            if api_calls is not None:
+                stats["agent_llm_calls"] = api_calls
+
+    steps = 0
+    tool_calls = 0
+    shell_commands = 0
+    llm_calls = 0
+    for message in messages:
+        if not isinstance(message, dict) or message.get("role") != "assistant":
+            continue
+        llm_calls += 1
+        extra = message.get("extra")
+        if not isinstance(extra, dict):
+            continue
+        actions = extra.get("actions")
+        if isinstance(actions, list):
+            steps += len(actions)
+            tool_calls += len(actions)
+            shell_commands += sum(
+                1
+                for action in actions
+                if isinstance(action, dict) and isinstance(action.get("command"), str)
+            )
+        response = extra.get("response")
+        if isinstance(response, dict):
+            _add_usage_counts(stats, response.get("usage"))
+            _add_usage_counts(stats, response.get("usage_metadata"))
+
+    if steps:
+        stats["agent_steps"] = steps
+    if tool_calls:
+        stats["agent_tool_calls"] = tool_calls
+    if shell_commands:
+        stats["agent_shell_commands"] = shell_commands
+    stats.setdefault("agent_llm_calls", llm_calls)
+    return stats
+
+
 def _task_run_with_cli_stats(
     *,
     task_id: str,
@@ -224,8 +312,11 @@ def _task_run_with_cli_stats(
     result: subprocess.CompletedProcess[str] | None,
     error: str | None = None,
     workspace: Path | None = None,
+    stats_workspace: Path | None = None,
 ) -> TaskRun:
     stats = _codex_json_event_stats(result.stdout or "") if result is not None else None
+    if stats is None:
+        stats = _mini_swe_agent_traj_stats(stats_workspace or workspace)
     return TaskRun(
         task_id=task_id,
         passed=passed,
@@ -660,6 +751,7 @@ def run_task_cli(
                     elapsed_seconds=time.monotonic() - started,
                     result=last_result,
                     workspace=workspace_path if keep_workspace else None,
+                    stats_workspace=workspace_path,
                 )
 
             # Decide whether to retry. We retry on any transient network error
@@ -746,6 +838,7 @@ def run_task_cli(
                                 elapsed_seconds=time.monotonic() - started,
                                 result=prom_result,
                                 workspace=workspace_path if keep_workspace else None,
+                                stats_workspace=workspace_path,
                             )
                         # PROM-fallback also failed — surface its message for visibility.
                         message = f"{message} | PROM-fallback({prom_model}): {prom_outcome.message}"
@@ -757,6 +850,7 @@ def run_task_cli(
                 elapsed_seconds=time.monotonic() - started,
                 result=last_result,
                 workspace=workspace_path if keep_workspace else None,
+                stats_workspace=workspace_path,
             )
 
         # Unreachable — the loop above always returns. Keep a deterministic

--- a/harness_bench/runner_openrouter.py
+++ b/harness_bench/runner_openrouter.py
@@ -32,12 +32,16 @@ from harness_bench.runner import (
     _load_env_from_dotenv,
     _mark_attempt,
     _one_line_detail,
+    _pending_task_attempts,
+    _resume_results,
     _task_attempt_label,
     _task_attempt_label_for,
     _task_run_with_agent_stats,
     _task_sort_key,
+    _write_interrupted_results_json,
     _write_partial_results_json,
     invoke_agent_with_stats,
+    normalize_json_output_path,
 )
 from harness_bench.tasks import ALL_TASKS, get_task
 
@@ -457,46 +461,56 @@ def run_all(
 ) -> list[TaskRun]:
     _load_env_from_dotenv()
     _ensure_openrouter_key()
+    json_output = normalize_json_output_path(json_output)
 
     if attempts < 1:
         raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
+    results = _resume_results(json_output, targets, attempts)
+    if fail_on_runtime_error and any(run.error for run in results):
+        _write_partial_results_json(results, json_output)
+        return results
+    pending_attempts = _pending_task_attempts(targets, attempts, results)
+    if not pending_attempts:
+        _write_partial_results_json(results, json_output)
+        return results
 
     if concurrency <= 1:
-        results: list[TaskRun] = []
         try:
-            for task in targets:
-                for attempt in range(1, attempts + 1):
-                    label = _task_attempt_label_for(task.id, attempt, attempts)
-                    print(f"[START] {label}: {task.name}")
-                    run = run_task(
-                        task,
-                        model_name=model_name,
-                        keep_workspace=keep_workspace,
-                        recursion_limit=recursion_limit,
-                        max_tokens=max_tokens,
-                        harness_profile=harness_profile,
-                        transient_attempts=transient_attempts,
-                    )
-                    run = _mark_attempt(run, attempt, attempts)
-                    results.append(run)
+            for task, attempt in pending_attempts:
+                label = _task_attempt_label_for(task.id, attempt, attempts)
+                print(f"[START] {label}: {task.name}")
+                run = run_task(
+                    task,
+                    model_name=model_name,
+                    keep_workspace=keep_workspace,
+                    recursion_limit=recursion_limit,
+                    max_tokens=max_tokens,
+                    harness_profile=harness_profile,
+                    transient_attempts=transient_attempts,
+                )
+                run = _mark_attempt(run, attempt, attempts)
+                results.append(run)
+                _write_partial_results_json(results, json_output)
+                status = "PASS" if run.passed else "FAIL"
+                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                if keep_workspace and run.workspace:
+                    print(f"  workspace: {run.workspace}")
+                if fail_on_runtime_error and run.error:
+                    results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
                     _write_partial_results_json(results, json_output)
-                    status = "PASS" if run.passed else "FAIL"
-                    print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-                    if keep_workspace and run.workspace:
-                        print(f"  workspace: {run.workspace}")
-                    if fail_on_runtime_error and run.error:
-                        return results
+                    return results
         except KeyboardInterrupt:
-            _write_partial_results_json(results, json_output)
+            _write_interrupted_results_json(results, json_output, pending_attempts, attempts)
             raise
+        results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
+        _write_partial_results_json(results, json_output)
         return results
 
     print_lock = threading.Lock()
-    completed = 0
+    completed = len(results)
     total = len(targets) * attempts
-    results = []
     executor = ThreadPoolExecutor(max_workers=concurrency)
     stop_without_wait = False
     future_to_task = {}
@@ -512,8 +526,7 @@ def run_all(
                 harness_profile=harness_profile,
                 transient_attempts=transient_attempts,
             ): (task, attempt)
-            for task in targets
-            for attempt in range(1, attempts + 1)
+            for task, attempt in pending_attempts
         }
         for future in as_completed(future_to_task):
             _task, attempt = future_to_task[future]
@@ -542,7 +555,7 @@ def run_all(
         stop_without_wait = True
         for future in future_to_task:
             future.cancel()
-        _write_partial_results_json(results, json_output)
+        _write_interrupted_results_json(results, json_output, pending_attempts, attempts)
         raise
     finally:
         executor.shutdown(wait=not stop_without_wait, cancel_futures=stop_without_wait)

--- a/harness_bench/runner_openrouter.py
+++ b/harness_bench/runner_openrouter.py
@@ -465,35 +465,42 @@ def run_all(
 
     if concurrency <= 1:
         results: list[TaskRun] = []
-        for task in targets:
-            for attempt in range(1, attempts + 1):
-                label = _task_attempt_label_for(task.id, attempt, attempts)
-                print(f"[START] {label}: {task.name}")
-                run = run_task(
-                    task,
-                    model_name=model_name,
-                    keep_workspace=keep_workspace,
-                    recursion_limit=recursion_limit,
-                    max_tokens=max_tokens,
-                    harness_profile=harness_profile,
-                    transient_attempts=transient_attempts,
-                )
-                run = _mark_attempt(run, attempt, attempts)
-                results.append(run)
-                _write_partial_results_json(results, json_output)
-                status = "PASS" if run.passed else "FAIL"
-                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-                if keep_workspace and run.workspace:
-                    print(f"  workspace: {run.workspace}")
-                if fail_on_runtime_error and run.error:
-                    return results
+        try:
+            for task in targets:
+                for attempt in range(1, attempts + 1):
+                    label = _task_attempt_label_for(task.id, attempt, attempts)
+                    print(f"[START] {label}: {task.name}")
+                    run = run_task(
+                        task,
+                        model_name=model_name,
+                        keep_workspace=keep_workspace,
+                        recursion_limit=recursion_limit,
+                        max_tokens=max_tokens,
+                        harness_profile=harness_profile,
+                        transient_attempts=transient_attempts,
+                    )
+                    run = _mark_attempt(run, attempt, attempts)
+                    results.append(run)
+                    _write_partial_results_json(results, json_output)
+                    status = "PASS" if run.passed else "FAIL"
+                    print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                    if keep_workspace and run.workspace:
+                        print(f"  workspace: {run.workspace}")
+                    if fail_on_runtime_error and run.error:
+                        return results
+        except KeyboardInterrupt:
+            _write_partial_results_json(results, json_output)
+            raise
         return results
 
     print_lock = threading.Lock()
     completed = 0
     total = len(targets) * attempts
     results = []
-    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+    executor = ThreadPoolExecutor(max_workers=concurrency)
+    stop_without_wait = False
+    future_to_task = {}
+    try:
         future_to_task = {
             executor.submit(
                 run_task,
@@ -524,11 +531,21 @@ def run_all(
                 if keep_workspace and run.workspace:
                     print(f"           workspace: {run.workspace}")
             if fail_on_runtime_error and run.error:
+                stop_without_wait = True
                 for pending_future in future_to_task:
                     if pending_future is not future:
                         pending_future.cancel()
                 results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
+                _write_partial_results_json(results, json_output)
                 return results
+    except KeyboardInterrupt:
+        stop_without_wait = True
+        for future in future_to_task:
+            future.cancel()
+        _write_partial_results_json(results, json_output)
+        raise
+    finally:
+        executor.shutdown(wait=not stop_without_wait, cancel_futures=stop_without_wait)
     results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     _write_partial_results_json(results, json_output)
     return results

--- a/harness_bench/runner_pure.py
+++ b/harness_bench/runner_pure.py
@@ -19,12 +19,16 @@ from harness_bench.runner import (
     _load_env_from_dotenv,
     _mark_attempt,
     _one_line_detail,
+    _pending_task_attempts,
+    _resume_results,
     _task_attempt_label,
     _task_attempt_label_for,
     _task_run_with_agent_stats,
     _task_sort_key,
+    _write_interrupted_results_json,
     _write_partial_results_json,
     invoke_agent_with_stats,
+    normalize_json_output_path,
 )
 from harness_bench.tasks import ALL_TASKS, get_task
 
@@ -139,40 +143,45 @@ def run_all(
 ) -> list[TaskRun]:
     _load_env_from_dotenv()
     _ensure_credentials()
+    json_output = normalize_json_output_path(json_output)
 
     if attempts < 1:
         raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
+    results = _resume_results(json_output, targets, attempts)
+    pending_attempts = _pending_task_attempts(targets, attempts, results)
+    if not pending_attempts:
+        _write_partial_results_json(results, json_output)
+        return results
 
     if concurrency <= 1:
-        results: list[TaskRun] = []
         try:
-            for task in targets:
-                for attempt in range(1, attempts + 1):
-                    label = _task_attempt_label_for(task.id, attempt, attempts)
-                    print(f"[START] {label}: {task.name}")
-                    run = run_task(
-                        task,
-                        keep_workspace=keep_workspace,
-                        recursion_limit=recursion_limit,
-                    )
-                    run = _mark_attempt(run, attempt, attempts)
-                    results.append(run)
-                    _write_partial_results_json(results, json_output)
-                    status = "PASS" if run.passed else "FAIL"
-                    print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-                    if keep_workspace and run.workspace:
-                        print(f"  workspace: {run.workspace}")
+            for task, attempt in pending_attempts:
+                label = _task_attempt_label_for(task.id, attempt, attempts)
+                print(f"[START] {label}: {task.name}")
+                run = run_task(
+                    task,
+                    keep_workspace=keep_workspace,
+                    recursion_limit=recursion_limit,
+                )
+                run = _mark_attempt(run, attempt, attempts)
+                results.append(run)
+                _write_partial_results_json(results, json_output)
+                status = "PASS" if run.passed else "FAIL"
+                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                if keep_workspace and run.workspace:
+                    print(f"  workspace: {run.workspace}")
         except KeyboardInterrupt:
-            _write_partial_results_json(results, json_output)
+            _write_interrupted_results_json(results, json_output, pending_attempts, attempts)
             raise
+        results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
+        _write_partial_results_json(results, json_output)
         return results
 
     print_lock = threading.Lock()
-    completed = 0
+    completed = len(results)
     total = len(targets) * attempts
-    results = []
     executor = ThreadPoolExecutor(max_workers=concurrency)
     interrupted = False
     future_to_task = {}
@@ -184,8 +193,7 @@ def run_all(
                 keep_workspace=keep_workspace,
                 recursion_limit=recursion_limit,
             ): (task, attempt)
-            for task in targets
-            for attempt in range(1, attempts + 1)
+            for task, attempt in pending_attempts
         }
         for future in as_completed(future_to_task):
             _task, attempt = future_to_task[future]
@@ -206,7 +214,7 @@ def run_all(
         interrupted = True
         for future in future_to_task:
             future.cancel()
-        _write_partial_results_json(results, json_output)
+        _write_interrupted_results_json(results, json_output, pending_attempts, attempts)
         raise
     finally:
         executor.shutdown(wait=not interrupted, cancel_futures=interrupted)

--- a/harness_bench/runner_pure.py
+++ b/harness_bench/runner_pure.py
@@ -147,29 +147,36 @@ def run_all(
 
     if concurrency <= 1:
         results: list[TaskRun] = []
-        for task in targets:
-            for attempt in range(1, attempts + 1):
-                label = _task_attempt_label_for(task.id, attempt, attempts)
-                print(f"[START] {label}: {task.name}")
-                run = run_task(
-                    task,
-                    keep_workspace=keep_workspace,
-                    recursion_limit=recursion_limit,
-                )
-                run = _mark_attempt(run, attempt, attempts)
-                results.append(run)
-                _write_partial_results_json(results, json_output)
-                status = "PASS" if run.passed else "FAIL"
-                print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
-                if keep_workspace and run.workspace:
-                    print(f"  workspace: {run.workspace}")
+        try:
+            for task in targets:
+                for attempt in range(1, attempts + 1):
+                    label = _task_attempt_label_for(task.id, attempt, attempts)
+                    print(f"[START] {label}: {task.name}")
+                    run = run_task(
+                        task,
+                        keep_workspace=keep_workspace,
+                        recursion_limit=recursion_limit,
+                    )
+                    run = _mark_attempt(run, attempt, attempts)
+                    results.append(run)
+                    _write_partial_results_json(results, json_output)
+                    status = "PASS" if run.passed else "FAIL"
+                    print(f"  [{status}] {run.elapsed_seconds:5.1f}s — {_one_line_detail(run)}")
+                    if keep_workspace and run.workspace:
+                        print(f"  workspace: {run.workspace}")
+        except KeyboardInterrupt:
+            _write_partial_results_json(results, json_output)
+            raise
         return results
 
     print_lock = threading.Lock()
     completed = 0
     total = len(targets) * attempts
     results = []
-    with ThreadPoolExecutor(max_workers=concurrency) as executor:
+    executor = ThreadPoolExecutor(max_workers=concurrency)
+    interrupted = False
+    future_to_task = {}
+    try:
         future_to_task = {
             executor.submit(
                 run_task,
@@ -195,6 +202,14 @@ def run_all(
                 )
                 if keep_workspace and run.workspace:
                     print(f"           workspace: {run.workspace}")
+    except KeyboardInterrupt:
+        interrupted = True
+        for future in future_to_task:
+            future.cancel()
+        _write_partial_results_json(results, json_output)
+        raise
+    finally:
+        executor.shutdown(wait=not interrupted, cancel_futures=interrupted)
     results.sort(key=lambda r: (*_task_sort_key(r.task_id), r.attempt))
     _write_partial_results_json(results, json_output)
     return results

--- a/harness_bench/versioning.py
+++ b/harness_bench/versioning.py
@@ -57,6 +57,8 @@ TASK_WAVES: tuple[TaskWave, ...] = (
     TaskWave("memory", 222, 253),
     TaskWave("agentic", 254, 298),
     TaskWave("VCS", 299, 313),
+    TaskWave("skills", 314, 330),
+    TaskWave("adversarial", 331, 351),
 )
 
 

--- a/harness_bench/versioning.py
+++ b/harness_bench/versioning.py
@@ -31,6 +31,35 @@ class TaskSetRevision:
         return f"{start}" if start == end else f"{start}-{end}"
 
 
+@dataclass(frozen=True)
+class TaskWave:
+    """A benchmark wave used for human-readable result breakdowns."""
+
+    name: str
+    start: int
+    end: int
+
+    @property
+    def label(self) -> str:
+        return f"{self.name} ({self.start}-{self.end})"
+
+    def contains(self, task_number: int) -> bool:
+        return self.start <= task_number <= self.end
+
+
+TASK_WAVES: tuple[TaskWave, ...] = (
+    TaskWave("core", 1, 30),
+    TaskWave("extra", 31, 60),
+    TaskWave("more", 61, 100),
+    TaskWave("hard", 101, 150),
+    TaskWave("extreme", 151, 205),
+    TaskWave("diagnostic", 206, 221),
+    TaskWave("memory", 222, 253),
+    TaskWave("agentic", 254, 298),
+    TaskWave("VCS", 299, 313),
+)
+
+
 TASK_SET_REVISIONS: tuple[TaskSetRevision, ...] = (
     TaskSetRevision(
         version="0.1.0",

--- a/scripts/hb-mini-swe-agent
+++ b/scripts/hb-mini-swe-agent
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+prompt="${1:?benchmark prompt missing}"
+mini_python=()
+
+if [[ -n "${MSWEA_PYTHON:-}" ]]; then
+  # Supports either an executable path or a short command with args.
+  read -r -a mini_python <<<"$MSWEA_PYTHON"
+else
+  mini_bin="${MSWEA_MINI_BIN:-}"
+  if [[ -z "$mini_bin" ]]; then
+    mini_bin="$(command -v mini || true)"
+  fi
+  if [[ -n "$mini_bin" ]]; then
+    shebang="$(head -n 1 "$mini_bin")"
+    shebang="${shebang#\#!}"
+    if [[ "$shebang" == /usr/bin/env\ -S\ * ]]; then
+      read -r -a mini_python <<<"${shebang#/usr/bin/env -S }"
+    elif [[ "$shebang" == /usr/bin/env\ * ]]; then
+      read -r -a mini_python <<<"${shebang#/usr/bin/env }"
+    else
+      mini_python=("$shebang")
+    fi
+  elif command -v uv >/dev/null 2>&1; then
+    mini_python=(uvx --from mini-swe-agent python)
+  else
+    echo "mini executable not found; install it with: uv tool install mini-swe-agent" >&2
+    exit 127
+  fi
+fi
+
+exec "${mini_python[@]}" - "$prompt" <<'PY'
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from minisweagent.agents import get_agent
+from minisweagent.config import builtin_config_dir, get_config_from_spec
+from minisweagent.environments import get_environment
+from minisweagent.models import get_model
+from minisweagent.utils.serialize import recursive_merge
+
+
+def _as_bool(value: str | None, *, default: bool = False) -> bool:
+    if value is None:
+        return default
+    return value.lower() not in {"", "0", "false", "no", "off"}
+
+
+def _as_int(value: str | None, *, default: int = 0) -> int:
+    if value is None or value == "":
+        return default
+    return int(value)
+
+
+def _as_float(value: str | None, *, default: float = 0.0) -> float:
+    if value is None or value == "":
+        return default
+    return float(value)
+
+
+def _openai_base_url() -> str:
+    return (
+        os.getenv("OPENAI_API_BASE")
+        or os.getenv("OPENAI_BASE_URL")
+        or "http://127.0.0.1:8090/v1"
+    )
+
+
+def _model_kwargs() -> dict:
+    kwargs = {
+        "custom_llm_provider": os.getenv("MSWEA_CUSTOM_LLM_PROVIDER", "openai"),
+        "api_base": _openai_base_url(),
+        "api_key": os.getenv("OPENAI_API_KEY", "0"),
+        "drop_params": _as_bool(os.getenv("MSWEA_DROP_PARAMS"), default=True),
+    }
+    extra = os.getenv("MSWEA_MODEL_KWARGS_JSON")
+    if extra:
+        kwargs.update(json.loads(extra))
+    return kwargs
+
+
+def _model_config() -> dict:
+    config = {
+        "model_class": os.getenv("MSWEA_MODEL_CLASS", "litellm"),
+        "model_name": os.getenv("MSWEA_MODEL_NAME", "openai/GigaChat-3-Ultra"),
+        "model_kwargs": _model_kwargs(),
+        "cost_tracking": os.getenv("MSWEA_COST_TRACKING", "ignore_errors"),
+    }
+    extra = os.getenv("MSWEA_MODEL_CONFIG_JSON")
+    if extra:
+        config.update(json.loads(extra))
+    return config
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: hb-mini-swe-agent '<benchmark prompt>'", file=sys.stderr)
+        return 2
+
+    task = sys.argv[1]
+    config = recursive_merge(
+        get_config_from_spec(str(builtin_config_dir / "mini.yaml")),
+        {
+            "agent": {
+                "agent_class": "default",
+                "cost_limit": _as_float(os.getenv("MSWEA_COST_LIMIT"), default=0.0),
+                "step_limit": _as_int(os.getenv("MSWEA_STEP_LIMIT"), default=0),
+                "wall_time_limit_seconds": _as_int(
+                    os.getenv("MSWEA_WALL_TIME_LIMIT_SECONDS"),
+                    default=0,
+                ),
+                "output_path": Path(os.getenv("MSWEA_OUTPUT_PATH", "mini-swe-agent.traj.json")),
+            },
+            "environment": {
+                "environment_class": os.getenv("MSWEA_ENVIRONMENT_CLASS", "local"),
+                "timeout": _as_int(os.getenv("MSWEA_COMMAND_TIMEOUT"), default=30),
+            },
+            "model": _model_config(),
+        },
+    )
+
+    # These keys belong to InteractiveAgent. DefaultAgent is the right class for
+    # benchmark subprocesses because runner_cli.py runs with stdin=/dev/null.
+    for key in ("mode", "confirm_exit", "whitelist_actions"):
+        config["agent"].pop(key, None)
+
+    model = get_model(config=config["model"])
+    env = get_environment(config["environment"], default_type="local")
+    agent = get_agent(model, env, config["agent"], default_type="default")
+    info = agent.run(task)
+    print(f"mini-swe-agent exit_status={info.get('exit_status', '')}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())
+PY

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -61,6 +61,25 @@ def test_summary_prints_pass_metrics_for_attempts(capsys: pytest.CaptureFixture[
     assert "Passed attempts: 3/4" in out
     assert "K  pass@K  pass^K" in out
     assert "-  ------  ------" in out
-    assert "1   1.5/2       -" in out
-    assert "2     2/2     1/2" in out
+    assert "1   75.0%       -" in out
+    assert "2  100.0%   50.0%" in out
     assert "task_1 #2/2: bad" in out
+
+
+def test_summary_prints_wave_breakdown_by_unique_task(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    results = [
+        TaskRun("task_01_example", False, "bad", 0.1, attempt=1, attempts=2),
+        TaskRun("task_01_example", True, "ok", 0.1, attempt=2, attempts=2),
+        TaskRun("task_31_example", False, "bad", 0.1, attempt=1, attempts=1),
+    ]
+
+    summarize(results, pass_at_ks=(), pass_hat_ks=())
+
+    out = capsys.readouterr().out
+    assert "Per-wave breakdown:" in out
+    assert "Wave           Tasks  Passed       %" in out
+    assert "core (1-30)        1       1  100.0%" in out
+    assert "extra (31-60)      1       0    0.0%" in out
+    assert "Total              2       1   50.0%" in out

--- a/tests/test_runner_cli.py
+++ b/tests/test_runner_cli.py
@@ -1,6 +1,7 @@
+import subprocess
 from pathlib import Path
 
-from harness_bench.runner_cli import _argv_for_workspace
+from harness_bench.runner_cli import _argv_for_workspace, _mini_swe_agent_traj_stats
 
 
 def test_opencode_command_gets_explicit_workspace_dir() -> None:
@@ -30,3 +31,105 @@ def test_workspace_argv_helper_does_not_mutate_input() -> None:
     argv.append("prompt")
 
     assert original == ["free-code", "-p"]
+
+
+def test_mini_swe_agent_traj_stats_count_steps_and_tokens(tmp_path: Path) -> None:
+    (tmp_path / "mini-swe-agent.traj.json").write_text(
+        """
+        {
+          "info": {"model_stats": {"api_calls": 2}},
+          "messages": [
+            {"role": "system", "content": "sys"},
+            {"role": "user", "content": "task"},
+            {
+              "role": "assistant",
+              "content": "inspect",
+              "extra": {
+                "actions": [{"command": "ls -la", "tool_call_id": "a"}],
+                "response": {
+                  "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 3,
+                    "total_tokens": 13
+                  }
+                }
+              }
+            },
+            {"role": "tool", "content": "ok"},
+            {
+              "role": "assistant",
+              "content": "finish",
+              "extra": {
+                "actions": [{"command": "echo COMPLETE_TASK_AND_SUBMIT_FINAL_OUTPUT"}],
+                "response": {
+                  "usage": {
+                    "input_tokens": 20,
+                    "output_tokens": 5,
+                    "total_tokens": 25
+                  }
+                }
+              }
+            },
+            {"role": "exit", "content": ""}
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    assert _mini_swe_agent_traj_stats(tmp_path) == {
+        "agent_events": 6,
+        "agent_llm_calls": 2,
+        "agent_input_tokens": 30,
+        "agent_output_tokens": 8,
+        "agent_total_tokens": 38,
+        "agent_steps": 2,
+        "agent_tool_calls": 2,
+        "agent_shell_commands": 2,
+    }
+
+
+def test_task_run_stats_can_read_mini_traj_without_kept_workspace(tmp_path: Path) -> None:
+    from harness_bench.runner_cli import _task_run_with_cli_stats
+
+    (tmp_path / "mini-swe-agent.traj.json").write_text(
+        """
+        {
+          "info": {"model_stats": {"api_calls": 1}},
+          "messages": [
+            {"role": "user", "content": "task"},
+            {
+              "role": "assistant",
+              "content": "write",
+              "extra": {
+                "actions": [{"command": "printf ok"}],
+                "response": {
+                  "usage": {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 2,
+                    "total_tokens": 9
+                  }
+                }
+              }
+            }
+          ]
+        }
+        """,
+        encoding="utf-8",
+    )
+
+    run = _task_run_with_cli_stats(
+        task_id="task_fake",
+        passed=True,
+        message="ok",
+        elapsed_seconds=0.1,
+        result=subprocess.CompletedProcess(["mini"], 0, "", ""),
+        workspace=None,
+        stats_workspace=tmp_path,
+    )
+
+    assert run.workspace is None
+    assert run.agent_steps == 1
+    assert run.agent_shell_commands == 1
+    assert run.agent_llm_calls == 1
+    assert run.agent_total_tokens == 9

--- a/tests/test_runner_cli.py
+++ b/tests/test_runner_cli.py
@@ -6,7 +6,7 @@ from harness_bench.runner_cli import _argv_for_workspace
 def test_opencode_command_gets_explicit_workspace_dir() -> None:
     argv = _argv_for_workspace(["opencode", "run", "--model", "x/y"], Path("/tmp/ws"))
 
-    assert argv == ["opencode", "run", "--model", "x/y", "--dir", "/tmp/ws"]
+    assert argv == ["opencode", "run", "--model", "x/y", "--dir", str(Path("/tmp/ws"))]
 
 
 def test_opencode_command_keeps_user_supplied_dir() -> None:

--- a/tests/test_runner_cli.py
+++ b/tests/test_runner_cli.py
@@ -1,7 +1,15 @@
 import subprocess
 from pathlib import Path
 
-from harness_bench.runner_cli import _argv_for_workspace, _mini_swe_agent_traj_stats
+from harness_bench.runner_cli import (
+    _argv_for_workspace,
+    _claude_json_event_stats,
+    _codex_json_event_stats,
+    _ensure_cli_json_events,
+    _gemini_json_event_stats,
+    _mini_swe_agent_traj_stats,
+    _task_run_with_cli_stats,
+)
 
 
 def test_opencode_command_gets_explicit_workspace_dir() -> None:
@@ -31,6 +39,179 @@ def test_workspace_argv_helper_does_not_mutate_input() -> None:
     argv.append("prompt")
 
     assert original == ["free-code", "-p"]
+
+
+def test_cli_json_events_asks_claude_for_stream_json() -> None:
+    argv = _ensure_cli_json_events(
+        ["/opt/homebrew/bin/claude", "--model", "GigaChat-3.5", "-p"]
+    )
+
+    assert argv == [
+        "/opt/homebrew/bin/claude",
+        "--model",
+        "GigaChat-3.5",
+        "-p",
+        "--output-format",
+        "stream-json",
+        "--verbose",
+    ]
+
+
+def test_cli_json_events_normalizes_claude_unicode_verbose_dash() -> None:
+    argv = _ensure_cli_json_events(
+        ["/opt/homebrew/bin/claude", "--model", "GigaChat-3.5", "—verbose", "-p"]
+    )
+
+    assert argv == [
+        "/opt/homebrew/bin/claude",
+        "--model",
+        "GigaChat-3.5",
+        "--verbose",
+        "-p",
+        "--output-format",
+        "stream-json",
+    ]
+
+
+def test_cli_json_events_rewrites_gemini_text_output_before_prompt_flag() -> None:
+    argv = _ensure_cli_json_events(
+        [
+            "/opt/homebrew/bin/gemini",
+            "-m",
+            "GigaChat-3.5",
+            "--output-format",
+            "text",
+            "-p",
+        ]
+    )
+
+    assert argv == [
+        "/opt/homebrew/bin/gemini",
+        "-m",
+        "GigaChat-3.5",
+        "--output-format",
+        "stream-json",
+        "-p",
+    ]
+
+
+def test_cli_json_events_inserts_gemini_output_before_prompt_flag() -> None:
+    argv = _ensure_cli_json_events(
+        ["/opt/homebrew/bin/gemini", "-m", "GigaChat-3.5", "-p"]
+    )
+
+    assert argv == [
+        "/opt/homebrew/bin/gemini",
+        "-m",
+        "GigaChat-3.5",
+        "--output-format",
+        "stream-json",
+        "-p",
+    ]
+
+
+def test_claude_json_event_stats_count_tools_and_tokens() -> None:
+    stdout = "\n".join(
+        [
+            '{"type":"system","session_id":"s"}',
+            (
+                '{"type":"assistant","message":{"content":[{"type":"text",'
+                '"text":"Working"}],"usage":{"input_tokens":7,'
+                '"output_tokens":1}}}'
+            ),
+            (
+                '{"type":"assistant","message":{"content":['
+                '{"type":"tool_use","name":"Bash","id":"t1","input":{}},'
+                '{"type":"tool_use","name":"Edit","id":"t2","input":{}}],'
+                '"usage":{"input_tokens":13,"output_tokens":4}}}'
+            ),
+            '{"type":"user","message":{"content":[{"type":"tool_result"}]}}',
+            '{"type":"result","num_turns":2,"totalTokens":50}',
+        ]
+    )
+
+    assert _claude_json_event_stats(stdout) == {
+        "agent_steps": 2,
+        "agent_tool_calls": 2,
+        "agent_shell_commands": 1,
+        "agent_events": 5,
+        "agent_llm_calls": 2,
+        "agent_input_tokens": 20,
+        "agent_output_tokens": 5,
+        "agent_total_tokens": 50,
+    }
+
+
+def test_gemini_json_event_stats_count_tools_and_tokens() -> None:
+    stdout = "\n".join(
+        [
+            '{"type":"init","session_id":"s","model":"GigaChat-3.5"}',
+            '{"type":"message","role":"user","content":"do it"}',
+            '{"type":"message","role":"assistant","content":"Working","delta":true}',
+            '{"type":"tool_use","tool_name":"run_shell_command","tool_id":"t1"}',
+            '{"type":"tool_result","tool_id":"t1","status":"success"}',
+            (
+                '{"type":"result","status":"success","stats":{'
+                '"input_tokens":30,"output_tokens":8,"total_tokens":38,'
+                '"tool_calls":3}}'
+            ),
+        ]
+    )
+
+    assert _gemini_json_event_stats(stdout) == {
+        "agent_steps": 3,
+        "agent_tool_calls": 3,
+        "agent_shell_commands": 1,
+        "agent_events": 6,
+        "agent_llm_calls": 1,
+        "agent_input_tokens": 30,
+        "agent_output_tokens": 8,
+        "agent_total_tokens": 38,
+    }
+
+
+def test_codex_and_claude_parsers_ignore_gemini_events() -> None:
+    stdout = "\n".join(
+        [
+            '{"type":"init","session_id":"s","model":"GigaChat-3.5"}',
+            '{"type":"message","role":"assistant","content":"Working","delta":true}',
+            '{"type":"tool_use","tool_name":"run_shell_command","tool_id":"t1"}',
+            (
+                '{"type":"result","status":"success","stats":{'
+                '"input_tokens":30,"output_tokens":8,"total_tokens":38,'
+                '"tool_calls":1}}'
+            ),
+        ]
+    )
+
+    assert _codex_json_event_stats(stdout) is None
+    assert _claude_json_event_stats(stdout) is None
+
+
+def test_task_run_stats_dispatches_to_gemini_parser() -> None:
+    stdout = "\n".join(
+        [
+            '{"type":"init","session_id":"s","model":"GigaChat-3.5"}',
+            '{"type":"tool_use","tool_name":"run_shell_command","tool_id":"t1"}',
+            (
+                '{"type":"result","status":"success","stats":{'
+                '"input_tokens":30,"output_tokens":8,"total_tokens":38,'
+                '"tool_calls":1}}'
+            ),
+        ]
+    )
+
+    run = _task_run_with_cli_stats(
+        task_id="task_fake",
+        passed=True,
+        message="ok",
+        elapsed_seconds=0.1,
+        result=subprocess.CompletedProcess(["gemini"], 0, stdout, ""),
+    )
+
+    assert run.agent_steps == 1
+    assert run.agent_shell_commands == 1
+    assert run.agent_total_tokens == 38
 
 
 def test_mini_swe_agent_traj_stats_count_steps_and_tokens(tmp_path: Path) -> None:

--- a/tests/test_runner_cli.py
+++ b/tests/test_runner_cli.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+from harness_bench.runner_cli import _argv_for_workspace
+
+
+def test_opencode_command_gets_explicit_workspace_dir() -> None:
+    argv = _argv_for_workspace(["opencode", "run", "--model", "x/y"], Path("/tmp/ws"))
+
+    assert argv == ["opencode", "run", "--model", "x/y", "--dir", "/tmp/ws"]
+
+
+def test_opencode_command_keeps_user_supplied_dir() -> None:
+    argv = _argv_for_workspace(
+        ["opencode", "run", "--dir", "/custom/ws"],
+        Path("/tmp/ws"),
+    )
+
+    assert argv == ["opencode", "run", "--dir", "/custom/ws"]
+
+
+def test_non_opencode_command_does_not_get_dir() -> None:
+    argv = _argv_for_workspace(["free-code", "-p"], Path("/tmp/ws"))
+
+    assert argv == ["free-code", "-p"]
+
+
+def test_workspace_argv_helper_does_not_mutate_input() -> None:
+    original = ["free-code", "-p"]
+    argv = _argv_for_workspace(original, Path("/tmp/ws"))
+    argv.append("prompt")
+
+    assert original == ["free-code", "-p"]

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -69,6 +69,16 @@ def test_allow_task_failures_returns_zero_when_harness_completed(monkeypatch) ->
     assert bench_main.main(["run", "--task", "task_fake", "--allow-task-failures"]) == 0
 
 
+def test_main_keyboard_interrupt_returns_130(monkeypatch, capsys) -> None:
+    def _interrupting_run_all_cli(**_kwargs: object) -> list[TaskRun]:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(bench_main, "run_all_cli", _interrupting_run_all_cli)
+
+    assert bench_main.main(["run-cli", "--task", "task_fake"]) == 130
+    assert "Interrupted by user; shutdown complete." in capsys.readouterr().err
+
+
 def test_openrouter_fail_on_runtime_error_returns_nonzero_with_allowed_task_failures(
     monkeypatch,
 ) -> None:
@@ -114,7 +124,7 @@ def test_openrouter_run_all_stops_on_runtime_error(monkeypatch) -> None:
     calls: list[str] = []
 
     def _fake_run_task(task: object, **_kwargs: object) -> TaskRun:
-        task_id = cast(str, getattr(task, "id"))
+        task_id = cast(SimpleNamespace, task).id
         calls.append(task_id)
         if task_id == "task_01_fake":
             return TaskRun(
@@ -184,6 +194,40 @@ def test_cli_timeout_kills_windows_process_tree(monkeypatch, tmp_path: Path) -> 
         )
 
     assert taskkill_calls == [["taskkill", "/F", "/T", "/PID", "4242"]]
+
+
+def test_cli_keyboard_interrupt_terminates_process(monkeypatch, tmp_path: Path) -> None:
+    from harness_bench import runner_cli
+
+    terminated_pids: list[int] = []
+
+    class _InterruptingProcess:
+        pid = 4242
+        returncode = None
+
+        def communicate(self, timeout: int | None = None) -> tuple[str, str]:
+            raise KeyboardInterrupt
+
+    monkeypatch.setattr(
+        runner_cli.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: _InterruptingProcess(),
+    )
+    monkeypatch.setattr(
+        runner_cli,
+        "_terminate_process_tree",
+        lambda proc: terminated_pids.append(proc.pid),
+    )
+
+    with pytest.raises(KeyboardInterrupt):
+        runner_cli._run_cli_subprocess(
+            ["fake-cli"],
+            cwd=tmp_path,
+            timeout=600,
+            env=None,
+        )
+
+    assert terminated_pids == [4242]
 
 
 def test_cli_subprocess_reader_replaces_invalid_utf8(monkeypatch, tmp_path: Path) -> None:

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -535,6 +535,141 @@ def test_run_all_writes_incremental_json(monkeypatch, tmp_path: Path) -> None:
     assert [task["task_id"] for task in payload["tasks"]] == ["task_01_fake", "task_02_fake"]
 
 
+def test_json_output_bare_filename_defaults_to_jobs(tmp_path: Path) -> None:
+    from harness_bench.runner import normalize_json_output_path
+
+    assert normalize_json_output_path("results.json") == Path("jobs/results.json")
+    assert normalize_json_output_path("reports/results.json") == Path("reports/results.json")
+    generated_in_named_dir = normalize_json_output_path("reports/")
+    assert generated_in_named_dir is not None
+    assert generated_in_named_dir.parent == Path("reports")
+    assert generated_in_named_dir.suffix == ".json"
+    generated_in_dir = normalize_json_output_path(tmp_path)
+    assert generated_in_dir is not None
+    assert generated_in_dir.parent == tmp_path
+    assert generated_in_dir.suffix == ".json"
+
+    parser = bench_main.build_parser()
+    args = parser.parse_args(["run-cli", "--json-output", "results.json"])
+    assert args.json_output == Path("jobs/results.json")
+    args = parser.parse_args(["run-cli", "--json-output"])
+    assert args.json_output.parent == Path("jobs")
+    assert args.json_output.suffix == ".json"
+
+
+def test_main_records_command_in_results_json(monkeypatch, tmp_path: Path) -> None:
+    import json
+
+    out = tmp_path / "results.json"
+    monkeypatch.setattr(
+        bench_main,
+        "run_all",
+        lambda **_kwargs: [TaskRun("task_fake", True, "ok", 0.01)],
+    )
+    monkeypatch.setattr(bench_main, "summarize", lambda _results: None)
+
+    argv = ["run", "--json-output", str(out)]
+    assert bench_main.main(argv) == 0
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert list(payload)[:2] == ["task_set_version", "command"]
+    assert payload["command"] == bench_main._command_for_argv(argv)
+
+
+def test_run_all_continues_from_existing_json(monkeypatch, tmp_path: Path, capsys) -> None:
+    import json
+
+    from harness_bench import runner
+
+    out = tmp_path / "results.json"
+    runner.write_results_json(
+        [TaskRun("task_01_fake", True, "already done", 0.01)],
+        out,
+    )
+    fake_tasks = [
+        SimpleNamespace(id="task_01_fake", name="Fake one"),
+        SimpleNamespace(id="task_02_fake", name="Fake two"),
+    ]
+    calls: list[str] = []
+
+    def _fake_run_task(task: object, **_kwargs: object) -> TaskRun:
+        task_id = cast(SimpleNamespace, task).id
+        calls.append(task_id)
+        return TaskRun(
+            task_id=task_id,
+            passed=True,
+            message="newly done",
+            elapsed_seconds=0.01,
+        )
+
+    monkeypatch.setattr(runner, "_load_env_from_dotenv", lambda: None)
+    monkeypatch.setattr(runner, "_ensure_credentials", lambda: None)
+    monkeypatch.setattr(runner, "get_task", lambda tid: next(t for t in fake_tasks if t.id == tid))
+    monkeypatch.setattr(runner, "run_task", _fake_run_task)
+
+    results = runner.run_all(
+        task_ids=["task_01_fake", "task_02_fake"],
+        concurrency=1,
+        json_output=out,
+    )
+
+    assert calls == ["task_02_fake"]
+    assert [result.task_id for result in results] == ["task_01_fake", "task_02_fake"]
+    assert "[CONTINUE] loaded 1/2 completed task attempt(s)" in capsys.readouterr().out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["total"] == 2
+    assert [task["message"] for task in payload["tasks"]] == ["already done", "newly done"]
+
+
+def test_run_all_records_keyboard_interrupt_in_json(monkeypatch, tmp_path: Path) -> None:
+    import json
+
+    from harness_bench import runner
+
+    out = tmp_path / "results.json"
+    fake_tasks = [
+        SimpleNamespace(id="task_01_fake", name="Fake one"),
+        SimpleNamespace(id="task_02_fake", name="Fake two"),
+    ]
+
+    def _fake_run_task(task: object, **_kwargs: object) -> TaskRun:
+        task_id = cast(SimpleNamespace, task).id
+        if task_id == "task_02_fake":
+            raise KeyboardInterrupt
+        return TaskRun(
+            task_id=task_id,
+            passed=True,
+            message="done before interrupt",
+            elapsed_seconds=0.01,
+        )
+
+    monkeypatch.setattr(runner, "_load_env_from_dotenv", lambda: None)
+    monkeypatch.setattr(runner, "_ensure_credentials", lambda: None)
+    monkeypatch.setattr(runner, "get_task", lambda tid: next(t for t in fake_tasks if t.id == tid))
+    monkeypatch.setattr(runner, "run_task", _fake_run_task)
+
+    with pytest.raises(KeyboardInterrupt):
+        runner.run_all(
+            task_ids=["task_01_fake", "task_02_fake"],
+            concurrency=1,
+            json_output=out,
+        )
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert payload["run_status"] == "interrupted"
+    assert payload["interrupted"] is True
+    assert [task["task_id"] for task in payload["tasks"]] == ["task_01_fake"]
+    assert payload["interrupted_attempts"] == [
+        {
+            "task_id": "task_02_fake",
+            "attempt": 1,
+            "attempts": 1,
+            "reason": "KeyboardInterrupt",
+            "rerun_on_continue": True,
+        }
+    ]
+
+
 def test_task_203_accepts_valid_markdown_alignment(tmp_path: Path) -> None:
     (tmp_path / "team_report.md").write_text(
         "| team | open | closed | closed_hours |\n"

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -11,7 +11,7 @@ from langgraph.errors import GraphRecursionError
 
 from harness_bench import __main__ as bench_main
 from harness_bench.core import Task, VerifyResult
-from harness_bench.runner import TaskRun, run_task
+from harness_bench.runner import TaskRun, run_task, write_results_json
 from harness_bench.tasks import get_task
 from harness_bench.verifiers import file_text_equals
 
@@ -585,6 +585,33 @@ def test_main_records_command_in_results_json(monkeypatch, tmp_path: Path) -> No
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert list(payload)[:2] == ["task_set_version", "command"]
     assert payload["command"] == bench_main._command_for_argv(argv)
+
+
+def test_summarize_json_reports_existing_repeated_attempt_run(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    out = tmp_path / "results.json"
+    results = [
+        TaskRun("task_01_fake", attempt == 1, "detail", 0.01, attempt=attempt, attempts=5)
+        for attempt in range(1, 6)
+    ]
+    results.extend(
+        TaskRun("task_31_fake", attempt < 5, "detail", 0.01, attempt=attempt, attempts=5)
+        for attempt in range(1, 6)
+    )
+    write_results_json(results, out)
+
+    assert bench_main.main(["summarize-json", str(out)]) == 0
+
+    output = capsys.readouterr().out
+    assert "Passed attempts: 5/10" in output
+    assert "K  pass@K  pass^K" in output
+    assert "1   50.0%   50.0%" in output
+    assert "5  100.0%    0.0%" in output
+    assert "core (1-30)        1       1  100.0%" in output
+    assert "extra (31-60)      1       1  100.0%" in output
+    assert "Failures:" not in output
 
 
 def test_run_all_continues_from_existing_json(monkeypatch, tmp_path: Path, capsys) -> None:

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -313,6 +313,7 @@ def test_codex_json_event_stats_count_agent_steps() -> None:
         "agent_tool_calls": 1,
         "agent_shell_commands": 1,
         "agent_events": 6,
+        "agent_llm_calls": 0,
         "agent_input_tokens": 10,
         "agent_output_tokens": 5,
         "agent_total_tokens": 15,

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -660,6 +660,83 @@ def test_run_all_continues_from_existing_json(monkeypatch, tmp_path: Path, capsy
     assert [task["message"] for task in payload["tasks"]] == ["already done", "newly done"]
 
 
+def test_cli_timeout_results_are_tagged_for_continue(tmp_path: Path) -> None:
+    import json
+
+    out = tmp_path / "results.json"
+
+    write_results_json(
+        [TaskRun("task_01_fake", False, "", 1.0, error="CLI timed out after 1s")],
+        out,
+    )
+
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    task = payload["tasks"][0]
+    assert task["failure_kind"] == "timeout"
+    assert task["rerun_on_continue"] is True
+
+
+def test_run_all_cli_continues_from_existing_json_reruns_cli_timeout(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    import json
+
+    from harness_bench import runner, runner_cli
+
+    out = tmp_path / "results.json"
+    runner.write_results_json(
+        [
+            TaskRun(
+                "task_01_fake",
+                False,
+                "",
+                1.0,
+                error="CLI timed out after 1s",
+            ),
+            TaskRun("task_02_fake", True, "already done", 0.01),
+        ],
+        out,
+    )
+    fake_tasks = [
+        SimpleNamespace(id="task_01_fake", name="Fake one"),
+        SimpleNamespace(id="task_02_fake", name="Fake two"),
+    ]
+    calls: list[str] = []
+
+    def _fake_run_task_cli(task: object, **_kwargs: object) -> TaskRun:
+        task_id = cast(SimpleNamespace, task).id
+        calls.append(task_id)
+        return TaskRun(
+            task_id=task_id,
+            passed=True,
+            message="rerun ok",
+            elapsed_seconds=0.01,
+        )
+
+    monkeypatch.setattr(runner_cli, "_load_env_from_dotenv", lambda: None)
+    monkeypatch.setattr(
+        runner_cli,
+        "get_task",
+        lambda tid: next(t for t in fake_tasks if t.id == tid),
+    )
+    monkeypatch.setattr(runner_cli, "run_task_cli", _fake_run_task_cli)
+
+    results = runner_cli.run_all_cli(
+        task_ids=["task_01_fake", "task_02_fake"],
+        concurrency=1,
+        json_output=out,
+    )
+
+    assert calls == ["task_01_fake"]
+    assert [result.task_id for result in results] == ["task_01_fake", "task_02_fake"]
+    assert "[CONTINUE] loaded 1/2 completed task attempt(s)" in capsys.readouterr().out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert [task["message"] for task in payload["tasks"]] == ["rerun ok", "already done"]
+    assert "rerun_on_continue" not in payload["tasks"][0]
+
+
 def test_run_all_records_keyboard_interrupt_in_json(monkeypatch, tmp_path: Path) -> None:
     import json
 

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -550,6 +550,9 @@ def test_json_output_bare_filename_defaults_to_jobs(tmp_path: Path) -> None:
     assert generated_in_dir.suffix == ".json"
 
     parser = bench_main.build_parser()
+    args = parser.parse_args(["run-cli"])
+    assert args.json_output.parent == Path("jobs")
+    assert args.json_output.suffix == ".json"
     args = parser.parse_args(["run-cli", "--json-output", "results.json"])
     assert args.json_output == Path("jobs/results.json")
     args = parser.parse_args(["run-cli", "--json-output"])
@@ -560,11 +563,19 @@ def test_json_output_bare_filename_defaults_to_jobs(tmp_path: Path) -> None:
 def test_main_records_command_in_results_json(monkeypatch, tmp_path: Path) -> None:
     import json
 
+    from harness_bench.runner import write_results_json
+
     out = tmp_path / "results.json"
+
+    def _fake_run_all(**kwargs: object) -> list[TaskRun]:
+        results = [TaskRun("task_fake", True, "ok", 0.01)]
+        write_results_json(results, cast(Path, kwargs["json_output"]))
+        return results
+
     monkeypatch.setattr(
         bench_main,
         "run_all",
-        lambda **_kwargs: [TaskRun("task_fake", True, "ok", 0.01)],
+        _fake_run_all,
     )
     monkeypatch.setattr(bench_main, "summarize", lambda _results: None)
 

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -382,9 +382,19 @@ def test_results_json_includes_agent_step_metrics() -> None:
                 agent_input_tokens=10,
                 agent_output_tokens=5,
                 agent_total_tokens=15,
-            )
+            ),
+            TaskRun(
+                "task_other",
+                False,
+                "bad",
+                0.02,
+                agent_steps=3,
+            ),
         ]
     )
+
+    assert payload["steps"] == 5
+    assert payload["tokens"] == 15
 
     task = payload["tasks"][0]
     assert task["agent_steps"] == 2

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -4,6 +4,7 @@ from harness_bench.tasks import ALL_TASKS
 from harness_bench.versioning import (
     EXPECTED_TASK_COUNT,
     TASK_SET_VERSION,
+    TASK_WAVES,
     revision_for_task_id,
     validate_task_set_metadata,
 )
@@ -12,6 +13,15 @@ from harness_bench.versioning import (
 def test_task_set_metadata_matches_registry() -> None:
     assert validate_task_set_metadata(ALL_TASKS) == []
     assert len(ALL_TASKS) == EXPECTED_TASK_COUNT
+
+
+def test_task_waves_cover_current_task_set() -> None:
+    covered = [
+        number
+        for wave in TASK_WAVES
+        for number in range(wave.start, wave.end + 1)
+    ]
+    assert covered == list(range(1, EXPECTED_TASK_COUNT + 1))
 
 
 def test_memory_tasks_belong_to_their_revisions() -> None:


### PR DESCRIPTION
## Summary

This PR makes long-running benchmark runs safer to stop, inspect, continue, and compare across agent harnesses.

- Handle Ctrl-C across `run`, `run-cli`, `run-pure`, and `run-openrouter`: cancel pending work, return 130 from the CLI entrypoint, and write interrupted JSON state before exit.
- Track and terminate active CLI subprocess trees on timeout or interruption so child agents do not keep running after the harness exits.
- Enable JSON checkpointing by default under `jobs/`; normalize bare filenames into that directory, generate timestamped outputs, record the launch command, and continue from completed task attempts in existing reports.
- Mark interrupted reports with `run_status: "interrupted"` and `interrupted_attempts` so pending attempts rerun from clean workspaces on continue.
- Add `summarize-json` for existing result artifacts, percentage pass@K/pass^K output, and per-wave result breakdowns.
- Improve CLI harness effort metrics: auto-enable JSON/stream-json output for Codex, Claude Code, and Gemini; parse steps, tool calls, shell commands, LLM calls, and token usage; keep OpenCode workspaces explicit with `--dir`.
- Add `scripts/hb-mini-swe-agent`, a non-interactive mini-SWE-agent wrapper for OpenAI-compatible gateways, with trajectory-based effort metrics.
- Update README docs and tests for checkpointing/resume behavior, interrupt handling, JSON summaries, CLI workspace behavior, mini-SWE-agent, and metric parsing.

## Testing

- `uv run pytest tests/test_runner_policy.py tests/test_metrics.py tests/test_runner_cli.py tests/test_versioning.py`
