### PR TITLE
feature/rerun_on_fail

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ uv run python -m harness_bench run-cli \
 # next continue when you rerun with the same JSON path. CLI per-task timeouts
 # are also marked `rerun_on_continue` and rerun from clean workspaces on the
 # next launch with the same `--json-output` file.
+# Add `--rerun-on-fail` when continuing to rerun every saved task attempt whose
+# `passed` field is false. Passing attempts stay checkpointed. With `-k N`, only
+# the failed attempt numbers are rerun, once per invocation.
 uv run python -m harness_bench run-cli \
     --cli-command 'codex exec -m gpt-5.5 --dangerously-bypass-approvals-and-sandbox' \
     --concurrency 5

--- a/harness_bench/__main__.py
+++ b/harness_bench/__main__.py
@@ -156,6 +156,7 @@ def _cmd_run(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
         attempts=args.attempts,
         json_output=args.json_output,
+        rerun_on_fail=args.rerun_on_fail,
     )
     _summarize_run(results, metric_ks)
     _maybe_report_json(args, results)
@@ -177,6 +178,7 @@ def _cmd_run_openrouter(args: argparse.Namespace) -> int:
         json_output=args.json_output,
         transient_attempts=args.transient_attempts,
         fail_on_runtime_error=args.fail_on_runtime_error,
+        rerun_on_fail=args.rerun_on_fail,
     )
     _summarize_run(results, metric_ks)
     _maybe_report_json(args, results)
@@ -197,6 +199,7 @@ def _cmd_run_pure(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
         attempts=args.attempts,
         json_output=args.json_output,
+        rerun_on_fail=args.rerun_on_fail,
     )
     _summarize_run(results, metric_ks)
     _maybe_report_json(args, results)
@@ -214,6 +217,7 @@ def _cmd_run_cli(args: argparse.Namespace) -> int:
         concurrency=args.concurrency,
         attempts=args.attempts,
         json_output=args.json_output,
+        rerun_on_fail=args.rerun_on_fail,
     )
     _summarize_run(results, metric_ks)
     _maybe_report_json(args, results)
@@ -333,6 +337,15 @@ def _add_json_output(p: argparse.ArgumentParser) -> None:
             "directory path, the filename is generated from the current "
             "timestamp. If the file exists, completed task attempts are loaded "
             "from it and skipped."
+        ),
+    )
+    p.add_argument(
+        "--rerun-on-fail",
+        action="store_true",
+        help=(
+            "When continuing from an existing JSON report, rerun saved task "
+            "attempts whose passed field is false. Successful attempts remain "
+            "checkpointed; each failed attempt is rerun once per invocation."
         ),
     )
 

--- a/harness_bench/runner.py
+++ b/harness_bench/runner.py
@@ -254,6 +254,8 @@ def _resume_results(
     json_output: str | Path | None,
     targets: list[Task],
     attempts: int,
+    *,
+    rerun_on_fail: bool = False,
 ) -> list[TaskRun]:
     json_output_path = normalize_json_output_path(json_output)
     if json_output_path is None or not json_output_path.exists():
@@ -270,6 +272,8 @@ def _resume_results(
         if run.task_id not in target_ids:
             continue
         if run.attempt < 1 or run.attempt > attempts:
+            continue
+        if rerun_on_fail and not run.passed:
             continue
         by_key[(run.task_id, run.attempt)] = replace(
             run,
@@ -669,6 +673,7 @@ def run_all(
     concurrency: int = 1,
     attempts: int = 1,
     json_output: str | Path | None = None,
+    rerun_on_fail: bool = False,
 ) -> list[TaskRun]:
     """Run a subset (or all) of the benchmark tasks.
 
@@ -688,7 +693,12 @@ def run_all(
         raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
-    results = _resume_results(json_output, targets, attempts)
+    results = _resume_results(
+        json_output,
+        targets,
+        attempts,
+        rerun_on_fail=rerun_on_fail,
+    )
     pending_attempts = _pending_task_attempts(targets, attempts, results)
     if not pending_attempts:
         _write_partial_results_json(results, json_output)

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -32,6 +32,7 @@ import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from tempfile import TemporaryDirectory, mkdtemp
+from urllib.parse import quote
 
 from harness_bench.core import Task
 from harness_bench.runner import (
@@ -177,6 +178,15 @@ def _is_gemini_prompt_command(argv: list[str]) -> bool:
     )
 
 
+def _is_grok_single_command(argv: list[str]) -> bool:
+    if not argv:
+        return False
+    executable = Path(argv[0]).name
+    return executable == "grok" and any(
+        arg in ("-p", "--single") or arg.startswith("--single=") for arg in argv
+    )
+
+
 def _argv_with_output_format(
     argv: list[str],
     output_format: str,
@@ -235,11 +245,23 @@ def _ensure_gemini_json_events(argv: list[str]) -> list[str]:
     )
 
 
+def _ensure_grok_json_events(argv: list[str]) -> list[str]:
+    """Ask Grok Build for JSONL events while keeping its prompt flag last."""
+    if not _is_grok_single_command(argv):
+        return argv
+    return _argv_with_output_format(
+        argv,
+        "streaming-json",
+        insert_before=("-p", "--single"),
+    )
+
+
 def _ensure_cli_json_events(argv: list[str]) -> list[str]:
     """Enable machine-readable CLI output for CLIs that expose it."""
     argv = _ensure_codex_json_events(argv)
     argv = _ensure_claude_json_events(argv)
-    return _ensure_gemini_json_events(argv)
+    argv = _ensure_gemini_json_events(argv)
+    return _ensure_grok_json_events(argv)
 
 
 def _iter_json_payloads(stdout: str) -> list[dict[str, object]]:
@@ -327,8 +349,140 @@ def _tool_name_is_shell(name: object) -> bool:
         "bash",
         "shell",
         "run_shell_command",
+        "run_terminal_command",
         "execute_shell_command",
     }
+
+
+def _grok_session_updates_path(workspace: Path, session_id: str) -> Path | None:
+    """Locate Grok's persisted ACP updates for a completed workspace session."""
+    grok_home = Path(os.getenv("GROK_HOME", Path.home() / ".grok")).expanduser()
+    candidates: list[Path] = []
+    for workspace_variant in (workspace.resolve(), workspace.absolute()):
+        encoded_cwd = quote(str(workspace_variant), safe="")
+        candidate = grok_home / "sessions" / encoded_cwd / session_id / "updates.jsonl"
+        if candidate not in candidates:
+            candidates.append(candidate)
+    return next((path for path in candidates if path.is_file()), None)
+
+
+def _grok_session_tool_stats(
+    *,
+    workspace: Path | None,
+    session_id: str,
+) -> tuple[int, int]:
+    """Return unique tool calls and shell calls from a persisted Grok session."""
+    if workspace is None:
+        return 0, 0
+    updates_path = _grok_session_updates_path(workspace, session_id)
+    if updates_path is None:
+        return 0, 0
+
+    try:
+        payloads = _iter_json_payloads(updates_path.read_text(encoding="utf-8"))
+    except OSError:
+        return 0, 0
+
+    tool_call_ids: set[str] = set()
+    shell_call_ids: set[str] = set()
+    anonymous_tool_calls = 0
+    anonymous_shell_calls = 0
+    for payload in payloads:
+        if payload.get("method") != "session/update":
+            continue
+        params = payload.get("params")
+        if not isinstance(params, dict):
+            continue
+        update = params.get("update")
+        if not isinstance(update, dict) or update.get("sessionUpdate") != "tool_call":
+            continue
+
+        tool_call_id = update.get("toolCallId")
+        meta = update.get("_meta")
+        tool_meta = meta.get("x.ai/tool") if isinstance(meta, dict) else None
+        tool_name: object = update.get("title")
+        tool_kind: object = None
+        if isinstance(tool_meta, dict):
+            tool_name = tool_meta.get("name") or tool_name
+            tool_kind = tool_meta.get("kind")
+        is_shell = tool_kind == "execute" or _tool_name_is_shell(tool_name)
+
+        if isinstance(tool_call_id, str) and tool_call_id:
+            tool_call_ids.add(tool_call_id)
+            if is_shell:
+                shell_call_ids.add(tool_call_id)
+        else:
+            anonymous_tool_calls += 1
+            if is_shell:
+                anonymous_shell_calls += 1
+
+    return (
+        len(tool_call_ids) + anonymous_tool_calls,
+        len(shell_call_ids) + anonymous_shell_calls,
+    )
+
+
+def _grok_json_event_stats(
+    stdout: str,
+    *,
+    workspace: Path | None = None,
+) -> dict[str, int] | None:
+    """Extract Grok Build metrics from streaming-json and its saved session."""
+    payloads = _iter_json_payloads(stdout)
+    end_payload: dict[str, object] | None = None
+    for payload in payloads:
+        if (
+            payload.get("type") == "end"
+            and isinstance(payload.get("sessionId"), str)
+            and any(key in payload for key in ("usage", "modelUsage", "num_turns"))
+        ):
+            end_payload = payload
+    if end_payload is None:
+        return None
+
+    grok_event_types = {
+        "thought",
+        "text",
+        "tool_call",
+        "tool_result",
+        "error",
+        "end",
+    }
+    events = sum(1 for payload in payloads if payload.get("type") in grok_event_types)
+    session_id = end_payload["sessionId"]
+    assert isinstance(session_id, str)
+    tool_calls, shell_commands = _grok_session_tool_stats(
+        workspace=workspace,
+        session_id=session_id,
+    )
+
+    stats = {
+        "agent_steps": tool_calls,
+        "agent_tool_calls": tool_calls,
+        "agent_shell_commands": shell_commands,
+        "agent_events": events,
+    }
+
+    usage = end_payload.get("usage")
+    usage_stats = _usage_stats_from_mapping(usage)
+    if isinstance(usage, dict):
+        cached_input_tokens = _int_or_none(usage.get("cache_read_input_tokens"))
+        if cached_input_tokens is not None:
+            usage_stats["agent_input_tokens"] = (
+                usage_stats.get("agent_input_tokens", 0) + cached_input_tokens
+            )
+    stats.update(usage_stats)
+
+    llm_calls = 0
+    model_usage = end_payload.get("modelUsage")
+    if isinstance(model_usage, dict):
+        for model_stats in model_usage.values():
+            if isinstance(model_stats, dict):
+                llm_calls += _int_or_none(model_stats.get("modelCalls")) or 0
+    if not llm_calls:
+        llm_calls = _int_or_none(end_payload.get("num_turns")) or 0
+    stats["agent_llm_calls"] = llm_calls
+    return _with_default_agent_metrics(stats)
 
 
 def _claude_tool_use_names(content: object) -> list[str]:
@@ -705,6 +859,11 @@ def _task_run_with_cli_stats(
         stats = _claude_json_event_stats(result.stdout or "")
     if stats is None and result is not None:
         stats = _gemini_json_event_stats(result.stdout or "")
+    if stats is None and result is not None:
+        stats = _grok_json_event_stats(
+            result.stdout or "",
+            workspace=stats_workspace or workspace,
+        )
     if stats is None:
         stats = _mini_swe_agent_traj_stats(stats_workspace or workspace)
     return TaskRun(

--- a/harness_bench/runner_cli.py
+++ b/harness_bench/runner_cli.py
@@ -1260,6 +1260,7 @@ def run_all_cli(
     concurrency: int = 1,
     attempts: int = 1,
     json_output: str | Path | None = None,
+    rerun_on_fail: bool = False,
 ) -> list[TaskRun]:
     """Run a subset (or all) of the benchmark via the CLI agent."""
     _load_env_from_dotenv()
@@ -1269,7 +1270,12 @@ def run_all_cli(
         raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
-    results = _resume_results(json_output, targets, attempts)
+    results = _resume_results(
+        json_output,
+        targets,
+        attempts,
+        rerun_on_fail=rerun_on_fail,
+    )
     pending_attempts = _pending_task_attempts(targets, attempts, results)
     if not pending_attempts:
         _write_partial_results_json(results, json_output)

--- a/harness_bench/runner_openrouter.py
+++ b/harness_bench/runner_openrouter.py
@@ -463,6 +463,7 @@ def run_all(
     json_output: str | Path | None = None,
     transient_attempts: int = DEFAULT_TRANSIENT_ATTEMPTS,
     fail_on_runtime_error: bool = False,
+    rerun_on_fail: bool = False,
 ) -> list[TaskRun]:
     _load_env_from_dotenv()
     _ensure_openrouter_key()
@@ -472,7 +473,12 @@ def run_all(
         raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
-    results = _resume_results(json_output, targets, attempts)
+    results = _resume_results(
+        json_output,
+        targets,
+        attempts,
+        rerun_on_fail=rerun_on_fail,
+    )
     if fail_on_runtime_error and any(run.error for run in results):
         _write_partial_results_json(results, json_output)
         return results

--- a/harness_bench/runner_pure.py
+++ b/harness_bench/runner_pure.py
@@ -149,6 +149,7 @@ def run_all(
     concurrency: int = 1,
     attempts: int = 1,
     json_output: str | Path | None = None,
+    rerun_on_fail: bool = False,
 ) -> list[TaskRun]:
     _load_env_from_dotenv()
     _ensure_credentials()
@@ -158,7 +159,12 @@ def run_all(
         raise ValueError("attempts must be positive")
 
     targets = [get_task(tid) for tid in task_ids] if task_ids else list(ALL_TASKS)
-    results = _resume_results(json_output, targets, attempts)
+    results = _resume_results(
+        json_output,
+        targets,
+        attempts,
+        rerun_on_fail=rerun_on_fail,
+    )
     pending_attempts = _pending_task_attempts(targets, attempts, results)
     if not pending_attempts:
         _write_partial_results_json(results, json_output)

--- a/tests/test_runner_cli.py
+++ b/tests/test_runner_cli.py
@@ -1,5 +1,6 @@
 import subprocess
 from pathlib import Path
+from urllib.parse import quote
 
 from harness_bench.runner_cli import (
     _argv_for_workspace,
@@ -7,6 +8,7 @@ from harness_bench.runner_cli import (
     _codex_json_event_stats,
     _ensure_cli_json_events,
     _gemini_json_event_stats,
+    _grok_json_event_stats,
     _mini_swe_agent_traj_stats,
     _task_run_with_cli_stats,
 )
@@ -110,6 +112,32 @@ def test_cli_json_events_inserts_gemini_output_before_prompt_flag() -> None:
     ]
 
 
+def test_cli_json_events_inserts_grok_output_before_prompt_flag() -> None:
+    argv = _ensure_cli_json_events(["grok", "-m", "grok-4.5", "-p"])
+
+    assert argv == [
+        "grok",
+        "-m",
+        "grok-4.5",
+        "--output-format",
+        "streaming-json",
+        "-p",
+    ]
+
+
+def test_cli_json_events_rewrites_grok_json_output() -> None:
+    argv = _ensure_cli_json_events(
+        ["grok", "--output-format", "json", "--single"]
+    )
+
+    assert argv == [
+        "grok",
+        "--output-format",
+        "streaming-json",
+        "--single",
+    ]
+
+
 def test_claude_json_event_stats_count_tools_and_tokens() -> None:
     stdout = "\n".join(
         [
@@ -168,6 +196,101 @@ def test_gemini_json_event_stats_count_tools_and_tokens() -> None:
         "agent_output_tokens": 8,
         "agent_total_tokens": 38,
     }
+
+
+def test_grok_json_event_stats_count_session_tools_and_tokens(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    grok_home = tmp_path / "grok-home"
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session_id = "019f65a5-6201-7562-8e7d-94b7d80a512d"
+    session_dir = (
+        grok_home
+        / "sessions"
+        / quote(str(workspace.resolve()), safe="")
+        / session_id
+    )
+    session_dir.mkdir(parents=True)
+    (session_dir / "updates.jsonl").write_text(
+        "\n".join(
+            [
+                (
+                    '{"method":"session/update","params":{"update":{'
+                    '"sessionUpdate":"tool_call","toolCallId":"shell-1",'
+                    '"title":"run_terminal_command","_meta":{"x.ai/tool":{'
+                    '"name":"run_terminal_command","kind":"execute"}}}}}'
+                ),
+                (
+                    '{"method":"session/update","params":{"update":{'
+                    '"sessionUpdate":"tool_call_update","toolCallId":"shell-1"}}}'
+                ),
+                (
+                    '{"method":"session/update","params":{"update":{'
+                    '"sessionUpdate":"tool_call","toolCallId":"write-1",'
+                    '"title":"write","_meta":{"x.ai/tool":{'
+                    '"name":"write","kind":"write"}}}}}'
+                ),
+            ]
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("GROK_HOME", str(grok_home))
+    stdout = "\n".join(
+        [
+            '{"type":"thought","data":"Working"}',
+            '{"type":"text","data":"DONE"}',
+            (
+                '{"type":"end","stopReason":"EndTurn",'
+                f'"sessionId":"{session_id}",'
+                '"usage":{"input_tokens":2713,"cache_read_input_tokens":23552,'
+                '"output_tokens":68,"reasoning_tokens":60,"total_tokens":26333},'
+                '"num_turns":2,"modelUsage":{"grok-4.5":{'
+                '"inputTokens":2713,"outputTokens":68,'
+                '"cacheReadInputTokens":23552,"modelCalls":2}}}'
+            ),
+        ]
+    )
+
+    assert _grok_json_event_stats(stdout, workspace=workspace) == {
+        "agent_steps": 2,
+        "agent_tool_calls": 2,
+        "agent_shell_commands": 1,
+        "agent_events": 3,
+        "agent_llm_calls": 2,
+        "agent_input_tokens": 26265,
+        "agent_output_tokens": 68,
+        "agent_total_tokens": 26333,
+    }
+
+
+def test_task_run_stats_dispatches_to_grok_parser() -> None:
+    stdout = "\n".join(
+        [
+            '{"type":"text","data":"OK"}',
+            (
+                '{"type":"end","sessionId":"session-1",'
+                '"usage":{"input_tokens":10,"cache_read_input_tokens":20,'
+                '"output_tokens":3,"total_tokens":33},'
+                '"num_turns":1}'
+            ),
+        ]
+    )
+
+    run = _task_run_with_cli_stats(
+        task_id="task_fake",
+        passed=True,
+        message="ok",
+        elapsed_seconds=0.1,
+        result=subprocess.CompletedProcess(["grok"], 0, stdout, ""),
+    )
+
+    assert run.agent_steps == 0
+    assert run.agent_llm_calls == 1
+    assert run.agent_input_tokens == 30
+    assert run.agent_output_tokens == 3
+    assert run.agent_total_tokens == 33
 
 
 def test_codex_and_claude_parsers_ignore_gemini_events() -> None:

--- a/tests/test_runner_policy.py
+++ b/tests/test_runner_policy.py
@@ -69,6 +69,25 @@ def test_allow_task_failures_returns_zero_when_harness_completed(monkeypatch) ->
     assert bench_main.main(["run", "--task", "task_fake", "--allow-task-failures"]) == 0
 
 
+def test_rerun_on_fail_cli_option_is_forwarded(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run_all_cli(**kwargs: object) -> list[TaskRun]:
+        captured.update(kwargs)
+        return [TaskRun("task_fake", True, "ok", 0.01)]
+
+    monkeypatch.setattr(bench_main, "run_all_cli", _fake_run_all_cli)
+    monkeypatch.setattr(bench_main, "summarize", lambda _results: None)
+
+    assert (
+        bench_main.main(
+            ["run-cli", "--task", "task_fake", "--rerun-on-fail"]
+        )
+        == 0
+    )
+    assert captured["rerun_on_fail"] is True
+
+
 def test_main_keyboard_interrupt_returns_130(monkeypatch, capsys) -> None:
     def _interrupting_run_all_cli(**_kwargs: object) -> list[TaskRun]:
         raise KeyboardInterrupt
@@ -745,6 +764,75 @@ def test_run_all_cli_continues_from_existing_json_reruns_cli_timeout(
     payload = json.loads(out.read_text(encoding="utf-8"))
     assert [task["message"] for task in payload["tasks"]] == ["rerun ok", "already done"]
     assert "rerun_on_continue" not in payload["tasks"][0]
+
+
+def test_run_all_cli_rerun_on_fail_replaces_only_failed_attempts(
+    monkeypatch,
+    tmp_path: Path,
+    capsys,
+) -> None:
+    import json
+
+    from harness_bench import runner, runner_cli
+
+    out = tmp_path / "results.json"
+    runner.write_results_json(
+        [
+            TaskRun(
+                "task_01_fake",
+                False,
+                "failed first attempt",
+                0.01,
+                attempt=1,
+                attempts=2,
+            ),
+            TaskRun(
+                "task_01_fake",
+                True,
+                "passed second attempt",
+                0.01,
+                attempt=2,
+                attempts=2,
+            ),
+        ],
+        out,
+    )
+    fake_task = SimpleNamespace(id="task_01_fake", name="Fake one")
+    calls: list[str] = []
+
+    def _fake_run_task_cli(task: object, **_kwargs: object) -> TaskRun:
+        task_id = cast(SimpleNamespace, task).id
+        calls.append(task_id)
+        return TaskRun(
+            task_id=task_id,
+            passed=True,
+            message="rerun passed",
+            elapsed_seconds=0.01,
+        )
+
+    monkeypatch.setattr(runner_cli, "_load_env_from_dotenv", lambda: None)
+    monkeypatch.setattr(runner_cli, "get_task", lambda _tid: fake_task)
+    monkeypatch.setattr(runner_cli, "run_task_cli", _fake_run_task_cli)
+
+    results = runner_cli.run_all_cli(
+        task_ids=["task_01_fake"],
+        concurrency=1,
+        attempts=2,
+        json_output=out,
+        rerun_on_fail=True,
+    )
+
+    assert calls == ["task_01_fake"]
+    assert [(result.attempt, result.passed) for result in results] == [
+        (1, True),
+        (2, True),
+    ]
+    assert "[CONTINUE] loaded 1/2 completed task attempt(s)" in capsys.readouterr().out
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    assert [task["message"] for task in payload["tasks"]] == [
+        "rerun passed",
+        "passed second attempt",
+    ]
 
 
 def test_run_all_records_keyboard_interrupt_in_json(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Что изменилось

PR улучшает продолжение benchmark runs из сохранённого JSON и добавляет сбор метрик для Grok Build CLI.

### Повтор неуспешных попыток

- Добавлен флаг `--rerun-on-fail` для `run`, `run-openrouter`, `run-pure` и `run-cli`.
- При продолжении из существующего `--json-output` успешные попытки остаются checkpointed, а записи с `passed: false` планируются заново.
- Для `-k N` повторяются только конкретные неуспешные attempt numbers — не более одного раза за один запуск.
- Результат повторной попытки заменяет старую failed-запись в итоговом JSON.
- Поведение задокументировано в README.

### Метрики Grok Build CLI

- Для `grok -p` / `grok --single` автоматически включается `streaming-json`, при этом prompt-флаг сохраняется в корректной позиции.
- Из финального события Grok извлекаются token usage, число LLM calls и agent events.
- Tool calls и shell commands считаются по сохранённым `updates.jsonl` с дедупликацией по `toolCallId`.
- Cached input tokens учитываются в `agent_input_tokens`.

## Проверка

```text
uv run pytest tests/test_runner_cli.py tests/test_runner_policy.py
52 passed
```
